### PR TITLE
Time sync offset util methods & createHmac fallback for react/preact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Binance API
 
+## 2.0.13
+- Expose time sync offset getter/setter in base client. `getTimeOffset()/setTimeOffest(value)`.
+
 ## 2.0.12
 - Increase default timeout for websocket pong heartbeats to 7500ms.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.13
 - Expose time sync offset getter/setter in base client. `getTimeOffset()/setTimeOffest(value)`.
+- Add handler to signMessage method, falling back to browser equivalent if method is not a function (react/preact/#141).
 
 ## 2.0.12
 - Increase default timeout for websocket pong heartbeats to 7500ms.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "Node.js connector for Binance's REST APIs and WebSockets, with TypeScript & integration tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -16,7 +16,7 @@
     "build:clean": "npm run clean && npm run build",
     "build:watch": "npm run clean && tsc --watch",
     "pack": "webpack --config webpack/webpack.config.js",
-    "prepublish": "npm run build:clean",
+    "prepublishOnly": "npm run build:clean",
     "betapublish": "npm publish --tag beta"
   },
   "author": "Tiago Siebler (https://github.com/tiagosiebler)",

--- a/src/util/node-support.ts
+++ b/src/util/node-support.ts
@@ -1,7 +1,12 @@
 import { createHmac } from 'crypto';
+import * as browserMethods from './browser-support';
 
 export async function signMessage(message: string, secret: string): Promise<string> {
-  return createHmac('sha256', secret)
+  if (typeof createHmac === 'function') {
+    return createHmac('sha256', secret)
     .update(message)
     .digest('hex');
+  }
+
+  return browserMethods.signMessage(message, secret);
 };


### PR DESCRIPTION
- Expose time sync offset getter/setter in base client. `getTimeOffset()/setTimeOffest(value)`.
- Add handler to signMessage method, falling back to browser equivalent if method is not a function (react/preact/#141).