### PR TITLE
#145 - Adding missing param withdrawOrderId

### DIFF
--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -193,6 +193,7 @@ export type WithdrawStatusCode = `${EnumWithdrawStatus}`;
 
 export interface WithdrawHistoryParams {
   coin?: string;
+  withdrawOrderId?: string;
   status?: WithdrawStatusCode;
   offset?: number;
   limit?: number;


### PR DESCRIPTION
Adding missing optional parameter 'withdrawOrderId' to interface 'WithdrawHistoryParams' in spot.ts. See issue #145 for more information.