### PR TITLE
Add Isolated Margin Account Info

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "Dylan Sproule (https://github.com/dylansproule)",
     "Gavy Aggarwal (http://gavyaggarwal.com/)",
     "Tony Pettigrew (https://github.com/NeverEnder4)",
-    "Chris <apexearth@gmail.com> (https://github.com/apexearth)"
+    "Chris <apexearth@gmail.com> (https://github.com/apexearth)",
+    "Bruno Lobo <me@brunolobo.xyz> (https://brunolobo.xyz)"
   ],
   "dependencies": {
     "axios": "^0.21.0",

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -122,7 +122,7 @@ import {
   SubAccountDepositHistoryParams,
   SubAccountUniversalTransferHistoryParams,
   SubAccountSummaryOnFuturesAccountV2Params,
-  QueryIsolatedMarginAccountInfo,
+  IsolatedMarginAccountInfo,
 } from './types/spot';
 
 import {
@@ -810,7 +810,7 @@ export class MainClient extends BaseRestClient {
 
   getIsolatedMarginAccountInfo(params?: {
     symbols?: string;
-  }): Promise<QueryIsolatedMarginAccountInfo> {
+  }): Promise<IsolatedMarginAccountInfo> {
     return this.getPrivate('sapi/v1/margin/isolated/account', { params });
   }
 

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -808,7 +808,7 @@ export class MainClient extends BaseRestClient {
 
   // TODO - https://binance-docs.github.io/apidocs/spot/en/#get-isolated-margin-transfer-history-user_data
 
-  queryIsolatedMarginAccountInfo(params?: {
+  getIsolatedMarginAccountInfo(params?: {
     symbols?: string;
   }): Promise<QueryIsolatedMarginAccountInfo> {
     return this.getPrivate('sapi/v1/margin/isolated/account', { params });

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -808,10 +808,10 @@ export class MainClient extends BaseRestClient {
 
   // TODO - https://binance-docs.github.io/apidocs/spot/en/#get-isolated-margin-transfer-history-user_data
 
-  queryIsolatedMarginAccountInfo(
-    symbols?: string
-  ): Promise<QueryIsolatedMarginAccountInfo> {
-    return this.getPrivate('sapi/v1/margin/isolated/account', { symbols });
+  queryIsolatedMarginAccountInfo(params?: {
+    symbols?: string;
+  }): Promise<QueryIsolatedMarginAccountInfo> {
+    return this.getPrivate('sapi/v1/margin/isolated/account', { params });
   }
 
   // TODO - https://binance-docs.github.io/apidocs/spot/en/#disable-isolated-margin-account-trade

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -122,6 +122,7 @@ import {
   SubAccountDepositHistoryParams,
   SubAccountUniversalTransferHistoryParams,
   SubAccountSummaryOnFuturesAccountV2Params,
+  QueryIsolatedMarginAccountInfo,
 } from './types/spot';
 
 import {
@@ -807,7 +808,11 @@ export class MainClient extends BaseRestClient {
 
   // TODO - https://binance-docs.github.io/apidocs/spot/en/#get-isolated-margin-transfer-history-user_data
 
-  // TODO - https://binance-docs.github.io/apidocs/spot/en/#query-isolated-margin-account-info-user_data
+  queryIsolatedMarginAccountInfo(
+    symbols?: string
+  ): Promise<QueryIsolatedMarginAccountInfo> {
+    return this.getPrivate('sapi/v1/margin/isolated/account', { symbols });
+  }
 
   // TODO - https://binance-docs.github.io/apidocs/spot/en/#disable-isolated-margin-account-trade
 

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -737,7 +737,7 @@ export interface IsolatedMarginAccountAssets {
   tradeEnabled: boolean;
 }
 
-export interface QueryIsolatedMarginAccountInfo {
+export interface IsolatedMarginAccountInfo {
   assets: IsolatedMarginAccountAssets[];
   totalAssetOfBtc?: numberInString;
   totalLiabilityOfBtc?: numberInString;

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -702,6 +702,48 @@ export interface IsolatedMarginAccountTransferParams {
   amount: number;
 }
 
+export interface IsolatedMarginAccountAsset {
+  asset: string;
+  borrowEnabled: boolean;
+  borrowed: numberInString;
+  free: numberInString;
+  interest: numberInString;
+  locked: numberInString;
+  netAsset: numberInString;
+  netAssetOfBtc: numberInString;
+  repayEnabled: boolean;
+  totalAsset: numberInString;
+}
+
+export type IsolatedMarginLevelStatus =
+  | 'EXCESSIVE'
+  | 'NORMAL'
+  | 'MARGIN_CALL'
+  | 'PRE_LIQUIDATION'
+  | 'FORCE_LIQUIDATION';
+
+export interface IsolatedMarginAccountAssets {
+  baseAsset: IsolatedMarginAccountAsset;
+  quoteAsset: IsolatedMarginAccountAsset;
+  symbol: string;
+  isolatedCreated: boolean;
+  enabled: boolean;
+  marginLevel: numberInString;
+  marginLevelStatus: IsolatedMarginLevelStatus;
+  marginRatio: numberInString;
+  indexPrice: numberInString;
+  liquidatePrice: numberInString;
+  liquidateRate: numberInString;
+  tradeEnabled: boolean;
+}
+
+export interface QueryIsolatedMarginAccountInfo {
+  assets: IsolatedMarginAccountAssets[];
+  totalAssetOfBtc?: numberInString;
+  totalLiabilityOfBtc?: numberInString;
+  totalNetAssetOfBtc?: numberInString;
+}
+
 export interface SpotSubUserAssetBtcList {
   email: string;
   totalAsset: numberInString;


### PR DESCRIPTION
Add missing Isolated Margin Account Info that was on the "TODO list"

https://binance-docs.github.io/apidocs/spot/en/#query-isolated-margin-account-info-user_data