### PR TITLE
Add missing type to WsMessageBookTickerEventFormatted interface

### DIFF
--- a/src/types/websockets.ts
+++ b/src/types/websockets.ts
@@ -294,6 +294,7 @@ export interface WsMessageBookTickerEventRaw extends WsSharedBase {
 export interface WsMessageBookTickerEventFormatted extends WsSharedBase {
   eventType: 'bookTicker';
   updateId: number;
+  symbol: string;
   bidPrice: number;
   bidQty: number;
   askPrice: number;


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #196  <!-- Issue # here -->

##  Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] Updated related documentation
- [ ] Updated/added related tests
- [x] I have tested my changes locally
