### PR TITLE
To enable/place BRACKET (OTOCO) ORDER, added GTE_GTC TIF option

### DIFF
--- a/examples/rest-future-bracket-order.ts
+++ b/examples/rest-future-bracket-order.ts
@@ -1,0 +1,75 @@
+import {
+  USDMClient,
+  NewFuturesOrderParams
+} from '../src/index';
+
+const key = process.env.APIKEY || 'APIKEY';
+const secret = process.env.APISECRET || 'APISECRET';
+
+const client = new USDMClient({
+  api_key: key,
+  api_secret: secret,
+  beautifyResponses: true
+});
+
+const symbol = 'ETHUSDT';
+
+// submit a 1:1 bracket market buy order with market entry order
+(async () => {
+  try {
+    // TODO: check balance and do other validations
+
+    const assetPrices = await client.getMarkPrice({
+      symbol: "ETHUSDT"
+    })
+    const markPrice: number = Number(assetPrices.markPrice)
+    const stopLossPrice = Number(markPrice * 99.9 / 100).toFixed(2)
+    const takeProfitPrice = Number(markPrice * 100.1 / 100).toFixed(2)
+
+    // create three orders
+    // 1. entry order (GTC),
+    // 2. take profit order (GTE_GTC),
+    // 3. stop loss order (GTE_GTC)
+
+    const entryOrder: NewFuturesOrderParams<string> = {
+      positionSide: "BOTH",
+      quantity: "0.01",
+      reduceOnly: "false",
+      side: "BUY",
+      symbol: "ETHUSDT",
+      type: "MARKET",
+    };
+
+    const takeProfitOrder: NewFuturesOrderParams<string> = {
+      positionSide: "BOTH",
+      priceProtect: "TRUE",
+      quantity: "0.01",
+      side: "SELL",
+      stopPrice: takeProfitPrice,
+      symbol: "ETHUSDT",
+      timeInForce: "GTE_GTC",
+      type: "TAKE_PROFIT_MARKET",
+      workingType: "MARK_PRICE",
+      closePosition: "true"
+    };
+
+    const stopLossOrder: NewFuturesOrderParams<string> = {
+      positionSide: "BOTH",
+      priceProtect: "TRUE",
+      quantity: "0.01",
+      side: "SELL",
+      stopPrice: stopLossPrice,
+      symbol: "ETHUSDT",
+      timeInForce: "GTE_GTC",
+      type: "STOP_MARKET",
+      workingType: "MARK_PRICE",
+      closePosition: "true"
+    };
+
+    const openedOrder = await client.submitMultipleOrders([entryOrder, takeProfitOrder, stopLossOrder])
+      .catch(e => console.log(e?.body || e));
+    console.log(openedOrder);
+  } catch (e) {
+    console.log(e);
+  }
+})();

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -19,7 +19,7 @@ export type BinanceBaseUrlKey =
   | 'voptions'
   | 'voptionstest';
 
-export type OrderTimeInForce = 'GTC' | 'IOC' | 'FOK';
+export type OrderTimeInForce = 'GTC' | 'IOC' | 'FOK' | 'GTE_GTC';
 
 export type StringBoolean = 'TRUE' | 'FALSE';
 


### PR DESCRIPTION
## Summary
Added an extra option 'GTE_GTC' to the type 'OrderTimeInForce'.
This option is required to place an bracket order in futures

## Detailed Explanation
Bracket (OTOCO) order can be placed from binance website in futures.
We can do same thing using api but it is not in the binance api documentation.
But for that we need an un-documented 'GTE_GTC' option for time-in-force.

Also added an example of how place OTOCO order.
