### PR TITLE
fix(#245): omit auth for public endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "2.0.36",
+  "version": "2.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "2.0.36",
+      "version": "2.1.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Node.js connector for Binance's REST APIs and WebSockets, with TypeScript & integration tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -636,7 +636,7 @@ export class MainClient extends BaseRestClient {
   }
 
   getHistoricalTrades(params: HistoricalTradesParams): Promise<RawTrade[]> {
-    return this.getPrivate('api/v3/historicalTrades', params);
+    return this.get('api/v3/historicalTrades', params);
   }
 
   getAggregateTrades(


### PR DESCRIPTION
## Summary
<!-- Add a brief description of the pr: -->
- Fixes #245 (endpoint was marked as private, binance didn't like receiving auth params in a public request)

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
