### PR TITLE
Adding type guards for raw websocket messages

### DIFF
--- a/src/types/websockets.ts
+++ b/src/types/websockets.ts
@@ -37,7 +37,12 @@ export type WsRawMessage = WsMessageKlineRaw
   | WsMessageBookTickerEventRaw
   | WsMessagePartialBookDepthEventRaw
   | WsRawSpotUserDataEventRaw
-  | WsMessageIndexPriceUpdateEventRaw;
+  | WsMessageIndexPriceUpdateEventRaw
+  | WsMessageFuturesUserDataAccountUpdateRaw
+  | WsMessageFuturesUserDataListenKeyExpiredRaw
+  | WsMessageFuturesUserDataMarginCallRaw
+  | WsMessageFuturesUserDataOrderTradeUpdateEventRaw
+  | WsMessageFuturesUserDataAccountConfigUpdateEventRaw;
 
 export type WsFormattedMessage = WsMessageKlineFormatted
   | WsMessageAggTradeFormatted

--- a/src/util/typeGuards.ts
+++ b/src/util/typeGuards.ts
@@ -1,10 +1,16 @@
 import {
   WsFormattedMessage,
+  WsMessage24hrMiniTickerRaw,
   WsMessage24hrTickerFormatted,
+  WsMessageFuturesUserDataAccountConfigUpdateEventRaw,
+  WsMessageFuturesUserDataAccountUpdateRaw,
   WsMessageFuturesUserDataEventFormatted,
+  WsMessageFuturesUserDataOrderTradeUpdateEventRaw,
   WsMessageKlineFormatted,
+  WsMessageKlineRaw,
   WsMessageMarkPriceUpdateEventFormatted,
   WsMessageSpotUserDataEventFormatted,
+  WsRawMessage,
   WsUserDataEvents
 } from "..";
 
@@ -48,4 +54,58 @@ export function isWsFormattedFuturesUserDataEvent(
   data: WsFormattedMessage,
 ): data is WsMessageFuturesUserDataEventFormatted {
   return isWsFormattedUserDataEvent(data) && data.wsMarket.includes('usdm');
+}
+
+/**
+ * Typeguard to validate all symbol 24hrMiniTicker raw event
+ */
+export function isAll24hrMiniTickerRaw(
+  data: WsRawMessage
+): data is WsMessage24hrMiniTickerRaw[] {
+  return Array.isArray(data) && data[0].e === '24hrMiniTicker';
+}
+
+/**
+ * Typeguard to validate a single 24hrMiniTicker raw event
+ */
+export function is24hrMiniTickerRaw(
+  data: WsRawMessage
+): data is WsMessage24hrMiniTickerRaw {
+  return !Array.isArray(data) && data.e === '24hrMiniTicker';
+}
+
+/**
+ * Typeguard to validate a single kline raw event
+ */
+export function isKlineRaw(
+  data: WsRawMessage
+): data is WsMessageKlineRaw {
+  return !Array.isArray(data) && data.e === 'kline';
+}
+
+/**
+ * Typeguard to validate a single ORDER_TRADE_UPDATE raw event
+ */
+export function isOrderTradeUpdateRaw(
+  data: WsRawMessage
+): data is WsMessageFuturesUserDataOrderTradeUpdateEventRaw {
+  return !Array.isArray(data) && data.e === 'ORDER_TRADE_UPDATE';
+}
+
+/**
+ * Typeguard to validate a single ACCOUNT_CONFIG_UPDATE raw event
+ */
+export function isAccountConfigUpdateRaw(
+  data: WsRawMessage
+): data is WsMessageFuturesUserDataAccountConfigUpdateEventRaw {
+  return !Array.isArray(data) && data.e === 'ACCOUNT_CONFIG_UPDATE';
+}
+
+/**
+ * Typeguard to validate a single ACCOUNT_UPDATE raw event
+ */
+export function isAccountUpdateRaw(
+  data: WsRawMessage
+): data is WsMessageFuturesUserDataAccountUpdateRaw {
+  return !Array.isArray(data) && data.e === 'ACCOUNT_UPDATE';
 }


### PR DESCRIPTION
## Summary
This change adds the ability to create type guards for raw Futures websocket events. Also included is some common typeguards.

## Additional Information
`package.json` version is _**not**_ yet bumped in this PR.
