### PR TITLE
Can merge: Reconnect WebSockets effectively

### DIFF
--- a/lib/ws.js
+++ b/lib/ws.js
@@ -71,7 +71,7 @@ class Socket extends EventEmitter {
 
     disconnect() {
         if (this._ws) {
-            this._ws.removeEventListener('close');
+            this._ws.removeAllListeners('close');
             this._ws.terminate();
         }
 

--- a/lib/ws.js
+++ b/lib/ws.js
@@ -6,10 +6,15 @@ const retry = require('retry');
 
 class Socket extends EventEmitter {
 
-    constructor(path, {retryOptions = {}, verbose = false}) {
+    constructor(path, { isCombinedPath = false, retryOptions = {}, verbose = false }) {
         super();
 
+        this._baseUrl = 'wss://stream.binance.com:9443/ws/';
+        this._combinedBaseUrl = 'wss://stream.binance.com:9443/stream?streams=';
+
         this._path = path;
+        this._isCombinedPath = isCombinedPath;
+
         this._ws = null;
         this._onMessageHandler = _.noop();
 
@@ -23,41 +28,54 @@ class Socket extends EventEmitter {
         };
     }
 
+    _getPath() {
+        return new Promise(resolve => {
+            if (_.isObject(this._path)) {
+                return this._path.getAuthenticatedPath().then(resolve);
+            }
+
+            resolve(this._path);
+        }).then(path => (this._isCombinedPath ? this._combinedBaseUrl : this._baseUrl) + path);
+    }
+
     onMessage(handlerFn) {
         this._onMessageHandler = handlerFn;
     }
 
     connect() {
-        this.disconnect();
+        const attemptConnect = (path) => {
+            console.log('path', path);
 
-        return new Promise((resolve) => {
-            const operation = retry.operation(this._options.retryOptions);
+            return new Promise((resolve) => {
+                const operation = retry.operation(this._options.retryOptions);
 
-            operation.attempt((currentAttempt) => {
-                this._ws = new WebSocket(this._path);
-                this._ws.once('error', e => {
-                    if (this._options.verbose) {
-                        console.log(`WebSocket connect attempt #${ currentAttempt }`);
-                    }
+                operation.attempt((currentAttempt) => {
+                    this._ws = new WebSocket(path);
+                    this._ws.once('error', e => {
+                        if (this._options.verbose) {
+                            console.log(`WebSocket connect attempt #${ currentAttempt }`);
+                        }
 
-                    operation.retry(e);
-                });
+                        operation.retry(e);
+                    });
 
-                this._ws.once('open', () => {
-                    this._onConnected();
-                    resolve(this);
+                    this._ws.once('open', () => {
+                        this._onConnected();
+                        resolve(this);
+                    });
                 });
             });
-        });
+        };
+
+        this.disconnect();
+        return this._getPath().then(attemptConnect);
     }
 
     disconnect() {
-        if (!this._ws) {
-            return;
+        if (this._ws) {
+            this._ws.removeEventListener('close');
+            this._ws.terminate();
         }
-
-        this._ws.removeEventListener('close');
-        this._ws.terminate();
     }
 
     getWebSocket() {
@@ -65,6 +83,7 @@ class Socket extends EventEmitter {
     }
 
     _onConnected() {
+        console.log('connected');
         this._ws.on('message', this._onMessageHandler);
         this._ws.on('unexpected-response', _.noop);
         this._ws.on('error', _.noop);
@@ -84,13 +103,11 @@ class BinanceWS {
     constructor(options = {}) {
         if (_.isBoolean(options)) {
             // support legacy boolean param that controls response beautification
-            options = {beautify: options};
+            options = { beautify: options };
         }
 
-        this._baseUrl = 'wss://stream.binance.com:9443/ws/';
-        this._combinedBaseUrl = 'wss://stream.binance.com:9443/stream?streams=';
         this._beautifier = new Beautifier();
-        this._options = _.defaults(options, {beautify: true, verbose: false, retryOptions: {}});
+        this._options = _.defaults(options, { beautify: true, verbose: false, retryOptions: {} });
 
         this.streams = {
             depth: (symbol) => `${symbol.toLowerCase()}@depth`,
@@ -103,11 +120,11 @@ class BinanceWS {
         };
     }
 
-    _setupWebSocket(eventHandler, path, isCombined) {
-        const fullPath = (isCombined ? this._combinedBaseUrl : this._baseUrl) + path;
-        const socket = new Socket(fullPath, _.pick(this._options, ['retryOptions', 'verbose']));
+    _setupWebSocket(eventHandler, path, isCombinedPath) {
+        const socketOptions = _.pick(this._options, ['retryOptions', 'verbose']);
+        const socket = new Socket(path, _.extend(socketOptions, { isCombinedPath }));
 
-        socket.onMessage((message) => {
+        socket.onMessage(message => {
             let event;
             try {
                 event = JSON.parse(message);
@@ -115,9 +132,9 @@ class BinanceWS {
                 if (this._options.verbose) {
                     console.error('WebSocket message handler received invalid JSON message', message);
                 }
-
                 event = message;
             }
+
             if (this._options.beautify) {
                 if (event.stream) {
                     event.data = this._beautifyResponse(event.data);
@@ -175,13 +192,28 @@ class BinanceWS {
     }
 
     onUserData(binanceRest, eventHandler, interval = 60000) {
-        return binanceRest.startUserDataStream()
-            .then((response) => {
-                setInterval(() => {
-                    binanceRest.keepAliveUserDataStream(response);
-                }, interval);
-                return this._setupWebSocket(eventHandler, response.listenKey);
-            });
+        const setupAuth = () => {
+            let intervalId;
+
+            return {
+                getAuthenticatedPath() {
+                    if (intervalId) {
+                        clearInterval(intervalId);
+                    }
+
+                    return binanceRest.startUserDataStream()
+                        .then(response => {
+                            intervalId = setInterval(() => {
+                                binanceRest.keepAliveUserDataStream(response);
+                            }, interval);
+
+                            return response.listenKey;
+                        });
+                }
+            };
+        };
+
+        return this._setupWebSocket(eventHandler, setupAuth());
     }
 
     onCombinedStream(streams, eventHandler) {

--- a/lib/ws.js
+++ b/lib/ws.js
@@ -1,15 +1,99 @@
+const EventEmitter = require('events');
 const WebSocket = require('ws');
 const Beautifier = require('./beautifier.js');
 const _ = require('underscore');
+const retry = require('retry');
+
+class Socket extends EventEmitter {
+
+    constructor(path, { retryOptions = {}, verbose = false }) {
+        super();
+
+        this._path = path;
+        this._ws = null;
+        this._onMessageHandler = _.noop();
+
+        this._options = {
+            verbose: verbose,
+            retryOptions: _.defaults(retryOptions, {
+                forever: true,
+                factor: 1.3,
+                maxTimeout: 5 * 60 * 1000
+            })
+        };
+    }
+
+    onMessage(handlerFn) {
+        this._onMessageHandler = handlerFn;
+    }
+
+    connect() {
+        const attemptConnectPromise = new Promise(resolve => {
+            const operation = retry.operation(this._options.retryOptions);
+
+            operation.attempt((currentAttempt) => {
+                this._ws = new WebSocket(this._path);
+                this._ws.once('error', e => {
+                    if (this._options.verbose) {
+                        console.log(`WebSocket connect attempt #${ currentAttempt }`);
+                    }
+
+                    operation.retry(e);
+                });
+
+                this._ws.once('open', () => {
+                    this._onConnected();
+                    resolve(this);
+                });
+            });
+        });
+
+        return this.disconnect().then(attemptConnectPromise);
+    }
+
+    disconnect() {
+        return new Promise(resolve => {
+            if (!this._ws) {
+                return resolve();
+            }
+
+            this._ws.removeEventListener('close');
+            this._ws.once('close', resolve);
+            this._ws.terminate();
+        });
+    }
+
+    getWebSocket() {
+        return this._ws;
+    }
+
+    _onConnected() {
+        this._ws.on('message', this._onMessageHandler);
+        this._ws.on('unexpected-response', _.noop);
+        this._ws.on('error', _.noop);
+        this._ws.once('close', () => this._reconnect());
+
+        this.emit('connected');
+    }
+
+    _reconnect() {
+        this.emit('reconnect');
+        return this.connect();
+    }
+}
 
 class BinanceWS {
 
-    constructor(beautify = true) {
+    constructor(options = {}) {
+        if (_.isBoolean(options)) {
+            // support legacy boolean param that controls response beautification
+            options = { beautify: options };
+        }
+
         this._baseUrl = 'wss://stream.binance.com:9443/ws/';
         this._combinedBaseUrl = 'wss://stream.binance.com:9443/stream?streams=';
-        this._sockets = {};
         this._beautifier = new Beautifier();
-        this._beautify = beautify;
+        this._options = _.defaults(options, { beautify: true, verbose: false, retryOptions: {} });
 
         this.streams = {
             depth: (symbol) => `${symbol.toLowerCase()}@depth`,
@@ -23,20 +107,21 @@ class BinanceWS {
     }
 
     _setupWebSocket(eventHandler, path, isCombined) {
-        if (this._sockets[path]) {
-            return this._sockets[path];
-        }
-        path = (isCombined ? this._combinedBaseUrl : this._baseUrl) + path;
-        const ws = new WebSocket(path);
+        const fullPath = (isCombined ? this._combinedBaseUrl : this._baseUrl) + path;
+        const socket = new Socket(fullPath, _.pick(this._options, ['retryOptions', 'verbose']));
 
-        ws.on('message', (message) => {
+        socket.onMessage((message) => {
             let event;
             try {
                 event = JSON.parse(message);
             } catch (e) {
+                if (this._options.verbose) {
+                    console.error('WebSocket message handler received invalid JSON message', message);
+                }
+
                 event = message;
             }
-            if (this._beautify) {
+            if (this._options.beautify) {
                 if (event.stream) {
                     event.data = this._beautifyResponse(event.data);
                 } else {
@@ -47,11 +132,7 @@ class BinanceWS {
             eventHandler(event);
         });
 
-        ws.on('error', () => {
-            // node.js EventEmitters will throw and then exit if no error listener is registered
-        });
-
-        return ws;
+        return socket.connect();
     }
 
     _beautifyResponse(data) {

--- a/lib/ws.js
+++ b/lib/ws.js
@@ -208,7 +208,8 @@ class BinanceWS {
                         .then(response => {
                             intervalId = setInterval(() => {
                                 binanceRest.keepAliveUserDataStream(response).catch(e => {
-                                    console.error(new Date(), 'Failed requesting keepAliveUserDataStream for onUserData listener', e);
+                                    const msg = 'Failed requesting keepAliveUserDataStream for onUserData listener';
+                                    console.error(new Date(), msg, e);
                                 });
                             }, interval);
 

--- a/lib/ws.js
+++ b/lib/ws.js
@@ -207,7 +207,9 @@ class BinanceWS {
                     return binanceRest.startUserDataStream()
                         .then(response => {
                             intervalId = setInterval(() => {
-                                binanceRest.keepAliveUserDataStream(response);
+                                binanceRest.keepAliveUserDataStream(response).catch(e => {
+                                    console.error(new Date(), 'Failed requesting keepAliveUserDataStream for onUserData listener', e);
+                                });
                             }, interval);
 
                             return response.listenKey;

--- a/lib/ws.js
+++ b/lib/ws.js
@@ -28,7 +28,7 @@ class Socket extends EventEmitter {
     }
 
     connect() {
-        const attemptConnectPromise = new Promise(resolve => {
+        const attemptConnect = (resolve) => {
             const operation = retry.operation(this._options.retryOptions);
 
             operation.attempt((currentAttempt) => {
@@ -46,9 +46,9 @@ class Socket extends EventEmitter {
                     resolve(this);
                 });
             });
-        });
+        };
 
-        return this.disconnect().then(attemptConnectPromise);
+        return this.disconnect().then(() => new Promise(attemptConnect));
     }
 
     disconnect() {

--- a/lib/ws.js
+++ b/lib/ws.js
@@ -44,8 +44,6 @@ class Socket extends EventEmitter {
 
     connect() {
         const attemptConnect = (path) => {
-            console.log('path', path);
-
             return new Promise((resolve) => {
                 const operation = retry.operation(this._options.retryOptions);
 
@@ -83,7 +81,6 @@ class Socket extends EventEmitter {
     }
 
     _onConnected() {
-        console.log('connected');
         this._ws.on('message', this._onMessageHandler);
         this._ws.on('unexpected-response', _.noop);
         this._ws.on('error', _.noop);

--- a/lib/ws.js
+++ b/lib/ws.js
@@ -74,6 +74,10 @@ class Socket extends EventEmitter {
             this._ws.removeEventListener('close');
             this._ws.terminate();
         }
+
+        if (_.isObject(this._path)) {
+            this._path.flushKeepAlive();
+        }
     }
 
     getWebSocket() {
@@ -193,11 +197,13 @@ class BinanceWS {
             let intervalId;
 
             return {
-                getAuthenticatedPath() {
+                flushKeepAlive() {
                     if (intervalId) {
                         clearInterval(intervalId);
                     }
+                },
 
+                getAuthenticatedPath() {
                     return binanceRest.startUserDataStream()
                         .then(response => {
                             intervalId = setInterval(() => {

--- a/lib/ws.js
+++ b/lib/ws.js
@@ -6,7 +6,7 @@ const retry = require('retry');
 
 class Socket extends EventEmitter {
 
-    constructor(path, { retryOptions = {}, verbose = false }) {
+    constructor(path, {retryOptions = {}, verbose = false}) {
         super();
 
         this._path = path;
@@ -28,7 +28,9 @@ class Socket extends EventEmitter {
     }
 
     connect() {
-        const attemptConnect = (resolve) => {
+        this.disconnect();
+
+        return new Promise((resolve) => {
             const operation = retry.operation(this._options.retryOptions);
 
             operation.attempt((currentAttempt) => {
@@ -46,21 +48,16 @@ class Socket extends EventEmitter {
                     resolve(this);
                 });
             });
-        };
-
-        return this.disconnect().then(() => new Promise(attemptConnect));
+        });
     }
 
     disconnect() {
-        return new Promise(resolve => {
-            if (!this._ws) {
-                return resolve();
-            }
+        if (!this._ws) {
+            return;
+        }
 
-            this._ws.removeEventListener('close');
-            this._ws.once('close', resolve);
-            this._ws.terminate();
-        });
+        this._ws.removeEventListener('close');
+        this._ws.terminate();
     }
 
     getWebSocket() {
@@ -87,13 +84,13 @@ class BinanceWS {
     constructor(options = {}) {
         if (_.isBoolean(options)) {
             // support legacy boolean param that controls response beautification
-            options = { beautify: options };
+            options = {beautify: options};
         }
 
         this._baseUrl = 'wss://stream.binance.com:9443/ws/';
         this._combinedBaseUrl = 'wss://stream.binance.com:9443/stream?streams=';
         this._beautifier = new Beautifier();
-        this._options = _.defaults(options, { beautify: true, verbose: false, retryOptions: {} });
+        this._options = _.defaults(options, {beautify: true, verbose: false, retryOptions: {}});
 
         this.streams = {
             depth: (symbol) => `${symbol.toLowerCase()}@depth`,

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   },
   "dependencies": {
     "request": "^2.81.0",
+    "retry": "^0.10.1",
     "underscore": "^1.8.3",
-    "ws": "^3.1.0"
+    "ws": "^4.0.0"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -114,6 +114,10 @@ assertion-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
 
+async-limiter@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
+
 async@1.x, async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -1338,6 +1342,10 @@ restore-cursor@^2.0.0:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
 
+retry@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
+
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
@@ -1657,10 +1665,11 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-3.1.0.tgz#8afafecdeab46d572e5397ee880739367aa2f41c"
+ws@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-4.0.0.tgz#bfe1da4c08eeb9780b986e0e4d10eccd7345999f"
   dependencies:
+    async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
 


### PR DESCRIPTION
Hi @aarongarvey,

After many many hours of fiddling around and testing every potential situation with `binanceWS` I've came up, in my opinion, an elegant solution that throttles WS connections/reconnections effectively using node-retry module.

I've tried observing WS states with `ws.ping()` command, but trying to re-instantiate a broken connection using this heartbeat strategy came out as not being a good solution, as in, once the internet connection gets restored, `ws` lib automatically tries to restore the socket by itself.

Looking forward to your review, ideas, suggestions. But as for now, I'm going to use this in my personal project to further test web socket stability.

Also: newly introduce Socket class allows end-user to listen for `reconnect` events. That will be extremely helpful for those who cannot lose their order update info.