### PR TITLE
v2.0.29: type fixes for new order type in futures & getExchangeInfo with symbol param

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,4 @@
 {
-    "tabWidth": 4,
-    "singleQuote": true
+  "tabWidth": 2,
+  "singleQuote": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "binance",
-  "version": "2.0.27",
+  "version": "2.0.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.0.27",
+      "name": "binance",
+      "version": "2.0.28",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "2.0.28",
+  "version": "2.0.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "2.0.28",
+      "version": "2.0.29",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.0.28",
+  "version": "2.0.29",
   "description": "Node.js connector for Binance's REST APIs and WebSockets, with TypeScript & integration tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -130,7 +130,7 @@ import {
   getServerTimeEndpoint,
   logInvalidOrderId,
   RestClientOptions,
-  serialiseParams
+  serialiseParams,
 } from './util/requestUtils';
 
 import BaseRestClient from './util/BaseRestClient';
@@ -138,7 +138,7 @@ import BaseRestClient from './util/BaseRestClient';
 export class MainClient extends BaseRestClient {
   constructor(
     restClientOptions: RestClientOptions = {},
-    requestOptions: AxiosRequestConfig = {},
+    requestOptions: AxiosRequestConfig = {}
   ) {
     super('spot1', restClientOptions, requestOptions);
     return this;
@@ -158,7 +158,7 @@ export class MainClient extends BaseRestClient {
    *
    * Wallet Endpoints
    *
-  **/
+   **/
 
   getSystemStatus(): Promise<SystemStatusResponse> {
     return this.get('sapi/v1/system/status');
@@ -168,7 +168,9 @@ export class MainClient extends BaseRestClient {
     return this.getPrivate('sapi/v1/capital/config/getall');
   }
 
-  getDailyAccountSnapshot(params: DailyAccountSnapshotParams): Promise<DailyAccountSnapshot> {
+  getDailyAccountSnapshot(
+    params: DailyAccountSnapshotParams
+  ): Promise<DailyAccountSnapshot> {
     return this.getPrivate('sapi/v1/accountSnapshot', params);
   }
 
@@ -188,15 +190,19 @@ export class MainClient extends BaseRestClient {
     return this.getPrivate('sapi/v1/capital/deposit/hisrec', params);
   }
 
-  getWithdrawHistory(params?: WithdrawHistoryParams): Promise<WithdrawHistory[]> {
+  getWithdrawHistory(
+    params?: WithdrawHistoryParams
+  ): Promise<WithdrawHistory[]> {
     return this.getPrivate('sapi/v1/capital/withdraw/history', params);
   }
 
-  getDepositAddress(params: DepositAddressParams): Promise<DepositAddressResponse> {
+  getDepositAddress(
+    params: DepositAddressParams
+  ): Promise<DepositAddressResponse> {
     return this.getPrivate('sapi/v1/capital/deposit/address', params);
   }
 
-  getAccountStatus(): Promise<{ data: string; }> {
+  getAccountStatus(): Promise<{ data: string }> {
     return this.getPrivate('sapi/v1/account/status');
   }
 
@@ -212,7 +218,9 @@ export class MainClient extends BaseRestClient {
     return this.getPrivate('sapi/v1/asset/assetDividend', params);
   }
 
-  getAssetDetail(params?: Partial<BasicAssetParam>): Promise<Record<ExchangeSymbol, AssetDetail>> {
+  getAssetDetail(
+    params?: Partial<BasicAssetParam>
+  ): Promise<Record<ExchangeSymbol, AssetDetail>> {
     return this.getPrivate('sapi/v1/asset/assetDetail', params);
   }
 
@@ -220,11 +228,15 @@ export class MainClient extends BaseRestClient {
     return this.getPrivate('sapi/v1/asset/tradeFee', params);
   }
 
-  submitUniversalTransfer(params: UniversalTransferParams): Promise<{ tranId: number; }> {
+  submitUniversalTransfer(
+    params: UniversalTransferParams
+  ): Promise<{ tranId: number }> {
     return this.postPrivate('sapi/v1/asset/transfer', params);
   }
 
-  getUniversalTransferHistory(params: UniversalTransferHistoryParams): Promise<any> {
+  getUniversalTransferHistory(
+    params: UniversalTransferHistoryParams
+  ): Promise<any> {
     return this.getPrivate('sapi/v1/asset/transfer', params);
   }
 
@@ -240,54 +252,82 @@ export class MainClient extends BaseRestClient {
    *
    * Sub-Account Endpoints
    *
-  **/
+   **/
 
-  createVirtualSubAccount(params: CreateSubAccountParams): Promise<VirtualSubAccount> {
+  createVirtualSubAccount(
+    params: CreateSubAccountParams
+  ): Promise<VirtualSubAccount> {
     return this.postPrivate('sapi/v1/sub-account/virtualSubAccount', params);
   }
 
-  getSubAccountList(params?: SubAccountListParams): Promise<SubAccountListResponse> {
+  getSubAccountList(
+    params?: SubAccountListParams
+  ): Promise<SubAccountListResponse> {
     return this.getPrivate('sapi/v1/sub-account/list', params);
   }
 
-  getSubAccountSpotAssetTransferHistory(params?: SubAccountSpotAssetTransferHistoryParams): Promise<SubAccountSpotAssetTransferHistory> {
+  getSubAccountSpotAssetTransferHistory(
+    params?: SubAccountSpotAssetTransferHistoryParams
+  ): Promise<SubAccountSpotAssetTransferHistory> {
     return this.getPrivate('sapi/v1/sub-account/sub/transfer/history', params);
   }
 
-  getSubAccountFuturesAssetTransferHistory(params: SubAccountFuturesAssetTransferHistoryParams): Promise<SubAccountFuturesAssetTransferHistory> {
-    return this.getPrivate('sapi/v1/sub-account/futures/internalTransfer', params);
+  getSubAccountFuturesAssetTransferHistory(
+    params: SubAccountFuturesAssetTransferHistoryParams
+  ): Promise<SubAccountFuturesAssetTransferHistory> {
+    return this.getPrivate(
+      'sapi/v1/sub-account/futures/internalTransfer',
+      params
+    );
   }
 
-  subAccountFuturesAssetTransfer(params: SubAccountFuturesAssetTransferParams): Promise<SubAccountFuturesAssetTransfer> {
-    return this.postPrivate('sapi/v1/sub-account/futures/internalTransfer', params);
+  subAccountFuturesAssetTransfer(
+    params: SubAccountFuturesAssetTransferParams
+  ): Promise<SubAccountFuturesAssetTransfer> {
+    return this.postPrivate(
+      'sapi/v1/sub-account/futures/internalTransfer',
+      params
+    );
   }
 
-  getSubAccountAssets(params: SubAccountAssetsParams): Promise<SubAccountAssets> {
+  getSubAccountAssets(
+    params: SubAccountAssetsParams
+  ): Promise<SubAccountAssets> {
     return this.getPrivate('sapi/v3/sub-account/assets', params);
   }
 
-  getSubAccountSpotAssetsSummary(params?: SubAccountSpotAssetsSummaryParams): Promise<SubAccountSpotAssetsSummary> {
+  getSubAccountSpotAssetsSummary(
+    params?: SubAccountSpotAssetsSummaryParams
+  ): Promise<SubAccountSpotAssetsSummary> {
     return this.getPrivate('sapi/v1/sub-account/spotSummary', params);
   }
 
-  getSubAccountDepositAddress(params: SubAccountDepositAddressParams): Promise<SubAccountDepositAddress> {
+  getSubAccountDepositAddress(
+    params: SubAccountDepositAddressParams
+  ): Promise<SubAccountDepositAddress> {
     return this.getPrivate('sapi/v1/capital/deposit/subAddress', params);
   }
 
-  getSubAccountDepositHistory(params: SubAccountDepositHistoryParams): Promise<DepositHistory[]> {
+  getSubAccountDepositHistory(
+    params: SubAccountDepositHistoryParams
+  ): Promise<DepositHistory[]> {
     return this.getPrivate('sapi/v1/capital/deposit/subHisrec', params);
   }
 
-  getSubAccountStatusOnMarginOrFutures(params?: { email?: string }): Promise<SubAccountStatus[]> {
-    return this.getPrivate('sapi/v1/sub-account/status', params );
+  getSubAccountStatusOnMarginOrFutures(params?: {
+    email?: string;
+  }): Promise<SubAccountStatus[]> {
+    return this.getPrivate('sapi/v1/sub-account/status', params);
   }
 
   subAccountEnableMargin(email: string): Promise<SubAccountEnableMargin> {
-    return this.postPrivate('sapi/v1/sub-account/margin/enable', { email } );
+    return this.postPrivate('sapi/v1/sub-account/margin/enable', { email });
   }
 
-  getSubAccountDetailOnMarginAccount(email: string): Promise<SubAccountMarginAccountDetail> {
-    return this.getPrivate('sapi/v1/sub-account/margin/account', { email } );
+  getSubAccountDetailOnMarginAccount(
+    email: string
+  ): Promise<SubAccountMarginAccountDetail> {
+    return this.getPrivate('sapi/v1/sub-account/margin/account', { email });
   }
 
   getSubAccountsSummaryOfMarginAccount(): Promise<SubAccountsMarginAccountSummary> {
@@ -295,98 +335,161 @@ export class MainClient extends BaseRestClient {
   }
 
   subAccountEnableFutures(email: string): Promise<SubAccountEnableFutures> {
-    return this.postPrivate('sapi/v1/sub-account/futures/enable', { email } );
+    return this.postPrivate('sapi/v1/sub-account/futures/enable', { email });
   }
 
-  getSubAccountFuturesAccountDetail(email: string): Promise<SubAccountFuturesAccountDetail> {
-    return this.getPrivate('sapi/v1/sub-account/futures/account', { email } );
+  getSubAccountFuturesAccountDetail(
+    email: string
+  ): Promise<SubAccountFuturesAccountDetail> {
+    return this.getPrivate('sapi/v1/sub-account/futures/account', { email });
   }
 
   getSubAccountFuturesAccountSummary(): Promise<SubAccountFuturesAccountSummary> {
     return this.getPrivate('sapi/v1/sub-account/futures/accountSummary');
   }
 
-  getSubAccountFuturesPositionRisk(email: string): Promise<FuturesPositionRisk[]> {
-    return this.getPrivate('sapi/v1/sub-account/futures/positionRisk', { email } );
+  getSubAccountFuturesPositionRisk(
+    email: string
+  ): Promise<FuturesPositionRisk[]> {
+    return this.getPrivate('sapi/v1/sub-account/futures/positionRisk', {
+      email,
+    });
   }
 
-  subAccountFuturesTransfer(params: SubAccountTransferParams): Promise<SubAccountTransfer> {
+  subAccountFuturesTransfer(
+    params: SubAccountTransferParams
+  ): Promise<SubAccountTransfer> {
     return this.postPrivate('sapi/v1/sub-account/futures/transfer', params);
   }
 
-  subAccountMarginTransfer(params: SubAccountTransferParams): Promise<SubAccountTransfer> {
+  subAccountMarginTransfer(
+    params: SubAccountTransferParams
+  ): Promise<SubAccountTransfer> {
     return this.postPrivate('sapi/v1/sub-account/margin/transfer', params);
   }
 
-  subAccountTransferToSameMaster(params: SubAccountTransferToSameMasterParams): Promise<SubAccountTransfer> {
+  subAccountTransferToSameMaster(
+    params: SubAccountTransferToSameMasterParams
+  ): Promise<SubAccountTransfer> {
     return this.postPrivate('sapi/v1/sub-account/transfer/subToSub', params);
   }
 
-  subAccountTransferToMaster(params: SubAccountTransferToMasterParams): Promise<SubAccountTransfer> {
+  subAccountTransferToMaster(
+    params: SubAccountTransferToMasterParams
+  ): Promise<SubAccountTransfer> {
     return this.postPrivate('sapi/v1/sub-account/transfer/subToMaster', params);
   }
 
-  subAccountTransferHistory(params?: SubAccountTransferHistoryParams): Promise<SubAccountTransferHistory[]> {
-    return this.getPrivate('sapi/v1/sub-account/transfer/subUserHistory', params);
+  subAccountTransferHistory(
+    params?: SubAccountTransferHistoryParams
+  ): Promise<SubAccountTransferHistory[]> {
+    return this.getPrivate(
+      'sapi/v1/sub-account/transfer/subUserHistory',
+      params
+    );
   }
 
-  subAccountUniversalTransfer(params: SubAccountUniversalTransferParams): Promise<SubAccountUniversalTransfer> {
+  subAccountUniversalTransfer(
+    params: SubAccountUniversalTransferParams
+  ): Promise<SubAccountUniversalTransfer> {
     return this.postPrivate('sapi/v1/sub-account/universalTransfer', params);
   }
 
-  getSubAccountUniversalTransferHistory(params?: SubAccountUniversalTransferHistoryParams): Promise<SubAccountUniversalTransferHistoryResponse> {
+  getSubAccountUniversalTransferHistory(
+    params?: SubAccountUniversalTransferHistoryParams
+  ): Promise<SubAccountUniversalTransferHistoryResponse> {
     return this.getPrivate('sapi/v1/sub-account/universalTransfer', params);
   }
 
-  getSubAccountDetailOnFuturesAccountV2(params: BasicFuturesSubAccountParams): Promise<SubAccountUSDMDetail | SubAccountCOINMDetail> {
+  getSubAccountDetailOnFuturesAccountV2(
+    params: BasicFuturesSubAccountParams
+  ): Promise<SubAccountUSDMDetail | SubAccountCOINMDetail> {
     return this.getPrivate('sapi/v2/sub-account/futures/account', params);
   }
 
-  getSubAccountSummaryOnFuturesAccountV2(params: SubAccountSummaryOnFuturesAccountV2Params): Promise<SubAccountUSDMSummary | SubAccountCOINMSummary> {
-    return this.getPrivate('sapi/v2/sub-account/futures/accountSummary', params);
+  getSubAccountSummaryOnFuturesAccountV2(
+    params: SubAccountSummaryOnFuturesAccountV2Params
+  ): Promise<SubAccountUSDMSummary | SubAccountCOINMSummary> {
+    return this.getPrivate(
+      'sapi/v2/sub-account/futures/accountSummary',
+      params
+    );
   }
 
-  getSubAccountFuturesPositionRiskV2(params: BasicFuturesSubAccountParams): Promise<SubAccountUSDMPositionRisk | SubAccountCOINMPositionRisk> {
+  getSubAccountFuturesPositionRiskV2(
+    params: BasicFuturesSubAccountParams
+  ): Promise<SubAccountUSDMPositionRisk | SubAccountCOINMPositionRisk> {
     return this.getPrivate('sapi/v2/sub-account/futures/positionRisk', params);
   }
 
-  subAccountEnableLeverageToken(params: SubAccountEnableLeverageToken): Promise<SubAccountEnableLeverageToken> {
+  subAccountEnableLeverageToken(
+    params: SubAccountEnableLeverageToken
+  ): Promise<SubAccountEnableLeverageToken> {
     return this.postPrivate('sapi/v1/sub-account/blvt/enable', params);
   }
-  
-  subAccountEnableOrDisableIPRestriction(params: EnableOrDisableIPRestrictionForSubAccountParams): Promise<SubAccountnableOrDisableIPRestriction> {
-    return this.postPrivate('sapi/v1/sub-account/subAccountApi/ipRestriction', params);
+
+  subAccountEnableOrDisableIPRestriction(
+    params: EnableOrDisableIPRestrictionForSubAccountParams
+  ): Promise<SubAccountnableOrDisableIPRestriction> {
+    return this.postPrivate(
+      'sapi/v1/sub-account/subAccountApi/ipRestriction',
+      params
+    );
   }
 
-  subAccountAddIPList(params: SubAccountnableOrDisableIPRestriction): Promise<SubAccountAddOrDeleteIPList> {
-    return this.postPrivate('sapi/v1/sub-account/subAccountApi/ipRestriction/ipList', params);
+  subAccountAddIPList(
+    params: SubAccountnableOrDisableIPRestriction
+  ): Promise<SubAccountAddOrDeleteIPList> {
+    return this.postPrivate(
+      'sapi/v1/sub-account/subAccountApi/ipRestriction/ipList',
+      params
+    );
   }
 
-  getSubAccountIPRestriction(params: BasicSubAccount): Promise<SubAccountnableOrDisableIPRestriction> {
-    return this.getPrivate('sapi/v1/sub-account/subAccountApi/ipRestriction', params);
+  getSubAccountIPRestriction(
+    params: BasicSubAccount
+  ): Promise<SubAccountnableOrDisableIPRestriction> {
+    return this.getPrivate(
+      'sapi/v1/sub-account/subAccountApi/ipRestriction',
+      params
+    );
   }
 
-  subAccountDeleteIPList(params: SubAccountnableOrDisableIPRestriction): Promise<SubAccountnableOrDisableIPRestriction> {
-    return this.deletePrivate('sapi/v1/sub-account/subAccountApi/ipRestriction/ipList', params);
+  subAccountDeleteIPList(
+    params: SubAccountnableOrDisableIPRestriction
+  ): Promise<SubAccountnableOrDisableIPRestriction> {
+    return this.deletePrivate(
+      'sapi/v1/sub-account/subAccountApi/ipRestriction/ipList',
+      params
+    );
   }
 
-  depositAssetsIntoManagedSubAccount(params: SubAccountTransferToSameMasterParams): Promise<MarginTransactionResponse> {
+  depositAssetsIntoManagedSubAccount(
+    params: SubAccountTransferToSameMasterParams
+  ): Promise<MarginTransactionResponse> {
     return this.postPrivate('sapi/v1/managed-subaccount/deposit', params);
   }
 
-  getManagedSubAccountAssetDetails(email: string): Promise<SubAccountAssetDetails[]> {
-    return this.getPrivate('sapi/v1/managed-subaccount/asset', { email } );
+  getManagedSubAccountAssetDetails(
+    email: string
+  ): Promise<SubAccountAssetDetails[]> {
+    return this.getPrivate('sapi/v1/managed-subaccount/asset', { email });
   }
 
-  withdrawAssetsFromManagedSubAccount(params: WithdrawAssetsFromManagedSubAccountParams): Promise<MarginTransactionResponse> {
+  withdrawAssetsFromManagedSubAccount(
+    params: WithdrawAssetsFromManagedSubAccountParams
+  ): Promise<MarginTransactionResponse> {
     return this.postPrivate('sapi/v1/managed-subaccount/withdraw', params);
   }
 
   /**
    * Broker Endpoints
    */
-  
-  getBrokerIfNewSpotUser(): Promise<{ rebateWorking: boolean; ifNewUser: boolean; }> {
+
+  getBrokerIfNewSpotUser(): Promise<{
+    rebateWorking: boolean;
+    ifNewUser: boolean;
+  }> {
     return this.getPrivate('sapi/v1/apiReferral/ifNewUser');
   }
 
@@ -398,10 +501,14 @@ export class MainClient extends BaseRestClient {
   // USD & Coin-M can be found under API getIncome() (find "API rebate" in results)
   getBrokerSpotRebateHistory(days: 7 | 30, customerId?: string) {
     if (days === 7) {
-      return this.getPrivate('sapi/v1/apiReferral/rebate/recentRecord', { customerId });
+      return this.getPrivate('sapi/v1/apiReferral/rebate/recentRecord', {
+        customerId,
+      });
     }
     if (days === 30) {
-      return this.getPrivate('sapi/v1/apiReferral/rebate/historicalRecord', { customerId });
+      return this.getPrivate('sapi/v1/apiReferral/rebate/historicalRecord', {
+        customerId,
+      });
     }
   }
 
@@ -409,7 +516,7 @@ export class MainClient extends BaseRestClient {
    *
    * Market Data Endpoints
    *
-  **/
+   **/
 
   testConnectivity(): Promise<{}> {
     return this.get('api/v3/ping');
@@ -421,7 +528,7 @@ export class MainClient extends BaseRestClient {
 
     let urlSuffix = '';
     if (symbols || symbol) {
-      urlSuffix += '?' + (symbols || symbol);
+      urlSuffix += '?symbol=' + (symbols || symbol);
     }
 
     return this.get('api/v3/exchangeInfo' + urlSuffix);
@@ -439,7 +546,9 @@ export class MainClient extends BaseRestClient {
     return this.getPrivate('api/v3/historicalTrades', params);
   }
 
-  getAggregateTrades(params: SymbolFromPaginatedRequestFromId): Promise<AggregateTrade[]> {
+  getAggregateTrades(
+    params: SymbolFromPaginatedRequestFromId
+  ): Promise<AggregateTrade[]> {
     return this.get('api/v3/aggTrades', params);
   }
 
@@ -451,18 +560,27 @@ export class MainClient extends BaseRestClient {
     return this.get('api/v3/avgPrice', params);
   }
 
-  get24hrChangeStatististics(params?: Partial<BasicSymbolParam>): Promise<DailyChangeStatistic | DailyChangeStatistic[]> {
+  get24hrChangeStatististics(
+    params?: Partial<BasicSymbolParam>
+  ): Promise<DailyChangeStatistic | DailyChangeStatistic[]> {
     if (!params?.symbol) {
       return this.get('api/v3/ticker/24hr') as Promise<DailyChangeStatistic[]>;
     }
-    return this.get('api/v3/ticker/24hr', params) as Promise<DailyChangeStatistic>;
+    return this.get(
+      'api/v3/ticker/24hr',
+      params
+    ) as Promise<DailyChangeStatistic>;
   }
 
-  getSymbolPriceTicker(params?: Partial<BasicSymbolParam>): Promise<SymbolPrice | SymbolPrice[]> {
+  getSymbolPriceTicker(
+    params?: Partial<BasicSymbolParam>
+  ): Promise<SymbolPrice | SymbolPrice[]> {
     return this.get('api/v3/ticker/price', params);
   }
 
-  getSymbolOrderBookTicker(params?: Partial<BasicSymbolParam>): Promise<SymbolOrderBookTicker | SymbolOrderBookTicker[]> {
+  getSymbolOrderBookTicker(
+    params?: Partial<BasicSymbolParam>
+  ): Promise<SymbolOrderBookTicker | SymbolOrderBookTicker[]> {
     return this.get('api/v3/ticker/bookTicker', params);
   }
 
@@ -470,14 +588,16 @@ export class MainClient extends BaseRestClient {
    *
    * Spot Account/Trade Endpoints
    *
-  **/
+   **/
 
   testNewOrder(params: NewSpotOrderParams): Promise<{}> {
     this.validateOrderId(params, 'newClientOrderId');
     return this.postPrivate('api/v3/order/test', params);
   }
 
-  submitNewOrder(params: NewSpotOrderParams): Promise<OrderResponseACK | OrderResponseResult | OrderResponseFull> {
+  submitNewOrder(
+    params: NewSpotOrderParams
+  ): Promise<OrderResponseACK | OrderResponseResult | OrderResponseFull> {
     this.validateOrderId(params, 'newClientOrderId');
     return this.postPrivate('api/v3/order', params);
   }
@@ -486,7 +606,9 @@ export class MainClient extends BaseRestClient {
     return this.deletePrivate('api/v3/order', params);
   }
 
-  cancelAllSymbolOrders(params: BasicSymbolParam): Promise<CancelSpotOrderResult[]> {
+  cancelAllSymbolOrders(
+    params: BasicSymbolParam
+  ): Promise<CancelSpotOrderResult[]> {
     return this.deletePrivate('api/v3/openOrders', params);
   }
 
@@ -530,7 +652,9 @@ export class MainClient extends BaseRestClient {
     return this.getPrivate('api/v3/account');
   }
 
-  getAccountTradeList(params: SymbolFromPaginatedRequestFromId): Promise<RawAccountTrade[]> {
+  getAccountTradeList(
+    params: SymbolFromPaginatedRequestFromId
+  ): Promise<RawAccountTrade[]> {
     return this.getPrivate('api/v3/myTrades', params);
   }
 
@@ -538,25 +662,35 @@ export class MainClient extends BaseRestClient {
    *
    * Margin Account/Trade Endpoints
    *
-  **/
+   **/
 
-  crossMarginAccountTransfer(params: CrossMarginAccountTransferParams): Promise<MarginTransactionResponse> {
+  crossMarginAccountTransfer(
+    params: CrossMarginAccountTransferParams
+  ): Promise<MarginTransactionResponse> {
     return this.postPrivate('sapi/v1/margin/transfer', params);
   }
-  
-  marginAccountBorrow(params: MarginAccountLoanParams): Promise<MarginTransactionResponse> {
+
+  marginAccountBorrow(
+    params: MarginAccountLoanParams
+  ): Promise<MarginTransactionResponse> {
     return this.postPrivate('sapi/v1/margin/loan', params);
   }
 
-  marginAccountRepay(params: MarginAccountLoanParams): Promise<MarginTransactionResponse> {
+  marginAccountRepay(
+    params: MarginAccountLoanParams
+  ): Promise<MarginTransactionResponse> {
     return this.postPrivate('sapi/v1/margin/repay', params);
   }
 
-  queryMarginAsset(params: QueryMarginAssetParams): Promise<QueryMarginAssetResponse> {
+  queryMarginAsset(
+    params: QueryMarginAssetParams
+  ): Promise<QueryMarginAssetResponse> {
     return this.get('sapi/v1/margin/asset', params);
   }
 
-  queryCrossMarginPair(params: QueryCrossMarginPairParams): Promise<QueryCrossMarginPairResponse> {
+  queryCrossMarginPair(
+    params: QueryCrossMarginPairParams
+  ): Promise<QueryCrossMarginPairResponse> {
     return this.get('sapi/v1/margin/pair', params);
   }
 
@@ -568,30 +702,42 @@ export class MainClient extends BaseRestClient {
     return this.get('sapi/v1/margin/allPairs');
   }
 
-  queryMarginPriceIndex(params: BasicSymbolParam): Promise<QueryMarginPriceIndexResponse> {
+  queryMarginPriceIndex(
+    params: BasicSymbolParam
+  ): Promise<QueryMarginPriceIndexResponse> {
     return this.get('sapi/v1/margin/priceIndex', params);
   }
 
-  marginAccountNewOrder(params: NewSpotOrderParams): Promise<OrderResponseACK | OrderResponseResult | OrderResponseFull> {
+  marginAccountNewOrder(
+    params: NewSpotOrderParams
+  ): Promise<OrderResponseACK | OrderResponseResult | OrderResponseFull> {
     this.validateOrderId(params, 'newClientOrderId');
     return this.postPrivate('sapi/v1/margin/order', params);
   }
 
-  marginAccountCancelOrder(params: CancelOrderParams): Promise<CancelSpotOrderResult> {
+  marginAccountCancelOrder(
+    params: CancelOrderParams
+  ): Promise<CancelSpotOrderResult> {
     return this.deletePrivate('sapi/v1/margin/order', params);
   }
 
-  marginAccountCancelOpenOrders(params: BasicSymbolParam): Promise<CancelSpotOrderResult[]> {
+  marginAccountCancelOpenOrders(
+    params: BasicSymbolParam
+  ): Promise<CancelSpotOrderResult[]> {
     return this.deletePrivate('sapi/v1/margin/openOrders', params);
   }
 
   // TODO - https://binance-docs.github.io/apidocs/spot/en/#get-cross-margin-transfer-history-user_data
 
-  queryLoanRecord(params: QueryMarginRecordParams): Promise<MarginRecordResponse> {
+  queryLoanRecord(
+    params: QueryMarginRecordParams
+  ): Promise<MarginRecordResponse> {
     return this.getPrivate('sapi/v1/margin/loan', params);
   }
 
-  queryRepayRecord(params: QueryMarginRecordParams): Promise<MarginRecordResponse> {
+  queryRepayRecord(
+    params: QueryMarginRecordParams
+  ): Promise<MarginRecordResponse> {
     return this.getPrivate('sapi/v1/margin/repay', params);
   }
 
@@ -611,7 +757,9 @@ export class MainClient extends BaseRestClient {
     return this.getPrivate('sapi/v1/margin/openOrders', params);
   }
 
-  queryMarginAccountAllOrders(params: GetAllOrdersParams): Promise<SpotOrder[]> {
+  queryMarginAccountAllOrders(
+    params: GetAllOrdersParams
+  ): Promise<SpotOrder[]> {
     return this.getPrivate('sapi/v1/margin/allOrders', params);
   }
 
@@ -637,15 +785,21 @@ export class MainClient extends BaseRestClient {
 
   // TODO - https://binance-docs.github.io/apidocs/spot/en/#query-margin-account-39-s-trade-list-user_data
 
-  queryMaxBorrow(params: BasicMarginAssetParams): Promise<QueryMaxBorrowResponse> {
+  queryMaxBorrow(
+    params: BasicMarginAssetParams
+  ): Promise<QueryMaxBorrowResponse> {
     return this.getPrivate('sapi/v1/margin/maxBorrowable', params);
   }
 
-  queryMaxTransferOutAmount(params: BasicMarginAssetParams): Promise<QueryMaxTransferOutAmountResponse> {
+  queryMaxTransferOutAmount(
+    params: BasicMarginAssetParams
+  ): Promise<QueryMaxTransferOutAmountResponse> {
     return this.getPrivate('sapi/v1/margin/maxTransferable', params);
   }
 
-  isolatedMarginAccountTransfer(params: IsolatedMarginAccountTransferParams): Promise<MarginTransactionResponse> {
+  isolatedMarginAccountTransfer(
+    params: IsolatedMarginAccountTransferParams
+  ): Promise<MarginTransactionResponse> {
     return this.postPrivate('sapi/v1/margin/isolated/transfer', params);
   }
 
@@ -679,10 +833,10 @@ export class MainClient extends BaseRestClient {
    *
    * User Data Stream Endpoints
    *
-  **/
+   **/
 
   // spot
-  getSpotUserDataListenKey(): Promise<{ listenKey: string; }> {
+  getSpotUserDataListenKey(): Promise<{ listenKey: string }> {
     return this.post('api/v3/userDataStream');
   }
 
@@ -695,7 +849,7 @@ export class MainClient extends BaseRestClient {
   }
 
   // margin
-  getMarginUserDataListenKey(): Promise<{ listenKey: string; }> {
+  getMarginUserDataListenKey(): Promise<{ listenKey: string }> {
     return this.post('sapi/v1/userDataStream');
   }
 
@@ -708,23 +862,37 @@ export class MainClient extends BaseRestClient {
   }
 
   // isolated margin
-  getIsolatedMarginUserDataListenKey(params: { symbol: string; }): Promise<{ listenKey: string; }> {
-    return this.post(`sapi/v1/userDataStream/isolated?${serialiseParams(params)}`);
+  getIsolatedMarginUserDataListenKey(params: {
+    symbol: string;
+  }): Promise<{ listenKey: string }> {
+    return this.post(
+      `sapi/v1/userDataStream/isolated?${serialiseParams(params)}`
+    );
   }
 
-  keepAliveIsolatedMarginUserDataListenKey(params: { symbol: string; listenKey: string; }): Promise<{}> {
-    return this.put(`sapi/v1/userDataStream/isolated?${serialiseParams(params)}`);
+  keepAliveIsolatedMarginUserDataListenKey(params: {
+    symbol: string;
+    listenKey: string;
+  }): Promise<{}> {
+    return this.put(
+      `sapi/v1/userDataStream/isolated?${serialiseParams(params)}`
+    );
   }
 
-  closeIsolatedMarginUserDataListenKey(params: { symbol: string; listenKey: string; }): Promise<{}> {
-    return this.delete(`sapi/v1/userDataStream/isolated?${serialiseParams(params)}`);
+  closeIsolatedMarginUserDataListenKey(params: {
+    symbol: string;
+    listenKey: string;
+  }): Promise<{}> {
+    return this.delete(
+      `sapi/v1/userDataStream/isolated?${serialiseParams(params)}`
+    );
   }
 
   /**
    *
    * Savings Endpoints
    *
-  **/
+   **/
 
   //TODO: https://binance-docs.github.io/apidocs/spot/en/#savings-endpoints
 
@@ -732,7 +900,7 @@ export class MainClient extends BaseRestClient {
    *
    * Mining Endpoints
    *
-  **/
+   **/
 
   //TODO: https://binance-docs.github.io/apidocs/spot/en/#mining-endpoints
 
@@ -741,7 +909,7 @@ export class MainClient extends BaseRestClient {
    * Futures Management Endpoints
    * Note: to trade futures use the usdm-client or coinm-client. The spot client only has the futures endpoints listed in the "spot" docs category
    *
-  **/
+   **/
 
   //TODO: https://binance-docs.github.io/apidocs/spot/en/#futures
 
@@ -749,7 +917,7 @@ export class MainClient extends BaseRestClient {
    *
    * BLVT Endpoints
    *
-  **/
+   **/
 
   //TODO: https://binance-docs.github.io/apidocs/spot/en/#blvt-endpoints
 
@@ -757,15 +925,21 @@ export class MainClient extends BaseRestClient {
    *
    * BSwap Endpoints
    *
-  **/
+   **/
 
   //TODO: https://binance-docs.github.io/apidocs/spot/en/#bswap-endpoints
-
 
   /**
    * Validate syntax meets requirements set by binance. Log warning if not.
    */
-  private validateOrderId(params: NewSpotOrderParams | CancelOrderParams | NewOCOParams | CancelOCOParams, orderIdProperty: OrderIdProperty): void {
+  private validateOrderId(
+    params:
+      | NewSpotOrderParams
+      | CancelOrderParams
+      | NewOCOParams
+      | CancelOCOParams,
+    orderIdProperty: OrderIdProperty
+  ): void {
     const apiCategory = 'spot';
     if (!params[orderIdProperty]) {
       params[orderIdProperty] = generateNewOrderId(apiCategory);
@@ -777,7 +951,7 @@ export class MainClient extends BaseRestClient {
       logInvalidOrderId(orderIdProperty, expectedOrderIdPrefix, params);
     }
   }
-};
+}
 
 /**
  * @deprecated use MainClient instead of SpotClient (it is the same)

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -527,8 +527,10 @@ export class MainClient extends BaseRestClient {
     const symbol = params?.symbol;
 
     let urlSuffix = '';
-    if (symbols || symbol) {
-      urlSuffix += '?symbol=' + (symbols || symbol);
+    if (symbol) {
+      urlSuffix += '?symbol=' + symbol;
+    } else if (symbols) {
+      urlSuffix += '?' + symbols;
     }
 
     return this.get('api/v3/exchangeInfo' + urlSuffix);

--- a/src/types/futures.ts
+++ b/src/types/futures.ts
@@ -1,6 +1,21 @@
-import { BooleanString, BooleanStringCapitalised, ExchangeFilter, KlineInterval, numberInString, OrderBookRow, OrderResponseType, OrderSide, OrderStatus, OrderTimeInForce, OrderType, RateLimiter, SymbolFilter } from "./shared";
+import {
+  BooleanString,
+  BooleanStringCapitalised,
+  ExchangeFilter,
+  KlineInterval,
+  numberInString,
+  OrderBookRow,
+  OrderResponseType,
+  OrderSide,
+  OrderStatus,
+  OrderTimeInForce,
+  OrderType,
+  RateLimiter,
+  SymbolFilter,
+} from './shared';
 
-export type FuturesContractType = 'PERPETUAL'
+export type FuturesContractType =
+  | 'PERPETUAL'
   | 'CURRENT_MONTH'
   | 'NEXT_MONTH'
   | 'CURRENT_QUARTER'
@@ -60,7 +75,7 @@ export type MarginType = 'ISOLATED' | 'CROSSED';
 export type WorkingType = 'MARK_PRICE' | 'CONTRACT_PRICE';
 
 export type FuturesOrderType =
-  'LIMIT'
+  | 'LIMIT'
   | 'MARKET'
   | 'STOP'
   | 'STOP_MARKET'
@@ -72,7 +87,7 @@ export interface NewFuturesOrderParams {
   symbol: string;
   side: OrderSide;
   positionSide?: PositionSide;
-  type: OrderType;
+  type: FuturesOrderType;
   timeInForce?: OrderTimeInForce;
   quantity?: number;
   reduceOnly?: BooleanString;
@@ -94,12 +109,13 @@ export enum EnumPositionMarginChangeType {
 
 export type PositionMarginChangeType = `${EnumPositionMarginChangeType}`;
 
-export type IncomeType = 'TRANSFER'
-| 'WELCOME_BONUS'
-| 'REALIZED_PNL'
-| 'FUNDING_FEE'
-| 'COMMISSION'
-| 'INSURANCE_CLEAR';
+export type IncomeType =
+  | 'TRANSFER'
+  | 'WELCOME_BONUS'
+  | 'REALIZED_PNL'
+  | 'FUNDING_FEE'
+  | 'COMMISSION'
+  | 'INSURANCE_CLEAR';
 
 export interface CancelMultipleOrdersParams {
   symbol: string;
@@ -179,13 +195,15 @@ export interface GetForceOrdersParams {
   limit?: number;
 }
 
-export type ContactType = 'PERPETUAL'
+export type ContactType =
+  | 'PERPETUAL'
   | 'CURRENT_MONTH'
   | 'NEXT_MONTH'
   | 'CURRENT_QUARTER'
   | 'NEXT_QUARTER';
 
-export type ContractStatus = 'PENDING_TRADING'
+export type ContractStatus =
+  | 'PENDING_TRADING'
   | 'TRADING'
   | 'PRE_DELIVERING'
   | 'DELIVERING'
@@ -212,7 +230,7 @@ export interface FuturesSymbolExchangeInfo {
   baseAssetPrecision: number;
   quotePrecision: number;
   underlyingType: 'COIN' | 'INDEX'; // No other known values
-  underlyingSubType: string[];// DEFI / NFT / BSC / HOT / etc
+  underlyingSubType: string[]; // DEFI / NFT / BSC / HOT / etc
   settlePlan: number;
   triggerProtect: numberInString;
   filters: SymbolFilter[];
@@ -270,8 +288,8 @@ export type FuturesKline = [
   number, // number of trades
   numberInString, // taker buy base asset vol
   numberInString, // taker buy quote asest vol
-  numberInString, // ignore?
-]
+  numberInString // ignore?
+];
 
 export interface FundingRateHistory {
   symbol: string;
@@ -296,7 +314,7 @@ export interface OpenInterest {
 
 export interface PositionModeParams {
   dualSidePosition: DualSideMode;
-};
+}
 
 export interface ModeChangeResult {
   code: 200 | number;

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -145,12 +145,15 @@ export interface CancelOrderParams {
   symbol: string;
   orderId?: number;
   origClientOrderId?: string;
+  /** For isolated margin trading only */
   newClientOrderId?: string;
+  /** For isolated margin trading only */
   isIsolated?: StringBoolean;
 }
 
 export interface CancelOCOParams {
   symbol: string;
+  /** For isolated margin trading only */
   isIsolated?: string;
   orderListId?: number;
   listClientOrderId?: number;
@@ -171,6 +174,7 @@ export interface NewOCOParams {
   stopIcebergQty?: number;
   stopLimitTimeInForce: OrderTimeInForce;
   newOrderRespType: OrderResponseType;
+  /** For isolated margin trading only */
   isIsolated?: StringBoolean;
   /** Define a side effect, only for margin trading */
   sideEffectType?: SideEffects;
@@ -190,6 +194,7 @@ export interface GetAllOrdersParams {
   startTime?: number;
   endTime?: number;
   limit?: number;
+  /** For isolated margin trading only */
   isIsolated?: StringBoolean;
 }
 

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -172,6 +172,7 @@ export interface NewOCOParams {
   stopLimitTimeInForce: OrderTimeInForce;
   newOrderRespType: OrderResponseType;
   isIsolated?: StringBoolean;
+  /** Define a side effect, only for margin trading */
   sideEffectType?: SideEffects;
 }
 

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -7,7 +7,17 @@ export type ExchangeSymbol = string;
 export type BooleanString = 'true' | 'false';
 export type BooleanStringCapitalised = 'TRUE' | 'FALSE';
 
-export type BinanceBaseUrlKey = 'spot' | 'spot1' | 'spot2' | 'spot3' | 'spot4' | 'usdmtest' | 'usdm' | 'coinm' | 'voptions' | 'voptionstest';
+export type BinanceBaseUrlKey =
+  | 'spot'
+  | 'spot1'
+  | 'spot2'
+  | 'spot3'
+  | 'spot4'
+  | 'usdmtest'
+  | 'usdm'
+  | 'coinm'
+  | 'voptions'
+  | 'voptionstest';
 
 export type OrderTimeInForce = 'GTC' | 'IOC' | 'FOK';
 
@@ -22,11 +32,16 @@ export type SideEffects = 'MARGIN_BUY' | 'AUTO_REPAY' | 'NO_SIDE_EFFECT';
  */
 export type OrderResponseType = 'ACK' | 'RESULT' | 'FULL';
 
-export type OrderIdProperty = 'newClientOrderId' | 'listClientOrderId' | 'limitClientOrderId' | 'stopClientOrderId';
+export type OrderIdProperty =
+  | 'newClientOrderId'
+  | 'listClientOrderId'
+  | 'limitClientOrderId'
+  | 'stopClientOrderId';
 
 export type OrderSide = 'BUY' | 'SELL';
 
-export type OrderStatus = 'NEW'
+export type OrderStatus =
+  | 'NEW'
   | 'PARTIALLY_FILLED'
   | 'FILLED'
   | 'CANCELED'
@@ -34,26 +49,21 @@ export type OrderStatus = 'NEW'
   | 'REJECTED'
   | 'EXPIRED';
 
-export type OrderExecutionType = 'NEW'
+export type OrderExecutionType =
+  | 'NEW'
   | 'CANCELED'
   | 'REJECTED'
   | 'TRADE'
   | 'EXPIRED';
 
 // listStatusType
-export type OCOStatus =
-  'RESPONSE'
-  | 'EXEC_STARTED'
-  | 'ALL_DONE';
+export type OCOStatus = 'RESPONSE' | 'EXEC_STARTED' | 'ALL_DONE';
 
 // listOrderStatus
-export type OCOOrderStatus =
-  'EXECUTING'
-  | 'ALL_DONE'
-  | 'REJECT';
+export type OCOOrderStatus = 'EXECUTING' | 'ALL_DONE' | 'REJECT';
 
 export type OrderType =
-  'LIMIT'
+  | 'LIMIT'
   | 'LIMIT_MAKER'
   | 'MARKET'
   | 'STOP_LOSS'
@@ -90,7 +100,7 @@ export interface OrderBookParams {
 }
 
 export type KlineInterval =
-  '1m'
+  | '1m'
   | '3m'
   | '5m'
   | '15m'
@@ -249,7 +259,8 @@ export interface SymbolMaxPositionFilter {
   maxPosition: numberInString;
 }
 
-export type SymbolFilter = SymbolPriceFilter
+export type SymbolFilter =
+  | SymbolPriceFilter
   | SymbolPercentPriceFilter
   | SymbolLotSizeFilter
   | SymbolMinNotionalFilter
@@ -270,7 +281,9 @@ export interface ExchangeMaxAlgoOrdersFilter {
   maxNumAlgoOrders: number;
 }
 
-export type ExchangeFilter = ExchangeMaxNumOrdersFilter | ExchangeMaxAlgoOrdersFilter;
+export type ExchangeFilter =
+  | ExchangeMaxNumOrdersFilter
+  | ExchangeMaxAlgoOrdersFilter;
 
 export type OrderBookPrice = numberInString;
 export type OrderBookAmount = numberInString;
@@ -279,7 +292,10 @@ export type OrderBookRow = [OrderBookPrice, OrderBookAmount];
 
 export type OrderBookPriceFormatted = number;
 export type OrderBookAmountFormatted = number;
-export type OrderBookRowFormatted = [OrderBookPriceFormatted, OrderBookAmountFormatted];
+export type OrderBookRowFormatted = [
+  OrderBookPriceFormatted,
+  OrderBookAmountFormatted
+];
 
 export interface GenericCodeMsgError {
   code: number;

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -1,4 +1,19 @@
-import { ExchangeFilter, ExchangeSymbol, KlineInterval, numberInString, OrderBookRow, OrderResponseType, OrderSide, OrderStatus, OrderTimeInForce, OrderType, RateLimiter, SymbolFilter, StringBoolean, SideEffects } from "./shared";
+import {
+  ExchangeFilter,
+  ExchangeSymbol,
+  KlineInterval,
+  numberInString,
+  OrderBookRow,
+  OrderResponseType,
+  OrderSide,
+  OrderStatus,
+  OrderTimeInForce,
+  OrderType,
+  RateLimiter,
+  SymbolFilter,
+  StringBoolean,
+  SideEffects,
+} from './shared';
 
 export interface BasicTimeRangeParam {
   startTime?: number;
@@ -13,13 +28,13 @@ export interface BasicFromPaginatedParams {
 }
 
 export type SymbolStatus =
-  'PRE_TRADING'
+  | 'PRE_TRADING'
   | 'TRADING'
   | 'POST_TRADING'
   | 'END_OF_DAY'
   | 'HALT'
   | 'AUCTION_MATCH'
-  | 'BREAK'
+  | 'BREAK';
 
 export interface SystemStatusResponse {
   status: 0 | 1;
@@ -64,7 +79,7 @@ export interface DailyFuturesAccountSnapshot {
 }
 
 export type DailyAccountSnapshotElement =
-  DailySpotAccountSnapshot
+  | DailySpotAccountSnapshot
   | DailyMarginAccountSnapshot
   | DailyFuturesAccountSnapshot;
 
@@ -265,7 +280,7 @@ export enum EnumUniversalTransferType {
   PayToSpot = 'PAY_MAIN',
 }
 
-export type UniversalTransferType = `${EnumUniversalTransferType}`
+export type UniversalTransferType = `${EnumUniversalTransferType}`;
 
 export interface UniversalTransferParams {
   type: UniversalTransferType;
@@ -325,21 +340,21 @@ export interface APITradingStatus {
     triggerCondition: Record<APILockTriggerCondition, number>;
     indicators: Record<ExchangeSymbol, APITriggerConditionSymbolStatus[]>;
     updateTime: number;
-  }
+  };
 }
 
 export interface APIPermissions {
   ipRestrict: boolean;
   createTime: number;
-  enableWithdrawals: boolean;   // This option allows you to withdraw via API. You must apply the IP Access Restriction filter in order to enable withdrawals
-  enableInternalTransfer: boolean;  // This option authorizes this key to transfer funds between your master account and your sub account instantly
-  permitsUniversalTransfer: boolean;  // Authorizes this key to be used for a dedicated universal transfer API to transfer multiple supported currencies. Each business's own transfer API rights are not affected by this authorization
-  enableVanillaOptions: boolean;  //  Authorizes this key to Vanilla options trading
+  enableWithdrawals: boolean; // This option allows you to withdraw via API. You must apply the IP Access Restriction filter in order to enable withdrawals
+  enableInternalTransfer: boolean; // This option authorizes this key to transfer funds between your master account and your sub account instantly
+  permitsUniversalTransfer: boolean; // Authorizes this key to be used for a dedicated universal transfer API to transfer multiple supported currencies. Each business's own transfer API rights are not affected by this authorization
+  enableVanillaOptions: boolean; //  Authorizes this key to Vanilla options trading
   enableReading: boolean;
-  enableFutures: boolean;  //  API Key created before your futures account opened does not support futures API service
-  enableMargin: boolean;   //  This option can be adjusted after the Cross Margin account transfer is completed
+  enableFutures: boolean; //  API Key created before your futures account opened does not support futures API service
+  enableMargin: boolean; //  This option can be adjusted after the Cross Margin account transfer is completed
   enableSpotAndMarginTrading: boolean; // Spot and margin trading
-  tradingAuthorityExpirationTime: number;  // Expiration time for spot and margin trading permission
+  tradingAuthorityExpirationTime: number; // Expiration time for spot and margin trading permission
 }
 
 export interface AssetDetail {
@@ -644,7 +659,7 @@ export interface MarginRecordParams {
   asset: string;
   principal: numberInString;
   timestamp: number;
-  status: LoanStatus
+  status: LoanStatus;
 }
 
 export interface MarginRecordResponse {
@@ -816,7 +831,8 @@ export interface SubAccountSpotAssetTransferHistoryParams {
   limit?: number;
 }
 
-export interface SubAccountSpotAssetTransferHistory extends SubAccountBasicTransfer {
+export interface SubAccountSpotAssetTransferHistory
+  extends SubAccountBasicTransfer {
   status: string;
 }
 
@@ -902,7 +918,7 @@ export interface SubAccountListBtc extends BasicBtcTotals {
 }
 
 export interface SubAccountsMarginAccountSummary extends BasicBtcTotals {
-  subAccountList: SubAccountListBtc
+  subAccountList: SubAccountListBtc;
 }
 
 export interface SubAccountEnableFutures {
@@ -1007,7 +1023,8 @@ export interface SubAccountEnableLeverageToken {
   enableBlvt: boolean;
 }
 
-export interface EnableOrDisableIPRestrictionForSubAccountParams extends BasicSubAccount {
+export interface EnableOrDisableIPRestrictionForSubAccountParams
+  extends BasicSubAccount {
   ipRestrict: boolean;
 }
 
@@ -1071,7 +1088,7 @@ export interface SubAccountUSDMDetail {
     totalUnrealizedProfit: numberInString;
     totalWalletBalance: numberInString;
     updateTime: number;
-  }
+  };
 }
 
 export interface COINMSubAccount {
@@ -1090,7 +1107,7 @@ export interface SubAccountCOINMDetail {
     canWithdraw: boolean;
     feeTier: number;
     updateTime: number;
-  }
+  };
 }
 
 export interface SubAccountUSDMSummary {
@@ -1104,7 +1121,7 @@ export interface SubAccountUSDMSummary {
     totalWalletBalance: numberInString;
     asset: string;
     subAccountList: FuturesSubAccountList[];
-  }
+  };
 }
 
 export interface SubAccountCOINMSummary {
@@ -1114,7 +1131,7 @@ export interface SubAccountCOINMSummary {
     totalWalletBalanceOfBTC: numberInString;
     asset: string;
     subAccountList: COINMSubAccount[];
-  }
+  };
 }
 
 export interface COINMPositionRisk {

--- a/src/usdm-client.ts
+++ b/src/usdm-client.ts
@@ -79,7 +79,7 @@ export class USDMClient extends BaseRestClient {
   constructor(
     restClientOptions: RestClientOptions = {},
     requestOptions: AxiosRequestConfig = {},
-    useTestnet?: boolean,
+    useTestnet?: boolean
   ) {
     const clientId = useTestnet ? 'usdmtest' : 'usdm';
     super(clientId, restClientOptions, requestOptions);
@@ -92,15 +92,16 @@ export class USDMClient extends BaseRestClient {
    * Abstraction required by each client to aid with time sync / drift handling
    */
   async getServerTime(): Promise<number> {
-    return this.get(getServerTimeEndpoint(this.clientId))
-      .then(response => response.serverTime);
+    return this.get(getServerTimeEndpoint(this.clientId)).then(
+      (response) => response.serverTime
+    );
   }
 
   /**
    *
    * Market Data Endpoints
    *
-  **/
+   **/
 
   testConnectivity(): Promise<{}> {
     return this.get('fapi/v1/ping');
@@ -118,11 +119,15 @@ export class USDMClient extends BaseRestClient {
     return this.get('fapi/v1/trades', params);
   }
 
-  getHistoricalTrades(params: HistoricalTradesParams): Promise<RawFuturesTrade[]> {
+  getHistoricalTrades(
+    params: HistoricalTradesParams
+  ): Promise<RawFuturesTrade[]> {
     return this.get('fapi/v1/historicalTrades', params);
   }
 
-  getAggregateTrades(params: SymbolFromPaginatedRequestFromId): Promise<AggregateFuturesTrade[]> {
+  getAggregateTrades(
+    params: SymbolFromPaginatedRequestFromId
+  ): Promise<AggregateFuturesTrade[]> {
     return this.get('fapi/v1/aggTrades', params);
   }
 
@@ -130,7 +135,9 @@ export class USDMClient extends BaseRestClient {
     return this.get('fapi/v1/klines', params);
   }
 
-  getContinuousContractKlines(params: ContinuousContractKlinesParams): Promise<FuturesKline[]> {
+  getContinuousContractKlines(
+    params: ContinuousContractKlinesParams
+  ): Promise<FuturesKline[]> {
     return this.get('fapi/v1/continuousKlines', params);
   }
 
@@ -138,7 +145,9 @@ export class USDMClient extends BaseRestClient {
     return this.get('fapi/v1/indexPriceKlines', params);
   }
 
-  getMarkPriceKlines(params: SymbolKlinePaginatedParams): Promise<FuturesKline[]> {
+  getMarkPriceKlines(
+    params: SymbolKlinePaginatedParams
+  ): Promise<FuturesKline[]> {
     return this.get('fapi/v1/markPriceKlines', params);
   }
 
@@ -146,7 +155,9 @@ export class USDMClient extends BaseRestClient {
     return this.get('fapi/v1/premiumIndex', params);
   }
 
-  getFundingRateHistory(params?: Partial<BasicSymbolPaginatedParams>): Promise<FundingRateHistory[]> {
+  getFundingRateHistory(
+    params?: Partial<BasicSymbolPaginatedParams>
+  ): Promise<FundingRateHistory[]> {
     return this.get('fapi/v1/fundingRate', params);
   }
 
@@ -158,7 +169,9 @@ export class USDMClient extends BaseRestClient {
     return this.get('fapi/v1/ticker/price', params);
   }
 
-  getSymbolOrderBookTicker(params?: Partial<BasicSymbolParam>): Promise<FuturesSymbolOrderBookTicker | FuturesSymbolOrderBookTicker[]> {
+  getSymbolOrderBookTicker(
+    params?: Partial<BasicSymbolParam>
+  ): Promise<FuturesSymbolOrderBookTicker | FuturesSymbolOrderBookTicker[]> {
     return this.get('fapi/v1/ticker/bookTicker', params);
   }
 
@@ -170,15 +183,21 @@ export class USDMClient extends BaseRestClient {
     return this.get('futures/data/openInterestHist', params);
   }
 
-  getTopTradersLongShortAccountRatio(params: FuturesDataPaginatedParams): Promise<any> {
+  getTopTradersLongShortAccountRatio(
+    params: FuturesDataPaginatedParams
+  ): Promise<any> {
     return this.get('futures/data/topLongShortAccountRatio', params);
   }
 
-  getTopTradersLongShortPositionRatio(params: FuturesDataPaginatedParams): Promise<any> {
+  getTopTradersLongShortPositionRatio(
+    params: FuturesDataPaginatedParams
+  ): Promise<any> {
     return this.get('futures/data/topLongShortPositionRatio', params);
   }
 
-  getGlobalLongShortAccountRatio(params: FuturesDataPaginatedParams): Promise<any> {
+  getGlobalLongShortAccountRatio(
+    params: FuturesDataPaginatedParams
+  ): Promise<any> {
     return this.get('futures/data/globalLongShortAccountRatio', params);
   }
 
@@ -198,7 +217,7 @@ export class USDMClient extends BaseRestClient {
    *
    * USD-Futures Account/Trade Endpoints
    *
-  **/
+   **/
 
   setPositionMode(params: PositionModeParams): Promise<ModeChangeResult> {
     return this.postPrivate('fapi/v1/positionSide/dual', params);
@@ -218,7 +237,9 @@ export class USDMClient extends BaseRestClient {
     return this.getPrivate('fapi/v1/multiAssetsMargin');
   }
 
-  submitNewOrder(params: NewFuturesOrderParams): Promise<NewOrderResult | NewOrderError> {
+  submitNewOrder(
+    params: NewFuturesOrderParams
+  ): Promise<NewOrderResult | NewOrderError> {
     this.validateOrderId(params, 'newClientOrderId');
     return this.postPrivate('fapi/v1/order', params);
   }
@@ -226,8 +247,12 @@ export class USDMClient extends BaseRestClient {
   /**
    * Warning: max 5 orders at a time!
    */
-  submitMultipleOrders(batchOrders: NewFuturesOrderParams[]): Promise<(NewOrderResult | NewOrderError)[]> {
-    batchOrders.forEach(order => this.validateOrderId(order, 'newClientOrderId'));
+  submitMultipleOrders(
+    batchOrders: NewFuturesOrderParams[]
+  ): Promise<(NewOrderResult | NewOrderError)[]> {
+    batchOrders.forEach((order) =>
+      this.validateOrderId(order, 'newClientOrderId')
+    );
     return this.postPrivate('fapi/v1/batchOrders', { batchOrders });
   }
 
@@ -239,16 +264,22 @@ export class USDMClient extends BaseRestClient {
     return this.deletePrivate('fapi/v1/order', params);
   }
 
-  cancelAllOpenOrders(params: BasicSymbolParam): Promise<CancelAllOpenOrdersResult> {
+  cancelAllOpenOrders(
+    params: BasicSymbolParam
+  ): Promise<CancelAllOpenOrdersResult> {
     return this.deletePrivate('fapi/v1/allOpenOrders', params);
   }
 
-  cancelMultipleOrders(params: CancelMultipleOrdersParams): Promise<(CancelFuturesOrderResult | GenericCodeMsgError)[]> {
+  cancelMultipleOrders(
+    params: CancelMultipleOrdersParams
+  ): Promise<(CancelFuturesOrderResult | GenericCodeMsgError)[]> {
     return this.deletePrivate('fapi/v1/batchOrders', params);
   }
 
   // Auto-cancel all open orders
-  setCancelOrdersOnTimeout(params: CancelOrdersTimeoutParams): Promise<SetCancelTimeoutResult> {
+  setCancelOrdersOnTimeout(
+    params: CancelOrdersTimeoutParams
+  ): Promise<SetCancelTimeoutResult> {
     return this.postPrivate('fapi/v1/countdownCancelAll', params);
   }
 
@@ -280,11 +311,15 @@ export class USDMClient extends BaseRestClient {
     return this.postPrivate('fapi/v1/marginType', params);
   }
 
-  setIsolatedPositionMargin(params: SetIsolatedMarginParams): Promise<SetIsolatedMarginResult> {
+  setIsolatedPositionMargin(
+    params: SetIsolatedMarginParams
+  ): Promise<SetIsolatedMarginResult> {
     return this.postPrivate('fapi/v1/positionMargin', params);
   }
 
-  getPositionMarginChangeHistory(params: GetPositionMarginChangeHistoryParams): Promise<any> {
+  getPositionMarginChangeHistory(
+    params: GetPositionMarginChangeHistoryParams
+  ): Promise<any> {
     return this.getPrivate('fapi/v1/positionMargin/history', params);
   }
 
@@ -292,7 +327,9 @@ export class USDMClient extends BaseRestClient {
     return this.getPrivate('fapi/v2/positionRisk', params);
   }
 
-  getAccountTrades(params: SymbolFromPaginatedRequestFromId): Promise<FuturesPositionTrade[]> {
+  getAccountTrades(
+    params: SymbolFromPaginatedRequestFromId
+  ): Promise<FuturesPositionTrade[]> {
     return this.getPrivate('fapi/v1/userTrades', params);
   }
 
@@ -300,7 +337,9 @@ export class USDMClient extends BaseRestClient {
     return this.getPrivate('fapi/v1/income', params);
   }
 
-  getNotionalAndLeverageBrackets(params?: Partial<BasicSymbolParam>): Promise<SymbolLeverageBracketsResult[] | SymbolLeverageBracketsResult> {
+  getNotionalAndLeverageBrackets(
+    params?: Partial<BasicSymbolParam>
+  ): Promise<SymbolLeverageBracketsResult[] | SymbolLeverageBracketsResult> {
     return this.getPrivate('fapi/v1/leverageBracket', params);
   }
 
@@ -312,11 +351,15 @@ export class USDMClient extends BaseRestClient {
     return this.getPrivate('fapi/v1/forceOrders', params);
   }
 
-  getApiQuantitativeRulesIndicators(params?: Partial<BasicSymbolParam>): Promise<any> {
+  getApiQuantitativeRulesIndicators(
+    params?: Partial<BasicSymbolParam>
+  ): Promise<any> {
     return this.getPrivate('fapi/v1/apiTradingStatus', params);
   }
 
-  getAccountComissionRate(params: BasicSymbolParam): Promise<RebateDataOverview> {
+  getAccountComissionRate(
+    params: BasicSymbolParam
+  ): Promise<RebateDataOverview> {
     return this.getPrivate('fapi/v1/commissionRate', params);
   }
 
@@ -324,24 +367,35 @@ export class USDMClient extends BaseRestClient {
    *
    * Broker Futures Endpoints
    *
-  **/
+   **/
 
   // 1 == USDT-Margined, 2 == Coin-margined
-  getBrokerIfNewFuturesUser(brokerId: string, type: 1 | 2 = 1): Promise<{ brokerId: string; rebateWorking: boolean; ifNewUser: boolean; }> {
+  getBrokerIfNewFuturesUser(
+    brokerId: string,
+    type: 1 | 2 = 1
+  ): Promise<{ brokerId: string; rebateWorking: boolean; ifNewUser: boolean }> {
     return this.getPrivate('fapi/v1/apiReferral/ifNewUser', {
       brokerId,
       type,
     });
   }
 
-  setBrokerCustomIdForClient(customerId: string, email: string): Promise<{ customerId: string; email: string; }> {
+  setBrokerCustomIdForClient(
+    customerId: string,
+    email: string
+  ): Promise<{ customerId: string; email: string }> {
     return this.postPrivate('fapi/v1/apiReferral/customization', {
       customerId,
       email,
     });
   }
 
-  getBrokerClientCustomIds(customerId: string, email: string, page?: number, limit?: number): Promise<any> {
+  getBrokerClientCustomIds(
+    customerId: string,
+    email: string,
+    page?: number,
+    limit?: number
+  ): Promise<any> {
     return this.getPrivate('fapi/v1/apiReferral/customization', {
       customerId,
       email,
@@ -353,7 +407,7 @@ export class USDMClient extends BaseRestClient {
   getBrokerUserCustomId(brokerId: string): Promise<any> {
     return this.getPrivate('fapi/v1/apiReferral/userCustomization', {
       brokerId,
-    })
+    });
   }
 
   getBrokerRebateDataOverview(type: 1 | 2 = 1): Promise<RebateDataOverview> {
@@ -362,7 +416,12 @@ export class USDMClient extends BaseRestClient {
     });
   }
 
-  getBrokerUserTradeVolume(type: 1 | 2 = 1, startTime?: number, endTime?: number, limit?: number): Promise<any> {
+  getBrokerUserTradeVolume(
+    type: 1 | 2 = 1,
+    startTime?: number,
+    endTime?: number,
+    limit?: number
+  ): Promise<any> {
     return this.getPrivate('fapi/v1/apiReferral/tradeVol', {
       type,
       startTime,
@@ -371,7 +430,12 @@ export class USDMClient extends BaseRestClient {
     });
   }
 
-  getBrokerRebateVolume(type: 1 | 2 = 1, startTime?: number, endTime?: number, limit?: number): Promise<any> {
+  getBrokerRebateVolume(
+    type: 1 | 2 = 1,
+    startTime?: number,
+    endTime?: number,
+    limit?: number
+  ): Promise<any> {
     return this.getPrivate('fapi/v1/apiReferral/rebateVol', {
       type,
       startTime,
@@ -380,7 +444,12 @@ export class USDMClient extends BaseRestClient {
     });
   }
 
-  getBrokerTradeDetail(type: 1 | 2 = 1, startTime?: number, endTime?: number, limit?: number): Promise<any> {
+  getBrokerTradeDetail(
+    type: 1 | 2 = 1,
+    startTime?: number,
+    endTime?: number,
+    limit?: number
+  ): Promise<any> {
     return this.getPrivate('fapi/v1/apiReferral/traderSummary', {
       type,
       startTime,
@@ -393,11 +462,11 @@ export class USDMClient extends BaseRestClient {
    *
    * User Data Stream Endpoints
    *
-  **/
+   **/
 
   // USD-M Futures
 
-  getFuturesUserDataListenKey(): Promise<{ listenKey: string; }> {
+  getFuturesUserDataListenKey(): Promise<{ listenKey: string }> {
     return this.post('fapi/v1/listenKey');
   }
 
@@ -409,11 +478,17 @@ export class USDMClient extends BaseRestClient {
     return this.delete('fapi/v1/listenKey');
   }
 
-
   /**
    * Validate syntax meets requirements set by binance. Log warning if not.
    */
-  private validateOrderId(params: NewFuturesOrderParams | CancelOrderParams | NewOCOParams | CancelOCOParams, orderIdProperty: OrderIdProperty): void {
+  private validateOrderId(
+    params:
+      | NewFuturesOrderParams
+      | CancelOrderParams
+      | NewOCOParams
+      | CancelOCOParams,
+    orderIdProperty: OrderIdProperty
+  ): void {
     const apiCategory = this.clientId;
     if (!params[orderIdProperty]) {
       params[orderIdProperty] = generateNewOrderId(apiCategory);
@@ -425,4 +500,4 @@ export class USDMClient extends BaseRestClient {
       logInvalidOrderId(orderIdProperty, expectedOrderIdPrefix, params);
     }
   }
-};
+}


### PR DESCRIPTION
<!--
Thanks for creating this pull request.

Please make sure that the pull request is limited to one type (enhancement, bug, etc.) and keep it as small as possible. It makes reviewing requests much after & safer.

You can always open multiple smaller PRs instead of opening a huge one, which is definitely preferred.
-->

## Summary
Minor fixes & refinements:
- Fixes #200, where passing a symbol to getExchangeInfo was constructing an incorrect URL.
- Fixes #187, where submitNewOrder type param was not pointing to the futures type enum.

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

## Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] Changes tested locally (if applicable)
- [ ] Updated related documentation (if applicable)
- [ ] Updated/added related tests (if applicable)

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->
