### PR TITLE
v2.1.6: fix(#254): some OCO response types are optional. add missing OCO request properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# binance
+# Node.js & Typescript Binance API SDK
 
 [![Tests](https://circleci.com/gh/tiagosiebler/binance.svg?style=shield)](https://circleci.com/gh/tiagosiebler/binance)
 [![npm version](https://img.shields.io/npm/v/binance)][1] [![npm size](https://img.shields.io/bundlephobia/min/binance/latest)][1] [![npm downloads](https://img.shields.io/npm/dt/binance)][1]
@@ -16,7 +16,6 @@ Node.js connector for the Binance APIs and WebSockets, with TypeScript & browser
   - End-to-end testing before any release.
   - Real API calls in e2e tests.
 - Support REST APIs for Binance Spot, Margin, Isolated Margin & USDM Futures.
-  - Automatically manage latency related authentication issues.
   - Strongly typed on most requests and responses.
 - Support Websockets for Binance Spot, Margin, Isolated Margin & USDM Futures.
   - Event driven messaging.
@@ -49,9 +48,10 @@ Refer to the [examples](./examples) folder for implementation demos.
 Check out my related projects:
 
 - Try my connectors:
-  - [ftx-api](https://www.npmjs.com/package/ftx-api)
-  - [bybit-api](https://www.npmjs.com/package/bybit-api)
   - [binance](https://www.npmjs.com/package/binance)
+  - [bybit-api](https://www.npmjs.com/package/bybit-api)
+  - [okx-api](https://www.npmjs.com/package/okx-api)
+  - [ftx-api](https://www.npmjs.com/package/ftx-api)
 - Try my misc utilities:
   - [orderbooks](https://www.npmjs.com/package/orderbooks)
 - Check out my examples:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Node.js connector for Binance's REST APIs and WebSockets, with TypeScript & integration tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -170,14 +170,19 @@ export interface NewOCOParams {
   side: OrderSide;
   quantity: number;
   limitClientOrderId?: string;
+  limitStrategyId?: number;
+  limitStrategyType?: number;
   price: number;
   limitIcebergQty?: number;
+  trailingdelta?: number;
   stopClientOrderId?: string;
   stopPrice: number;
+  stopStrategyId?: number;
+  stopStrategyType?: number;
   stopLimitPrice?: number;
   stopIcebergQty?: number;
-  stopLimitTimeInForce: OrderTimeInForce;
-  newOrderRespType: OrderResponseType;
+  stopLimitTimeInForce?: OrderTimeInForce;
+  newOrderRespType?: OrderResponseType;
   /** For isolated margin trading only */
   isIsolated?: StringBoolean;
   /** Define a side effect, only for margin trading */


### PR DESCRIPTION
## Summary
- Fixes #254 (some OCO params should be optional)
- Adds some newer missing OCO params to request type
- Update readme a bit.

<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
