### PR TITLE
v2.0.32: fix(#162): submitMultipleOrders support for futures client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.0.31",
+  "version": "2.0.32",
   "description": "Node.js connector for Binance's REST APIs and WebSockets, with TypeScript & integration tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types/futures.ts
+++ b/src/types/futures.ts
@@ -83,20 +83,21 @@ export type FuturesOrderType =
   | 'TAKE_PROFIT_MARKET'
   | 'TRAILING_STOP_MARKET';
 
-export interface NewFuturesOrderParams {
+// When using the submitMultipleOrders() endpoint, it seems to expect strings instead of numbers. All other endpoints use numbers.
+export interface NewFuturesOrderParams<numberType = number> {
   symbol: string;
   side: OrderSide;
   positionSide?: PositionSide;
   type: FuturesOrderType;
   timeInForce?: OrderTimeInForce;
-  quantity?: number;
+  quantity?: numberType;
   reduceOnly?: BooleanString;
-  price?: number;
+  price?: numberType;
   newClientOrderId?: string;
-  stopPrice?: number;
+  stopPrice?: numberType;
   closePosition?: BooleanString;
-  activationPrice?: number;
-  callbackRate?: number;
+  activationPrice?: numberType;
+  callbackRate?: numberType;
   workingType?: WorkingType;
   priceProtect?: BooleanStringCapitalised;
   newOrderRespType?: OrderResponseType;

--- a/test/futures-usdm/private.test.ts
+++ b/test/futures-usdm/private.test.ts
@@ -1,4 +1,5 @@
-import { USDMClient } from "../../src/usdm-client";
+import { NewFuturesOrderParams } from '../../src/types/futures';
+import { USDMClient } from '../../src/usdm-client';
 
 describe('Private Futures USDM REST API Endpoints', () => {
   const API_KEY = process.env.API_KEY_COM;
@@ -18,11 +19,15 @@ describe('Private Futures USDM REST API Endpoints', () => {
 
   describe('Account/Trade Endpoints', () => {
     it('getCurrentPositionMode()', async () => {
-      expect(await api.getCurrentPositionMode()).toStrictEqual({'dualSidePosition': expect.any(Boolean)});
+      expect(await api.getCurrentPositionMode()).toStrictEqual({
+        dualSidePosition: expect.any(Boolean),
+      });
     });
 
     it('getMultiAssetsMode()', async () => {
-      expect(await api.getMultiAssetsMode()).toStrictEqual({'multiAssetsMargin': expect.any(Boolean)});
+      expect(await api.getMultiAssetsMode()).toStrictEqual({
+        multiAssetsMargin: expect.any(Boolean),
+      });
     });
 
     it('getAllOpenOrders()', async () => {
@@ -35,24 +40,24 @@ describe('Private Futures USDM REST API Endpoints', () => {
 
     it('getAccountInformation()', async () => {
       expect(await api.getAccountInformation()).toMatchObject({
-        'assets': expect.any(Array),
-        'availableBalance': expect.any(String),
-        'canDeposit': expect.any(Boolean),
-        'canTrade': expect.any(Boolean),
-        'canWithdraw': expect.any(Boolean),
-        'feeTier': expect.any(Number),
-        'maxWithdrawAmount': expect.any(String),
-        'positions': expect.any(Array),
-        'totalCrossUnPnl': expect.any(String),
-        'totalCrossWalletBalance': expect.any(String),
-        'totalInitialMargin': expect.any(String),
-        'totalMaintMargin': expect.any(String),
-        'totalMarginBalance': expect.any(String),
-        'totalOpenOrderInitialMargin': expect.any(String),
-        'totalPositionInitialMargin': expect.any(String),
-        'totalUnrealizedProfit': expect.any(String),
-        'totalWalletBalance': expect.any(String),
-        'updateTime': expect.any(Number),
+        assets: expect.any(Array),
+        availableBalance: expect.any(String),
+        canDeposit: expect.any(Boolean),
+        canTrade: expect.any(Boolean),
+        canWithdraw: expect.any(Boolean),
+        feeTier: expect.any(Number),
+        maxWithdrawAmount: expect.any(String),
+        positions: expect.any(Array),
+        totalCrossUnPnl: expect.any(String),
+        totalCrossWalletBalance: expect.any(String),
+        totalInitialMargin: expect.any(String),
+        totalMaintMargin: expect.any(String),
+        totalMarginBalance: expect.any(String),
+        totalOpenOrderInitialMargin: expect.any(String),
+        totalPositionInitialMargin: expect.any(String),
+        totalUnrealizedProfit: expect.any(String),
+        totalWalletBalance: expect.any(String),
+        updateTime: expect.any(Number),
       });
     });
 
@@ -65,11 +70,15 @@ describe('Private Futures USDM REST API Endpoints', () => {
     });
 
     it('getNotionalAndLeverageBrackets()', async () => {
-      expect(await api.getNotionalAndLeverageBrackets()).toMatchObject(expect.any(Array));
+      expect(await api.getNotionalAndLeverageBrackets()).toMatchObject(
+        expect.any(Array)
+      );
     });
 
     it('getADLQuantileEstimation()', async () => {
-      expect(await api.getADLQuantileEstimation()).toMatchObject(expect.any(Array));
+      expect(await api.getADLQuantileEstimation()).toMatchObject(
+        expect.any(Array)
+      );
     });
 
     it('getForceOrders()', async () => {
@@ -78,21 +87,23 @@ describe('Private Futures USDM REST API Endpoints', () => {
 
     it('getApiQuantitativeRulesIndicators()', async () => {
       expect(await api.getApiQuantitativeRulesIndicators()).toMatchObject({
-        'indicators': expect.any(Object),
-        'updateTime': expect.any(Number),
+        indicators: expect.any(Object),
+        updateTime: expect.any(Number),
       });
     });
 
     it('getAccountComissionRate()', async () => {
       expect(await api.getAccountComissionRate({ symbol })).toMatchObject({
-        'makerCommissionRate': expect.any(String),
-        'symbol': expect.any(String),
-        'takerCommissionRate': expect.any(String),
+        makerCommissionRate: expect.any(String),
+        symbol: expect.any(String),
+        takerCommissionRate: expect.any(String),
       });
     });
 
     it('cancelOrder()', async () => {
-      expect(api.cancelOrder({ symbol, orderId: 123456 })).rejects.toMatchObject({
+      expect(
+        api.cancelOrder({ symbol, orderId: 123456 })
+      ).rejects.toMatchObject({
         code: -2011,
         message: 'Unknown order sent.',
         body: { code: -2011, msg: 'Unknown order sent.' },
@@ -101,8 +112,32 @@ describe('Private Futures USDM REST API Endpoints', () => {
 
     it('cancelAllOpenOrders()', async () => {
       expect(api.cancelAllOpenOrders({ symbol })).resolves.toMatchObject({
-        "code": 200,
+        code: 200,
       });
+    });
+
+    it('submitMultipleOrders()', async () => {
+      const templateOrder: NewFuturesOrderParams<string> = {
+        symbol: 'VETUSDT',
+        side: 'BUY',
+        type: 'MARKET',
+        positionSide: 'LONG',
+        quantity: '1000000',
+      };
+      const orders: NewFuturesOrderParams<string>[] = [
+        templateOrder,
+        templateOrder,
+      ];
+      expect(api.submitMultipleOrders(orders)).resolves.toMatchObject([
+        {
+          code: -4061,
+          msg: "Order's position side does not match user's setting.",
+        },
+        {
+          code: -4061,
+          msg: "Order's position side does not match user's setting.",
+        },
+      ]);
     });
   });
 
@@ -126,5 +161,4 @@ describe('Private Futures USDM REST API Endpoints', () => {
       });
     });
   });
-
 });

--- a/test/spot/private.test.ts
+++ b/test/spot/private.test.ts
@@ -1,16 +1,19 @@
-import { MainClient, NewSpotOrderParams } from "../../src/index";
+import { MainClient, NewSpotOrderParams } from '../../src/index';
 
 describe('Private Spot REST API Endpoints', () => {
   const API_KEY = process.env.API_KEY_COM;
   const API_SECRET = process.env.API_SECRET_COM;
 
-  const api = new MainClient({
-    disableTimeSync: true,
-    api_key: API_KEY,
-    api_secret: API_SECRET,
-  }, {
-    timeout: 1000 * 60,
-  });
+  const api = new MainClient(
+    {
+      disableTimeSync: true,
+      api_key: API_KEY,
+      api_secret: API_SECRET,
+    },
+    {
+      timeout: 1000 * 60,
+    }
+  );
 
   const symbol = 'BTCUSDT';
   const coin = 'BTC';
@@ -34,7 +37,10 @@ describe('Private Spot REST API Endpoints', () => {
 
   describe('Wallet Endpoints', () => {
     it('getSystemStatus()', async () => {
-      expect(await api.getSystemStatus()).toMatchObject({'msg': "normal", 'status': 0});
+      expect(await api.getSystemStatus()).toMatchObject({
+        msg: 'normal',
+        status: 0,
+      });
     });
 
     it('getAccountInformation()', async () => {
@@ -48,7 +54,7 @@ describe('Private Spot REST API Endpoints', () => {
         sellerCommission: expect.any(Number),
         takerCommission: expect.any(Number),
         updateTime: expect.any(Number),
-       });
+      });
     });
 
     it('getAllCoinsInformation()', async () => {
@@ -56,17 +62,21 @@ describe('Private Spot REST API Endpoints', () => {
     });
 
     it('getAccountTradeList(symbol)', async () => {
-      expect(await api.getAccountTradeList({ symbol })).toMatchObject(expect.any(Array));
+      expect(await api.getAccountTradeList({ symbol })).toMatchObject(
+        expect.any(Array)
+      );
     });
 
     it('getDailyAccountSnapshot()', async () => {
-      expect(await api.getDailyAccountSnapshot({
-        type: 'SPOT',
-       })).toMatchObject({
-         code: 200,
-         msg: expect.any(String),
-         snapshotVos: expect.any(Array),
-       });
+      expect(
+        await api.getDailyAccountSnapshot({
+          type: 'SPOT',
+        })
+      ).toMatchObject({
+        code: 200,
+        msg: expect.any(String),
+        snapshotVos: expect.any(Array),
+      });
     });
 
     it('getDepositHistory()', async () => {
@@ -110,42 +120,53 @@ describe('Private Spot REST API Endpoints', () => {
     });
 
     it.skip('getUniversalTransferHistory()', async () => {
-      expect(await api.getUniversalTransferHistory({
-        type: 'MAIN_UMFUTURE'
-      })).toMatchObject({
+      expect(
+        await api.getUniversalTransferHistory({
+          type: 'MAIN_UMFUTURE',
+        })
+      ).toMatchObject({
         rows: expect.any(Array),
       });
     });
 
     it('getApiTradingStatus()', async () => {
-      expect(await api.getApiTradingStatus()).toMatchObject({ data: expect.any(Object) });
+      expect(await api.getApiTradingStatus()).toMatchObject({
+        data: expect.any(Object),
+      });
     });
 
     it('getApiKeyPermissions()', async () => {
-      expect(await api.getApiKeyPermissions()).toMatchObject(expect.any(Object));
+      expect(await api.getApiKeyPermissions()).toMatchObject(
+        expect.any(Object)
+      );
     });
-
   });
 
   describe.skip('Sub-Account Endpoints', () => {
     it('getSubAccountList()', async () => {
-      expect(await api.getSubAccountList()).toMatchObject({ subAccounts: expect.any(Array) });
+      expect(await api.getSubAccountList()).toMatchObject({
+        subAccounts: expect.any(Array),
+      });
     });
 
     it('getSubAccountSpotAssetTransferHistory()', async () => {
-      expect(await api.getSubAccountSpotAssetTransferHistory()).toMatchObject(expect.any(Array));
+      expect(await api.getSubAccountSpotAssetTransferHistory()).toMatchObject(
+        expect.any(Array)
+      );
     });
 
     it('getSubAccountSpotAssetsSummary()', async () => {
       expect(await api.getSubAccountSpotAssetsSummary()).toMatchObject({
         totalCount: expect.any(Number),
         masterAccountTotalAsset: expect.any(String),
-        spotSubUserAssetBtcVoList: expect.any(Array)
+        spotSubUserAssetBtcVoList: expect.any(Array),
       });
     });
 
     it('getSubAccountStatusOnMarginOrFutures()', async () => {
-      expect(await api.getSubAccountStatusOnMarginOrFutures()).toMatchObject(expect.any(Array));
+      expect(await api.getSubAccountStatusOnMarginOrFutures()).toMatchObject(
+        expect.any(Array)
+      );
     });
 
     it('getSubAccountsSummaryOfMarginAccount()', async () => {
@@ -153,7 +174,7 @@ describe('Private Spot REST API Endpoints', () => {
         totalAssetOfBtc: expect.any(String),
         totalLiabilityOfBtc: expect.any(String),
         totalNetAssetOfBtc: expect.any(String),
-        subAccountList: expect.any(Array)
+        subAccountList: expect.any(Array),
       });
     });
 
@@ -167,10 +188,9 @@ describe('Private Spot REST API Endpoints', () => {
         totalUnrealizedProfit: expect.any(String),
         totalWalletBalance: expect.any(String),
         asset: expect.any(String),
-        subAccountList: expect.any(Array)
+        subAccountList: expect.any(Array),
       });
     });
-
   });
 
   describe('User Data Stream', () => {
@@ -182,15 +202,21 @@ describe('Private Spot REST API Endpoints', () => {
 
       it('should keep alive user data key', async () => {
         const { listenKey } = await api.getSpotUserDataListenKey();
-        expect(await api.keepAliveSpotUserDataListenKey(listenKey)).toStrictEqual({});
+        expect(
+          await api.keepAliveSpotUserDataListenKey(listenKey)
+        ).toStrictEqual({});
       });
 
       it('should close user data key', async () => {
         const { listenKey } = await api.getSpotUserDataListenKey();
         expect(listenKey).toStrictEqual(expect.any(String));
 
-        expect(await api.closeSpotUserDataListenKey(listenKey)).toStrictEqual({});
-        expect(api.keepAliveSpotUserDataListenKey(listenKey)).rejects.toMatchObject({
+        expect(await api.closeSpotUserDataListenKey(listenKey)).toStrictEqual(
+          {}
+        );
+        expect(
+          api.keepAliveSpotUserDataListenKey(listenKey)
+        ).rejects.toMatchObject({
           code: -1125,
           message: 'This listenKey does not exist.',
         });
@@ -205,15 +231,21 @@ describe('Private Spot REST API Endpoints', () => {
 
       it('should keep alive user data key', async () => {
         const { listenKey } = await api.getMarginUserDataListenKey();
-        expect(await api.keepAliveMarginUserDataListenKey(listenKey)).toStrictEqual({});
+        expect(
+          await api.keepAliveMarginUserDataListenKey(listenKey)
+        ).toStrictEqual({});
       });
 
       it('should close user data key', async () => {
         const { listenKey } = await api.getMarginUserDataListenKey();
         expect(listenKey).toStrictEqual(expect.any(String));
 
-        expect(await api.closeMarginUserDataListenKey(listenKey)).toStrictEqual({});
-        expect(api.keepAliveMarginUserDataListenKey(listenKey)).rejects.toMatchObject({
+        expect(await api.closeMarginUserDataListenKey(listenKey)).toStrictEqual(
+          {}
+        );
+        expect(
+          api.keepAliveMarginUserDataListenKey(listenKey)
+        ).rejects.toMatchObject({
           code: -1105,
           message: 'This listenKey does not exist.',
         });
@@ -222,24 +254,38 @@ describe('Private Spot REST API Endpoints', () => {
 
     describe.skip('Binance Isolated Margin', () => {
       it('should create a user data key', async () => {
-        const { listenKey } = await api.getIsolatedMarginUserDataListenKey({ symbol });
+        const { listenKey } = await api.getIsolatedMarginUserDataListenKey({
+          symbol,
+        });
         expect(listenKey).toStrictEqual(expect.any(String));
       });
 
       it('should keep alive user data key', async () => {
-        const { listenKey } = await api.getIsolatedMarginUserDataListenKey({ symbol });
-        expect(await api.keepAliveIsolatedMarginUserDataListenKey({ symbol, listenKey })).toStrictEqual({});
+        const { listenKey } = await api.getIsolatedMarginUserDataListenKey({
+          symbol,
+        });
+        expect(
+          await api.keepAliveIsolatedMarginUserDataListenKey({
+            symbol,
+            listenKey,
+          })
+        ).toStrictEqual({});
       });
 
       it('should close user data key', async () => {
-        const { listenKey } = await api.getIsolatedMarginUserDataListenKey({ symbol });
-        expect(await api.closeIsolatedMarginUserDataListenKey({ symbol, listenKey })).toStrictEqual({});
-        expect(api.keepAliveIsolatedMarginUserDataListenKey({ symbol, listenKey })).rejects.toMatchObject({
+        const { listenKey } = await api.getIsolatedMarginUserDataListenKey({
+          symbol,
+        });
+        expect(
+          await api.closeIsolatedMarginUserDataListenKey({ symbol, listenKey })
+        ).toStrictEqual({});
+        expect(
+          api.keepAliveIsolatedMarginUserDataListenKey({ symbol, listenKey })
+        ).rejects.toMatchObject({
           code: -1105,
           message: 'This listenKey does not exist.',
         });
       });
     });
-
   });
 });


### PR DESCRIPTION
## Summary
<!-- Add a brief description of the pr: -->
- fixes #162 - submitMultipleOrders for futures client. Request body was wrong & numeric types here should be passed as strings (thanks to everyone that helped figure this out)
- misc linting
- add return type to futures get symbol price ticker method

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
