### PR TITLE
firstTradeId comes as a lowercase f in the API

### DIFF
--- a/lib/beautifier.js
+++ b/lib/beautifier.js
@@ -183,7 +183,7 @@ class Beautifier {
                 q: 'quoteAssetVolume',
                 O: 'openTime',
                 C: 'closeTime',
-                F: 'firstTradeId',
+                f: 'firstTradeId',
                 L: 'lastTradeId',
                 n: 'trades'
             }


### PR DESCRIPTION
checkout this documentation https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#klinecandlestick-streams