### PR TITLE
v2.2.0: 1s interval, ws client resilience, new savings endpoints, disable time sync by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,6 @@ Or buy me a coffee using any of these:
 
 Contributions are encouraged, I will review any incoming pull requests. See the issues tab for todo items.
 
-## Stargazers
+## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tiagosiebler/ftx-api,tiagosiebler/bybit-api,tiagosiebler/binance,tiagosiebler/orderbooks&type=Date)](https://star-history.com/#tiagosiebler/ftx-api&tiagosiebler/bybit-api&tiagosiebler/binance&tiagosiebler/orderbooks&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=tiagosiebler/ftx-api,tiagosiebler/bybit-api,tiagosiebler/binance,tiagosiebler/orderbooks,tiagosiebler/okx-api,tiagosiebler/awesome-crypto-examples&type=Date)](https://star-history.com/#tiagosiebler/ftx-api&tiagosiebler/bybit-api&tiagosiebler/binance&tiagosiebler/orderbooks&tiagosiebler/okx-api&tiagosiebler/awesome-crypto-examples&Date)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.1.6",
+  "version": "2.2.0",
   "description": "Node.js connector for Binance's REST APIs and WebSockets, with TypeScript & integration tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -38,6 +38,8 @@ import {
   BSwapOperations,
   BSwapOperationsParams,
   CancelSpotOrderResult,
+  ChangePermissionApiKeyBrokerSubAccountParams,
+  ChangePermissionApiKeyBrokerSubAccountResponse,
   ConvertDustParams,
   CreateApiKeyBrokerSubAccountParams,
   CreateApiKeyBrokerSubAccountResponse,
@@ -48,6 +50,7 @@ import {
   DailyAccountSnapshot,
   DailyAccountSnapshotParams,
   DailyChangeStatistic,
+  DeleteApiKeyBrokerSubAccountParams,
   DepositAddressParams,
   DepositAddressResponse,
   DepositHistory,
@@ -55,12 +58,18 @@ import {
   DustConversion,
   DustInfo,
   DustLog,
+  EnableFuturesBrokerSubAccountParams,
+  EnableFuturesBrokerSubAccountResponse,
   EnableMarginApiKeyBrokerSubAccountParams,
+  EnableMarginBrokerSubAccountParams,
+  EnableMarginBrokerSubAccountResponse,
   EnableOrDisableIPRestrictionForSubAccountParams,
   EnableUniversalTransferApiKeyBrokerSubAccountParams,
   EnableUniversalTransferApiKeyBrokerSubAccountResponse,
   ExchangeInfo,
   ExchangeInfoParams,
+  FixedAndActivityProjectParams,
+  FixedAndActivityProjectPositionParams,
   FlexibleSavingBasicParams,
   FuturesPositionRisk,
   GetApiKeyBrokerSubAccountParams,
@@ -70,6 +79,7 @@ import {
   GetUniversalTransferBrokerParams,
   IsolatedMarginAccountInfo,
   IsolatedMarginAccountTransferParams,
+  LeftDailyPurchaseQuotaFlexibleProductResponse,
   MarginAccountLoanParams,
   MarginRecordResponse,
   MarginTransactionResponse,
@@ -80,6 +90,7 @@ import {
   OrderResponseResult,
   PurchaseFlexibleProductParams,
   PurchaseFlexibleProductResponse,
+  PurchaseRecordParams,
   QueryCrossMarginAccountDetailsParams,
   QueryCrossMarginPairParams,
   QueryCrossMarginPairResponse,
@@ -91,6 +102,7 @@ import {
   QueryMaxTransferOutAmountResponse,
   RawAccountTrade,
   RawTrade,
+  RedeemFlexibleProductParams,
   RemoveBSwapLiquidityParams,
   SpotOrder,
   StakingBasicParams,
@@ -546,6 +558,7 @@ export class MainClient extends BaseRestClient {
   ): Promise<BrokerSubAccount[]> {
     return this.getPrivate('sapi/v1/broker/subAccount', params);
   }
+
   getApiKeyBrokerSubAccount(
     params: GetApiKeyBrokerSubAccountParams
   ): Promise<ApiKeyBrokerSubAccount[]> {
@@ -558,6 +571,24 @@ export class MainClient extends BaseRestClient {
     return this.postPrivate('sapi/v1/broker/subAccountApi', params);
   }
 
+  deleteApiKeyBrokerSubAccount(
+    params: DeleteApiKeyBrokerSubAccountParams
+  ): Promise<{}> {
+    return this.deletePrivate('sapi/v1/broker/subAccountApi', params);
+  }
+
+  changePermissionApiKeyBrokerSubAccount(
+    params: ChangePermissionApiKeyBrokerSubAccountParams
+  ): Promise<ChangePermissionApiKeyBrokerSubAccountResponse> {
+    return this.postPrivate('sapi/v1/broker/subAccountApi/permission', params);
+  }
+
+  changeComissionBrokerSubAccount(
+    params: ChangePermissionApiKeyBrokerSubAccountParams
+  ): Promise<ChangePermissionApiKeyBrokerSubAccountResponse> {
+    return this.postPrivate('sapi/v1/broker/subAccountApi/permission', params);
+  }
+
   enableUniversalTransferApiKeyBrokerSubAccount(
     params: EnableUniversalTransferApiKeyBrokerSubAccountParams
   ): Promise<EnableUniversalTransferApiKeyBrokerSubAccountResponse> {
@@ -565,6 +596,18 @@ export class MainClient extends BaseRestClient {
       'sapi/v1/broker/subAccountApi/permission/universalTransfer',
       params
     );
+  }
+
+  enableMarginBrokerSubAccount(
+    params: EnableMarginBrokerSubAccountParams
+  ): Promise<EnableMarginBrokerSubAccountResponse> {
+    return this.postPrivate('sapi/v1/broker/subAccount/futures', params);
+  }
+
+  enableFuturesBrokerSubAccount(
+    params: EnableFuturesBrokerSubAccountParams
+  ): Promise<EnableFuturesBrokerSubAccountResponse> {
+    return this.postPrivate('sapi/v1/broker/subAccount', params);
   }
 
   enableMarginApiKeyBrokerSubAccount(
@@ -1033,16 +1076,83 @@ export class MainClient extends BaseRestClient {
   ): Promise<StakingProduct[]> {
     return this.getPrivate(`sapi/v1/lending/daily/product/list`, params);
   }
+
   purchaseFlexibleProduct(
     params: PurchaseFlexibleProductParams
   ): Promise<PurchaseFlexibleProductResponse> {
     return this.postPrivate(`sapi/v1/lending/daily/purchase`, params);
   }
+
+  redeemFlexibleProduct(params: RedeemFlexibleProductParams): Promise<{}> {
+    return this.postPrivate(`sapi/v1/lending/daily/redeem`, params);
+  }
+
   getFlexibleProductPosition(params: {
     asset?: string;
   }): Promise<StakingProduct[]> {
     return this.getPrivate(`sapi/v1/lending/daily/token/position`, params);
   }
+
+  getLeftDailyPurchaseQuotaFlexibleProduct(params: {
+    productId: string;
+  }): Promise<LeftDailyPurchaseQuotaFlexibleProductResponse> {
+    return this.getPrivate(`sapi/v1/lending/daily/userLeftQuota`, params);
+  }
+
+  getLeftDailyRedemptionQuotaFlexibleProduct(params: {
+    productId: string;
+  }): Promise<
+    LeftDailyPurchaseQuotaFlexibleProductResponse & {
+      dailyQuota: string;
+      minRedemptionAmount: string;
+    }
+  > {
+    return this.getPrivate(`sapi/v1/lending/daily/userRedemptionQuota`, params);
+  }
+
+  purchaseFixedAndActivityProject(params: {
+    projectId: string;
+    lot: number;
+  }): Promise<PurchaseFlexibleProductResponse> {
+    return this.postPrivate(`sapi/v1/lending/customizedFixed/purchase`, params);
+  }
+
+  getFixedAndActivityProjects(
+    params: FixedAndActivityProjectParams
+  ): Promise<any[]> {
+    return this.getPrivate(`sapi/v1/lending/project/list`, params);
+  }
+
+  getFixedAndActivityProductPosition(
+    params: FixedAndActivityProjectPositionParams
+  ): Promise<any[]> {
+    return this.getPrivate(`sapi/v1/lending/project/position/list`, params);
+  }
+
+  getLendingAccount(): Promise<StakingProduct[]> {
+    return this.getPrivate(`sapi/v1/lending/union/account`);
+  }
+
+  getPurchaseRecord(params: PurchaseRecordParams): Promise<any[]> {
+    return this.getPrivate(`sapi/v1/lending/union/purchaseRecord`, params);
+  }
+
+  getRedemptionRecord(params: PurchaseRecordParams): Promise<any[]> {
+    return this.getPrivate(`sapi/v1/lending/union/redemptionRecord`, params);
+  }
+
+  getInterestHistory(params: PurchaseRecordParams): Promise<any[]> {
+    return this.getPrivate(`sapi/v1/lending/union/interestHistory`, params);
+  }
+
+  changeFixedAndActivityPositionToDailyPosition(params: {
+    projectId: string;
+    lot: number;
+    positionId?: number;
+  }): Promise<PurchaseFlexibleProductResponse> {
+    return this.postPrivate(`sapi/v1/lending/positionChanged`, params);
+  }
+
   /**
    *
    * Mining Endpoints

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -104,6 +104,7 @@ export interface OrderBookParams {
 }
 
 export type KlineInterval =
+  | '1s'
   | '1m'
   | '3m'
   | '5m'

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -940,6 +940,28 @@ export interface EnableUniversalTransferApiKeyBrokerSubAccountParams {
   canUniversalTransfer: boolean;
 }
 
+export interface EnableMarginBrokerSubAccountParams {
+  subAccountId: string;
+  margin: boolean;
+}
+
+export interface EnableMarginBrokerSubAccountResponse {
+  subAccountId: string;
+  enableMargin: boolean;
+  updateTime: number;
+}
+
+export interface EnableFuturesBrokerSubAccountParams {
+  subAccountId: string;
+  futures: boolean;
+}
+
+export interface EnableFuturesBrokerSubAccountResponse {
+  subAccountId: string;
+  enableFutures: boolean;
+  updateTime: number;
+}
+
 export interface EnableMarginApiKeyBrokerSubAccountParams {
   subAccountId: string;
   margin: boolean;
@@ -962,6 +984,27 @@ export interface GetUniversalTransferBrokerParams {
   page?: number;
   limit?: number;
   showAllStatus?: boolean;
+}
+
+export interface DeleteApiKeyBrokerSubAccountParams {
+  subAccountId: string;
+  subAccountApiKey: string;
+}
+
+export interface ChangePermissionApiKeyBrokerSubAccountParams {
+  subAccountId: string;
+  subAccountApiKey: string;
+  canTrade: boolean;
+  marginTrade: boolean;
+  futuresTrade: boolean;
+}
+
+export interface ChangePermissionApiKeyBrokerSubAccountResponse {
+  subAccountId: string;
+  apikey: string;
+  canTrade: boolean;
+  marginTrade: boolean;
+  futuresTrade: boolean;
 }
 
 export interface VirtualSubAccount {
@@ -1421,6 +1464,51 @@ export interface PurchaseFlexibleProductParams {
 
 export interface PurchaseFlexibleProductResponse {
   purchaseId: number;
+}
+
+export interface RedeemFlexibleProductParams {
+  productId: string;
+  amount: number;
+  type: 'FAST' | 'NORMAL';
+}
+
+export interface LeftDailyPurchaseQuotaFlexibleProductResponse {
+  asset: string;
+  leftQuota: string;
+}
+
+export type ProjectStatus = 'ALL' | 'SUBSCRIBABLE' | 'UNSUBSCRIBABLE';
+export type ProjectType = 'ACTIVITY' | 'CUSTOMIZED_FIXED';
+export type ProjectSortBy =
+  | 'START_TIME'
+  | 'LOT_SIZE'
+  | 'INTEREST_RATE'
+  | 'DURATION';
+
+export interface FixedAndActivityProjectParams {
+  asset?: string;
+  type: ProjectType;
+  status?: ProjectStatus;
+  isSortAsc?: boolean;
+  sortBy?: ProjectSortBy;
+  current?: number;
+  size?: number;
+}
+export interface FixedAndActivityProjectPositionParams {
+  asset?: string;
+  projectId?: string;
+  status?: StakingStatus;
+}
+
+export type LendingType = 'DAILY' | 'ACTIVITY' | 'CUSTOMIZED_FIXED';
+
+export interface PurchaseRecordParams {
+  lendingType: LendingType;
+  asset?: string;
+  startTime?: number;
+  endTime?: number;
+  current?: number;
+  size?: number;
 }
 
 export interface StakingHistory {

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -551,7 +551,7 @@ export interface OrderResponseResult {
   price: numberInString;
   origQty: numberInString;
   executedQty: numberInString;
-  cumulativeQuoteQty: numberInString;
+  cummulativeQuoteQty: numberInString;
   status: OrderStatus;
   timeInForce: OrderTimeInForce;
   type: OrderType;
@@ -574,7 +574,7 @@ export interface OrderResponseFull {
   price: numberInString;
   origQty: numberInString;
   executedQty: numberInString;
-  cumulativeQuoteQty: numberInString;
+  cummulativeQuoteQty: numberInString;
   status: OrderStatus;
   timeInForce: OrderTimeInForce;
   type: OrderType;
@@ -594,7 +594,7 @@ export interface CancelSpotOrderResult {
   price: numberInString;
   origQty: numberInString;
   executedQty: numberInString;
-  cumulativeQuoteQty: numberInString;
+  cummulativeQuoteQty: numberInString;
   status: OrderStatus;
   timeInForce: OrderTimeInForce;
   type: OrderType;

--- a/src/util/BaseRestClient.ts
+++ b/src/util/BaseRestClient.ts
@@ -44,6 +44,8 @@ export default abstract class BaseRestClient {
       syncIntervalMs: 3600000,
       // if true, we'll throw errors if any params are undefined
       strictParamValidation: false,
+      // disable the time sync mechanism by default
+      disableTimeSync: true,
       ...options,
     };
 

--- a/src/util/WsStore.ts
+++ b/src/util/WsStore.ts
@@ -12,11 +12,10 @@ interface WsStoredState {
   activePingTimer?: NodeJS.Timeout | number | undefined;
   activePongTimer?: NodeJS.Timeout | number | undefined;
   subscribedTopics: WsTopicList;
-};
-
+}
 
 export default class WsStore {
-  private wsState: Record<string, WsStoredState>
+  private wsState: Record<string, WsStoredState>;
   private logger: typeof DefaultLogger;
 
   constructor(logger: typeof DefaultLogger) {
@@ -40,11 +39,14 @@ export default class WsStore {
 
   create(key: string): WsStoredState | undefined {
     if (this.hasExistingActiveConnection(key)) {
-      this.logger.warning('WsStore setConnection() overwriting existing open connection: ', this.getWs(key));
+      this.logger.warning(
+        'WsStore setConnection() overwriting existing open connection: ',
+        this.getWs(key)
+      );
     }
     this.wsState[key] = {
       subscribedTopics: new Set(),
-      connectionState: WsConnectionState.READY_STATE_INITIAL
+      connectionState: WsConnectionState.READY_STATE_INITIAL,
     };
     return this.get(key);
   }
@@ -52,7 +54,10 @@ export default class WsStore {
   delete(key: string) {
     if (this.hasExistingActiveConnection(key)) {
       const ws = this.getWs(key);
-      this.logger.warning('WsStore deleting state for connection still open: ', ws);
+      this.logger.warning(
+        'WsStore deleting state for connection still open: ',
+        ws
+      );
       ws?.close();
     }
     delete this.wsState[key];
@@ -70,7 +75,10 @@ export default class WsStore {
 
   setWs(key: string, wsConnection: WebSocket): WebSocket {
     if (this.isWsOpen(key)) {
-      this.logger.warning('WsStore setConnection() overwriting existing open connection: ', this.getWs(key));
+      this.logger.warning(
+        'WsStore setConnection() overwriting existing open connection: ',
+        this.getWs(key)
+      );
     }
     this.get(key, true)!.ws = wsConnection;
     return wsConnection;
@@ -80,7 +88,10 @@ export default class WsStore {
 
   isWsOpen(key: string): boolean {
     const existingConnection = this.getWs(key);
-    return !!existingConnection && existingConnection.readyState === existingConnection.OPEN;
+    return (
+      !!existingConnection &&
+      existingConnection.readyState === existingConnection.OPEN
+    );
   }
 
   getConnectionState(key: string): WsConnectionState {
@@ -96,8 +107,10 @@ export default class WsStore {
   }
 
   isWsConnecting(key: string): boolean {
-    return this.isConnectionState(key, WsConnectionState.READY_STATE_CONNECTING)
-      || this.isConnectionState(key, WsConnectionState.READY_STATE_RECONNECTING);
+    return (
+      this.isConnectionState(key, WsConnectionState.READY_STATE_CONNECTING) ||
+      this.isConnectionState(key, WsConnectionState.READY_STATE_RECONNECTING)
+    );
   }
 
   /* subscribed topics */

--- a/src/util/beautifier.ts
+++ b/src/util/beautifier.ts
@@ -6,7 +6,6 @@ export default class Beautifier {
   private floatKeysHashMap: Record<string, boolean>;
 
   constructor() {
-
     this.floatKeys = [
       'accumulatedQuantity',
       'accumulatedRealisedPreFee',
@@ -36,7 +35,7 @@ export default class Beautifier {
       'commissionAmount',
       'crossWalletBalance',
       'currentClose',
-      'cumulativeQuoteAssetTransactedQty',
+      'cummulativeQuoteAssetTransactedQty',
       'entryPrice',
       'executedQty',
       'free',
@@ -121,12 +120,12 @@ export default class Beautifier {
       'withdrawMax',
       'withdrawMin',
       'withdrawIntegerMultiple',
-      'withdrawing'
+      'withdrawing',
     ];
 
     // Map so we don't have to perform indexOf for each iteration
     this.floatKeysHashMap = {};
-    this.floatKeys.forEach(keyName => {
+    this.floatKeys.forEach((keyName) => {
       this.floatKeysHashMap[keyName] = true;
     });
 
@@ -139,7 +138,7 @@ export default class Beautifier {
         l: 'lastTradeId',
         T: 'timestamp',
         m: 'maker',
-        M: 'bestPriceMatch'
+        M: 'bestPriceMatch',
       },
       bookTickerEvent: {
         e: 'eventType',
@@ -148,7 +147,7 @@ export default class Beautifier {
         b: 'bidPrice',
         B: 'bidQty',
         a: 'askPrice',
-        A: 'askQty'
+        A: 'askQty',
       },
       klines: {
         0: 'openTime',
@@ -162,21 +161,21 @@ export default class Beautifier {
         8: 'trades',
         9: 'takerBaseAssetVolume',
         10: 'takerQuoteAssetVolume',
-        11: 'ignored'
+        11: 'ignored',
       },
       bids: [
         {
           0: 'price',
           1: 'quantity',
-          2: 'ignored'
-        }
+          2: 'ignored',
+        },
       ],
       asks: [
         {
           0: 'price',
           1: 'quantity',
-          2: 'ignored'
-        }
+          2: 'ignored',
+        },
       ],
       depthUpdateEvent: {
         e: 'eventType',
@@ -185,40 +184,40 @@ export default class Beautifier {
         U: 'firstUpdateId',
         u: 'lastUpdateId',
         b: 'bidDepthDelta',
-        a: 'askDepthDelta'
+        a: 'askDepthDelta',
       },
       bidDepthDelta: [
         {
           0: 'price',
           1: 'quantity',
-          2: 'ignored'
-        }
+          2: 'ignored',
+        },
       ],
       askDepthDelta: [
         {
           0: 'price',
           1: 'quantity',
-          2: 'ignored'
-        }
+          2: 'ignored',
+        },
       ],
       klineEvent: {
         e: 'eventType',
         E: 'eventTime',
         s: 'symbol',
-        k: 'kline'
+        k: 'kline',
       },
       continuous_klineEvent: {
         e: 'eventType',
         E: 'eventTime',
         ps: 'symbol',
         ct: 'contractType',
-        k: 'kline'
+        k: 'kline',
       },
       indexPrice_klineEvent: {
         e: 'eventType',
         E: 'eventTime',
         ps: 'symbol',
-        k: 'kline'
+        k: 'kline',
       },
       kline: {
         t: 'startTime',
@@ -237,7 +236,7 @@ export default class Beautifier {
         q: 'quoteVolume',
         V: 'volumeActive',
         Q: 'quoteVolumeActive',
-        B: 'ignored'
+        B: 'ignored',
       },
       aggTradeEvent: {
         e: 'eventType',
@@ -250,7 +249,7 @@ export default class Beautifier {
         l: 'lastTradeId',
         T: 'time',
         m: 'maker',
-        M: 'ignored'
+        M: 'ignored',
       },
       outboundAccountInfoEvent: {
         e: 'eventType',
@@ -263,13 +262,13 @@ export default class Beautifier {
         W: 'canWithdraw',
         D: 'canDeposit',
         B: 'balances',
-        u: 'lastUpdateTime'
+        u: 'lastUpdateTime',
       },
       outboundAccountPositionEvent: {
         e: 'eventType',
         E: 'eventTime',
         u: 'lastUpdateTime',
-        B: 'balances'
+        B: 'balances',
       },
       balanceUpdateEvent: {
         e: 'eventType',
@@ -282,7 +281,7 @@ export default class Beautifier {
         e: 'eventType',
         E: 'eventTime',
         i: 'symbol',
-        p: 'indexPrice'
+        p: 'indexPrice',
       },
       listStatusEvent: {
         e: 'eventType',
@@ -387,7 +386,7 @@ export default class Beautifier {
           iw: 'isolatedWalletAmount',
           mp: 'markPrice',
           up: 'unrealisedPnl',
-          mm: 'maintenanceMarginRequired'
+          mm: 'maintenanceMarginRequired',
         },
       ],
       listenKeyExpiredEvent: {
@@ -424,8 +423,8 @@ export default class Beautifier {
         {
           a: 'asset',
           f: 'availableBalance',
-          l: 'onOrderBalance'
-        }
+          l: 'onOrderBalance',
+        },
       ],
       executionReportEvent: {
         e: 'eventType',
@@ -457,7 +456,7 @@ export default class Beautifier {
         m: 'isMaker',
         M: 'ignoreThis2',
         O: 'orderCreationTime',
-        Z: 'cumulativeQuoteAssetTransactedQty',
+        Z: 'cummulativeQuoteAssetTransactedQty',
         Y: 'lastQuoteAssetTransactedQty',
         Q: 'orderQuoteQty',
       },
@@ -472,7 +471,7 @@ export default class Beautifier {
         a: 'sellerOrderId',
         T: 'time',
         m: 'maker',
-        M: 'ignored'
+        M: 'ignored',
       },
       '24hrTickerEvent': {
         e: 'eventType',
@@ -511,12 +510,12 @@ export default class Beautifier {
         v: 'baseAssetVolume',
         q: 'quoteAssetVolume',
       },
-      'forceOrderEvent': {
+      forceOrderEvent: {
         e: 'eventType',
         E: 'eventTime',
         o: 'liquidationOrder',
       },
-      'liquidationOrder': {
+      liquidationOrder: {
         s: 'symbol',
         S: 'side',
         o: 'orderType',
@@ -528,7 +527,7 @@ export default class Beautifier {
         l: 'lastFilledQuantity',
         z: 'orderFilledAccumulatedQuantity',
         T: 'orderTradeTime',
-      }
+      },
     };
   }
 
@@ -576,7 +575,7 @@ export default class Beautifier {
       } else if (type === 'string' || type === 'number' || type === 'boolean') {
         beautifedArray.push(this.beautifyValueWithKey(parentKey || key, val));
       } else {
-        beautifedArray.push(this.beautifyObjectValues(val))
+        beautifedArray.push(this.beautifyObjectValues(val));
       }
     }
     return beautifedArray;
@@ -584,7 +583,11 @@ export default class Beautifier {
 
   beautify(data: any, key?: string | number) {
     if (typeof key !== 'string' && typeof key !== 'number') {
-      console.warn(`beautify(object, ${key}) is not valid key - beautification failed `, data, key);
+      console.warn(
+        `beautify(object, ${key}) is not valid key - beautification failed `,
+        data,
+        key
+      );
       return data;
     }
     const knownBeautification = this.beautificationMap[key];
@@ -607,7 +610,7 @@ export default class Beautifier {
       let newKey = knownBeautification[key] || key;
       if (Array.isArray(newKey)) {
         newKey = newKey[0];
-      };
+      }
 
       if (!Array.isArray(value)) {
         if (valueType === 'object' && value !== null) {
@@ -621,25 +624,24 @@ export default class Beautifier {
       const newArray: any[] = [];
       if (Array.isArray(this.beautificationMap[newKey])) {
         for (const elementValue of value) {
-          const mappedBeautification = this.beautificationMap[knownBeautification[key]];
+          const mappedBeautification =
+            this.beautificationMap[knownBeautification[key]];
           const childMapping = mappedBeautification[0];
 
           if (typeof childMapping === 'object' && childMapping !== null) {
             const mappedResult = {};
             for (const childElementKey in elementValue) {
               const newKey = childMapping[childElementKey] || childElementKey;
-              mappedResult[newKey] = this.beautify(elementValue[childElementKey], newKey);
+              mappedResult[newKey] = this.beautify(
+                elementValue[childElementKey],
+                newKey
+              );
             }
             newArray.push(mappedResult);
             continue;
           }
 
-          newArray.push(
-            this.beautify(
-              elementValue,
-              childMapping
-            )
-          );
+          newArray.push(this.beautify(elementValue, childMapping));
         }
       }
       newItem[newKey] = newArray;
@@ -650,9 +652,13 @@ export default class Beautifier {
   /**
    * Entry point to beautify WS message. EventType is determined automatically unless this is a combined stream event.
    */
-  beautifyWsMessage(data: any, eventType?: string, isCombined?: boolean): WsFormattedMessage {
+  beautifyWsMessage(
+    data: any,
+    eventType?: string,
+    isCombined?: boolean
+  ): WsFormattedMessage {
     if (Array.isArray(data)) {
-      return data.map(event => {
+      return data.map((event) => {
         if (event.e) {
           return this.beautify(event, event.e + 'Event');
         }

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -520,6 +520,14 @@ export class WebsocketClient extends EventEmitter {
     terminateWs(this.getWs(wsKey));
   }
 
+  public closeAll(force?: boolean) {
+    const keys = this.wsStore.getKeys();
+    this.logger.info(`Closing all ws connections: ${keys}`);
+    keys.forEach((key) => {
+      this.close(key, force);
+    });
+  }
+
   public closeWs(ws: WebSocket, willReconnect?: boolean) {
     const wsKey = this.wsUrlKeyMap[ws.url];
     if (!wsKey) {
@@ -631,125 +639,6 @@ export class WebsocketClient extends EventEmitter {
 
     return wsBaseEndpoints[market];
   }
-
-  //   // const networkKey = this.options.livenet ? 'livenet' : 'testnet';
-  //   // if (this.isLinear() || wsKey.startsWith('linear')){
-  //   //   if (wsKey === wsKeyLinearPublic) {
-  //   //     return linearEndpoints.public[networkKey];
-  //   //   }
-
-  //   //   if (wsKey === wsKeyLinearPrivate) {
-  //   //     return linearEndpoints.private[networkKey];
-  //   //   }
-
-  //   //   this.logger.error('Unhandled linear wsKey: ', { ...loggerCategory, wsKey });
-  //   //   return linearEndpoints[networkKey];
-  //   // }
-  //   // return inverseEndpoints[networkKey];
-  // }
-
-  // private getWsKeyForTopic(baseUrlKey: BinanceBaseUrlKey, topic: string) {
-  //   return isSpotBase(baseUrlKey) ? wsKeySpot : getLinearWsKeyForTopic(topic);
-  // }
-
-  // public subscribeSpotPublic(wsTopics: string[] | string) {
-  //   return this.subscribe('spot', wsTopics);
-  // }
-
-  // public unsubscribeSpotPublic(wsTopics: string[] | string) {
-  //   return this.unsubscribe('spot', wsTopics);
-  // }
-
-  // TODO: force these through single stream, instead of general one
-  /**
-   * Add topic/topics to WS subscription list
-   */
-  // public subscribe(baseUrlKey: BinanceBaseUrlKey, wsTopics: string[] | string) {
-  //   const topics = Array.isArray(wsTopics) ? wsTopics : [wsTopics];
-  //   topics.forEach(topic => this.wsStore.addTopic(
-  //     this.getWsKeyForTopic(baseUrlKey, topic),//wsKeySpot
-  //     topic
-  //   ));
-
-  //   // attempt to send subscription topic per websocket
-  //   this.wsStore.getKeys().forEach((wsKey: WsKey) => {
-  //     // if connected, send subscription request
-  //     if (this.wsStore.isConnectionState(wsKey, READY_STATE_CONNECTED)) {
-  //       return this.requestSubscribeTopics(wsKey, topics);
-  //     }
-
-  //     // start connection process if it hasn't yet begun. Topics are automatically subscribed to on-connect
-  //     if (
-  //       !this.wsStore.isConnectionState(wsKey, READY_STATE_CONNECTING) &&
-  //       !this.wsStore.isConnectionState(wsKey, READY_STATE_RECONNECTING)
-  //     ) {
-  //       return this.connectSingleStream(wsKey);
-  //     }
-  //   });
-  // }
-
-  /**
-   * Remove topic/topics from WS subscription list
-   */
-  // public unsubscribe(baseUrlKey: BinanceBaseUrlKey, wsTopics: string[] | string) {
-  //   const topics = Array.isArray(wsTopics) ? wsTopics : [wsTopics];
-  //   topics.forEach(topic => this.wsStore.deleteTopic(
-  //     this.getWsKeyForTopic(baseUrlKey, topic),
-  //     topic
-  //   ));
-
-  //   this.wsStore.getKeys().forEach((wsKey: WsKey) => {
-  //     // unsubscribe request only necessary if active connection exists
-  //     if (this.wsStore.isConnectionState(wsKey, READY_STATE_CONNECTED)) {
-  //       this.requestUnsubscribeTopics(wsKey, topics);
-  //     }
-  //   });
-  // }
-
-  // /**
-  //  * Request connection of all dependent websockets, instead of waiting for automatic connection by library
-  //  */
-  // public connectAll(): Promise<WebSocket | undefined>[] | undefined {
-  //   return [this.connectSingleStream(wsKeySpot)];
-
-  //   // if (this.isInverse()) {
-  //   //   return [this.connect(wsKeySpot)];
-  //   // }
-
-  //   // if (this.isLinear()) {
-  //   //   return [this.connect(wsKeyLinearPublic), this.connect(wsKeyLinearPrivate)];
-  //   // }
-  // }
-
-  // private async connectSingleStream(streamName: string): Promise<WebSocket | undefined> {
-  //   try {
-  //     if (this.wsStore.isWsOpen(streamName)) {
-  //       this.logger.error('Refused to connect to ws with existing active connection', { ...loggerCategory, wsKey: streamName })
-  //       return this.wsStore.getWs(streamName);
-  //     }
-
-  //     if (this.wsStore.isConnectionState(streamName, READY_STATE_CONNECTING)) {
-  //       this.logger.error('Refused to connect to ws, connection attempt already active', { ...loggerCategory, wsKey: streamName })
-  //       return;
-  //     }
-
-  //     if (
-  //       !this.wsStore.getConnectionState(streamName) ||
-  //       this.wsStore.isConnectionState(streamName, READY_STATE_INITIAL)
-  //     ) {
-  //       this.setWsState(streamName, READY_STATE_CONNECTING);
-  //     }
-
-  //     const url = this.getWsUrl(streamName) + '/stream?';
-  //     //+ authParams;
-  //     const ws = this.connectToWsUrl(url, streamName);
-
-  //     return this.wsStore.setWs(streamName, ws);
-  //   } catch (err) {
-  //     this.parseWsError('Connection failed', err, streamName);
-  //     this.reconnectWithDelay(streamName, this.options.reconnectTimeout!);
-  //   }
-  // }
 
   public getWs(wsKey: WsKey): WebSocket | undefined {
     return this.wsStore.getWs(wsKey);

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -10,7 +10,7 @@ import {
   WsMarket,
   WsRawMessage,
   WsResponse,
-  WsUserDataEvents
+  WsUserDataEvents,
 } from './types/websockets';
 import { USDMClient } from './usdm-client';
 
@@ -20,7 +20,7 @@ import {
   appendEventMarket,
   getContextFromWsKey,
   getWsKeyWithContext,
-  RestClientOptions
+  RestClientOptions,
 } from './util/requestUtils';
 import { terminateWs } from './util/ws-utils';
 
@@ -36,7 +36,7 @@ const wsBaseEndpoints: Record<WsMarket, string> = {
   coinm: 'wss://dstream.binance.com',
   coinmTestnet: 'wss://dstream.binancefuture.com',
   options: 'wss://vstream.binance.com',
-  optionsTestnet: 'wss://testnetws.binanceops.com'
+  optionsTestnet: 'wss://testnetws.binanceops.com',
 };
 
 const loggerCategory = { category: 'binance-ws' };
@@ -194,7 +194,7 @@ export class WebsocketClient extends EventEmitter {
       pongTimeout: 7500,
       pingInterval: 10000,
       reconnectTimeout: 500,
-      ...options
+      ...options,
     };
 
     this.listenKeyStateStore = {};
@@ -206,7 +206,7 @@ export class WebsocketClient extends EventEmitter {
       ...this.options,
       ...this.options.restOptions,
       api_key: this.options.api_key,
-      api_secret: this.options.api_secret
+      api_secret: this.options.api_secret,
     };
   }
 
@@ -263,7 +263,7 @@ export class WebsocketClient extends EventEmitter {
       this.logger.silly(`Sending upstream ws message: `, {
         ...loggerCategory,
         wsMessage,
-        wsKey
+        wsKey,
       });
       if (!wsKey) {
         throw new Error('No wsKey provided');
@@ -281,7 +281,7 @@ export class WebsocketClient extends EventEmitter {
         ...loggerCategory,
         wsMessage,
         wsKey,
-        exception: e
+        exception: e,
       });
     }
   }
@@ -307,7 +307,7 @@ export class WebsocketClient extends EventEmitter {
       this.logger.error(`Failed to send WS ping`, {
         ...loggerCategory,
         wsKey,
-        exception: e
+        exception: e,
       });
     }
   }
@@ -356,7 +356,7 @@ export class WebsocketClient extends EventEmitter {
       ...loggerCategory,
       wsKey,
       event,
-      wsConnectionState
+      wsConnectionState,
     });
 
     // User data sockets include the listen key. To prevent accummulation in memory we should clean up old disconnected states
@@ -424,7 +424,7 @@ export class WebsocketClient extends EventEmitter {
                 'ORDER_TRADE_UPDATE',
                 'ACCOUNT_UPDATE',
                 'ORDER_TRADE_UPDATE',
-                'ACCOUNT_CONFIG_UPDATE'
+                'ACCOUNT_CONFIG_UPDATE',
               ].includes(eventType)
             ) {
               this.emit('formattedUserDataMessage', beautifiedMessage);
@@ -438,7 +438,7 @@ export class WebsocketClient extends EventEmitter {
         this.emit('reply', {
           type: event.type,
           data: msg,
-          wsKey
+          wsKey,
         });
         return;
       }
@@ -450,7 +450,7 @@ export class WebsocketClient extends EventEmitter {
           parsedMessage: JSON.stringify(msg),
           rawEvent: event,
           wsKey,
-          source
+          source,
         }
       );
     } catch (e) {
@@ -459,7 +459,7 @@ export class WebsocketClient extends EventEmitter {
         rawEvent: event,
         wsKey,
         error: e,
-        source
+        source,
       });
       this.emit('error', { wsKey, error: e, rawEvent: event, source });
     }
@@ -474,7 +474,7 @@ export class WebsocketClient extends EventEmitter {
     this.wsStore.get(wsKey, true)!.activePongTimer = setTimeout(() => {
       this.logger.info('Pong timeout - closing socket to reconnect', {
         ...loggerCategory,
-        wsKey
+        wsKey,
       });
       this.close(wsKey, true);
     }, this.options.pongTimeout);
@@ -490,7 +490,7 @@ export class WebsocketClient extends EventEmitter {
       ...loggerCategory,
       wsKey,
       event,
-      source
+      source,
     });
     ws.pong();
   }
@@ -500,7 +500,7 @@ export class WebsocketClient extends EventEmitter {
       ...loggerCategory,
       wsKey,
       event,
-      source
+      source,
     });
     this.clearPongTimer(wsKey);
   }
@@ -537,7 +537,7 @@ export class WebsocketClient extends EventEmitter {
       case 'Unexpected server response: 401':
         this.logger.error(`${context} due to 401 authorization failure.`, {
           ...loggerCategory,
-          wsKey
+          wsKey,
         });
         break;
 
@@ -566,7 +566,7 @@ export class WebsocketClient extends EventEmitter {
     this.logger.info('Reconnecting to websocket with delay...', {
       ...loggerCategory,
       wsKey,
-      connectionDelayMs
+      connectionDelayMs,
     });
 
     setTimeout(() => {
@@ -576,7 +576,7 @@ export class WebsocketClient extends EventEmitter {
           ...loggerCategory,
           wsKey,
           market,
-          symbol
+          symbol,
         });
 
         // We'll set a new one once the new stream respawns, with a diff listenKey in the key
@@ -590,7 +590,7 @@ export class WebsocketClient extends EventEmitter {
       this.logger.info('Reconnecting to public websocket', {
         ...loggerCategory,
         wsKey,
-        wsUrl
+        wsUrl,
       });
       this.connectToWsUrl(wsUrl, wsKey);
     }, connectionDelayMs);
@@ -813,7 +813,7 @@ export class WebsocketClient extends EventEmitter {
     const wsMessage = JSON.stringify({
       method: 'SUBSCRIBE',
       params: topics,
-      id: new Date().getTime()
+      id: new Date().getTime(),
     });
 
     this.tryWsSend(wsKey, wsMessage);
@@ -826,7 +826,7 @@ export class WebsocketClient extends EventEmitter {
     const wsMessage = JSON.stringify({
       op: 'UNSUBSCRIBE',
       params: topics,
-      id: new Date().getTime()
+      id: new Date().getTime(),
     });
 
     this.tryWsSend(wsKey, wsMessage);
@@ -838,7 +838,7 @@ export class WebsocketClient extends EventEmitter {
   public requestListSubscriptions(wsKey: WsKey, requestId: number) {
     const wsMessage = JSON.stringify({
       method: 'LIST_SUBSCRIPTIONS',
-      id: requestId
+      id: requestId,
     });
 
     this.tryWsSend(wsKey, wsMessage);
@@ -856,7 +856,7 @@ export class WebsocketClient extends EventEmitter {
     const wsMessage = JSON.stringify({
       method: 'SET_PROPERTY',
       params: [property, value],
-      id: requestId
+      id: requestId,
     });
 
     this.tryWsSend(wsKey, wsMessage);
@@ -873,7 +873,7 @@ export class WebsocketClient extends EventEmitter {
     const wsMessage = JSON.stringify({
       method: 'GET_PROPERTY',
       params: [property],
-      id: requestId
+      id: requestId,
     });
 
     this.tryWsSend(wsKey, wsMessage);
@@ -897,7 +897,7 @@ export class WebsocketClient extends EventEmitter {
       market,
       lastKeepAlive: 0,
       keepAliveTimer: undefined,
-      keepAliveFailures: 0
+      keepAliveFailures: 0,
     };
     return this.listenKeyStateStore[listenKey];
   }
@@ -1021,7 +1021,7 @@ export class WebsocketClient extends EventEmitter {
           ...loggerCategory,
           listenKey,
           error: e,
-          keepAliveAttempts: listenKeyState.keepAliveFailures
+          keepAliveAttempts: listenKeyState.keepAliveFailures,
         }
       );
       setTimeout(
@@ -1121,7 +1121,7 @@ export class WebsocketClient extends EventEmitter {
         market,
         symbol,
         isTestnet,
-        error: e
+        error: e,
       });
       this.emit('error', { wsKey: market + '_' + 'userData', error: e });
     }
@@ -1136,7 +1136,7 @@ export class WebsocketClient extends EventEmitter {
           symbol,
           isTestnet,
           respawnAttempt,
-          delayInSeconds
+          delayInSeconds,
         }
       );
       setTimeout(
@@ -1191,7 +1191,7 @@ export class WebsocketClient extends EventEmitter {
     const wsKey = getWsKeyWithContext(market, streamName, lowerCaseSymbol);
     return this.connectToWsUrl(
       this.getWsBaseUrl(market, wsKey) +
-      `/ws/${lowerCaseSymbol}@${streamName}${speedSuffix}`,
+        `/ws/${lowerCaseSymbol}@${streamName}${speedSuffix}`,
       wsKey,
       forceNewConnection
     );
@@ -1212,7 +1212,7 @@ export class WebsocketClient extends EventEmitter {
     const wsKey = getWsKeyWithContext(market, streamName, lowerCaseSymbol);
     return this.connectToWsUrl(
       this.getWsBaseUrl(market, wsKey) +
-      `/ws/${lowerCaseSymbol}@${streamName}${speedSuffix}`,
+        `/ws/${lowerCaseSymbol}@${streamName}${speedSuffix}`,
       wsKey,
       forceNewConnection
     );
@@ -1255,7 +1255,7 @@ export class WebsocketClient extends EventEmitter {
     );
     return this.connectToWsUrl(
       this.getWsBaseUrl(market, wsKey) +
-      `/ws/${lowerCaseSymbol}@${streamName}_${interval}`,
+        `/ws/${lowerCaseSymbol}@${streamName}_${interval}`,
       wsKey,
       forceNewConnection
     );
@@ -1281,7 +1281,7 @@ export class WebsocketClient extends EventEmitter {
     );
     return this.connectToWsUrl(
       this.getWsBaseUrl(market, wsKey) +
-      `/ws/${lowerCaseSymbol}_${contractType}@${streamName}_${interval}`,
+        `/ws/${lowerCaseSymbol}_${contractType}@${streamName}_${interval}`,
       wsKey,
       forceNewConnection
     );
@@ -1306,7 +1306,7 @@ export class WebsocketClient extends EventEmitter {
     );
     return this.connectToWsUrl(
       this.getWsBaseUrl(market, wsKey) +
-      `/ws/${lowerCaseSymbol}@${streamName}_${interval}`,
+        `/ws/${lowerCaseSymbol}@${streamName}_${interval}`,
       wsKey,
       forceNewConnection
     );
@@ -1331,7 +1331,7 @@ export class WebsocketClient extends EventEmitter {
     );
     return this.connectToWsUrl(
       this.getWsBaseUrl(market, wsKey) +
-      `/ws/${lowerCaseSymbol}@${streamName}_${interval}`,
+        `/ws/${lowerCaseSymbol}@${streamName}_${interval}`,
       wsKey,
       forceNewConnection
     );
@@ -1489,7 +1489,7 @@ export class WebsocketClient extends EventEmitter {
     const updateMsSuffx = updateMs === 100 ? `@${updateMs}ms` : '';
     return this.connectToWsUrl(
       this.getWsBaseUrl(market, wsKey) +
-      `/ws/${lowerCaseSymbol}@${streamName}${levels}${updateMsSuffx}`,
+        `/ws/${lowerCaseSymbol}@${streamName}${levels}${updateMsSuffx}`,
       wsKey,
       forceNewConnection
     );
@@ -1515,7 +1515,7 @@ export class WebsocketClient extends EventEmitter {
     const updateMsSuffx = updateMs === 100 ? `@${updateMs}ms` : '';
     return this.connectToWsUrl(
       this.getWsBaseUrl(market, wsKey) +
-      `/ws/${lowerCaseSymbol}@${streamName}${updateMsSuffx}`,
+        `/ws/${lowerCaseSymbol}@${streamName}${updateMsSuffx}`,
       wsKey,
       forceNewConnection
     );
@@ -1710,7 +1710,7 @@ export class WebsocketClient extends EventEmitter {
     } catch (e) {
       this.logger.error(`Failed to connect to spot user data`, {
         ...loggerCategory,
-        error: e
+        error: e,
       });
       this.emit('error', { wsKey: 'spot' + '_' + 'userData', error: e });
     }
@@ -1759,7 +1759,7 @@ export class WebsocketClient extends EventEmitter {
     } catch (e) {
       this.logger.error(`Failed to connect to margin user data`, {
         ...loggerCategory,
-        error: e
+        error: e,
       });
       this.emit('error', { wsKey: 'margin' + '_' + 'userData', error: e });
     }
@@ -1777,7 +1777,7 @@ export class WebsocketClient extends EventEmitter {
       const lowerCaseSymbol = symbol.toLowerCase();
       const { listenKey } =
         await this.getSpotRestClient().getIsolatedMarginUserDataListenKey({
-          symbol: lowerCaseSymbol
+          symbol: lowerCaseSymbol,
         });
       const market: WsMarket = 'isolatedMargin';
       const wsKey = getWsKeyWithContext(
@@ -1812,11 +1812,11 @@ export class WebsocketClient extends EventEmitter {
       this.logger.error(`Failed to connect to isolated margin user data`, {
         ...loggerCategory,
         error: e,
-        symbol
+        symbol,
       });
       this.emit('error', {
         wsKey: 'isolatedMargin' + '_' + 'userData',
-        error: e
+        error: e,
       });
     }
   }
@@ -1875,7 +1875,7 @@ export class WebsocketClient extends EventEmitter {
     } catch (e) {
       this.logger.error(`Failed to connect to USD Futures user data`, {
         ...loggerCategory,
-        error: e
+        error: e,
       });
       this.emit('error', { wsKey: 'usdm' + '_' + 'userData', error: e });
     }
@@ -1884,10 +1884,15 @@ export class WebsocketClient extends EventEmitter {
   /**
    * Subscribe to COIN-M Futures user data stream - listen key is automatically generated.
    */
-  public async subscribeCoinFuturesUserDataStream(isTestnet?: boolean, forceNewConnection?: boolean, isReconnecting?: boolean): Promise<WebSocket> {
+  public async subscribeCoinFuturesUserDataStream(
+    isTestnet?: boolean,
+    forceNewConnection?: boolean,
+    isReconnecting?: boolean
+  ): Promise<WebSocket> {
     try {
-
-      const { listenKey } = await this.getCOINMRestClient(isTestnet).getFuturesUserDataListenKey();
+      const { listenKey } = await this.getCOINMRestClient(
+        isTestnet
+      ).getFuturesUserDataListenKey();
 
       const market: WsMarket = isTestnet ? 'coinmTestnet' : 'coinm';
       const streamName = 'userData';
@@ -1925,7 +1930,7 @@ export class WebsocketClient extends EventEmitter {
     } catch (e) {
       this.logger.error(`Failed to connect to COIN Futures user data`, {
         ...loggerCategory,
-        error: e
+        error: e,
       });
       this.emit('error', { wsKey: 'coinm' + '_' + 'userData', error: e });
     }

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -24,7 +24,7 @@ import {
 } from './util/requestUtils';
 import { terminateWs } from './util/ws-utils';
 
-import WsStore from './util/WsStore';
+import WsStore, { WsConnectionStateEnum } from './util/WsStore';
 import { CoinMClient } from './coinm-client';
 
 const wsBaseEndpoints: Record<WsMarket, string> = {
@@ -47,13 +47,13 @@ const READY_STATE_CONNECTED = 2;
 const READY_STATE_CLOSING = 3;
 const READY_STATE_RECONNECTING = 4;
 
-export enum WsConnectionState {
-  READY_STATE_INITIAL,
-  READY_STATE_CONNECTING,
-  READY_STATE_CONNECTED,
-  READY_STATE_CLOSING,
-  READY_STATE_RECONNECTING,
-}
+// export enum WsConnectionState {
+//   READY_STATE_INITIAL,
+//   READY_STATE_CONNECTING,
+//   READY_STATE_CONNECTED,
+//   READY_STATE_CLOSING,
+//   READY_STATE_RECONNECTING,
+// }
 
 export interface WSClientConfigurableOptions {
   api_key?: string;
@@ -508,6 +508,37 @@ export class WebsocketClient extends EventEmitter {
     this.clearPongTimer(wsKey);
   }
 
+  /**
+   * Closes a connection, if it's even open. If open, this will trigger a reconnect asynchronously.
+   * If closed, trigger a reconnect immediately
+   */
+  // private executeReconnectableClose(wsKey: WsKey, reason: string) {
+  //   this.logger.info(`${reason} - closing socket to reconnect`, {
+  //     ...loggerCategory,
+  //     wsKey,
+  //     reason,
+  //   });
+
+  //   const wasOpen = this.wsStore.isWsOpen(wsKey);
+
+  //   this.getWs(wsKey)?.terminate();
+  //   delete this.wsStore.get(wsKey, true).activePongTimer;
+  //   this.clearPingTimer(wsKey);
+  //   this.clearPongTimer(wsKey);
+
+  //   if (!wasOpen) {
+  //     this.logger.info(
+  //       `${reason} - socket already closed - trigger immediate reconnect`,
+  //       {
+  //         ...loggerCategory,
+  //         wsKey,
+  //         reason,
+  //       }
+  //     );
+  //     this.reconnectWithDelay(wsKey, this.options.reconnectTimeout);
+  //   }
+  // }
+
   public close(wsKey: WsKey, willReconnect?: boolean) {
     this.logger.info('Closing connection', { ...loggerCategory, wsKey });
     this.setWsState(
@@ -644,7 +675,7 @@ export class WebsocketClient extends EventEmitter {
     return this.wsStore.getWs(wsKey);
   }
 
-  private setWsState(wsKey: WsKey, state: WsConnectionState) {
+  private setWsState(wsKey: WsKey, state: WsConnectionStateEnum) {
     this.wsStore.setConnectionState(wsKey, state);
   }
 

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -199,6 +199,9 @@ export class WebsocketClient extends EventEmitter {
 
     this.listenKeyStateStore = {};
     this.wsUrlKeyMap = {};
+
+    // add default error handling so this doesn't crash node (if the user didn't set a handler)
+    this.on('error', () => {});
   }
 
   private getRestClientOptions(): RestClientOptions {

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -41,20 +41,6 @@ const wsBaseEndpoints: Record<WsMarket, string> = {
 
 const loggerCategory = { category: 'binance-ws' };
 
-const READY_STATE_INITIAL = 0;
-const READY_STATE_CONNECTING = 1;
-const READY_STATE_CONNECTED = 2;
-const READY_STATE_CLOSING = 3;
-const READY_STATE_RECONNECTING = 4;
-
-// export enum WsConnectionState {
-//   READY_STATE_INITIAL,
-//   READY_STATE_CONNECTING,
-//   READY_STATE_CONNECTED,
-//   READY_STATE_CLOSING,
-//   READY_STATE_RECONNECTING,
-// }
-
 export interface WSClientConfigurableOptions {
   api_key?: string;
   api_secret?: string;
@@ -317,7 +303,9 @@ export class WebsocketClient extends EventEmitter {
 
   private onWsOpen(ws: WebSocket, wsKey: WsKey, wsUrl: string) {
     this.logger.silly(`onWsOpen(): ${wsUrl} : ${wsKey}`);
-    if (this.wsStore.isConnectionState(wsKey, READY_STATE_RECONNECTING)) {
+    if (
+      this.wsStore.isConnectionState(wsKey, WsConnectionStateEnum.RECONNECTING)
+    ) {
       this.logger.info('Websocket reconnected', { ...loggerCategory, wsKey });
       this.emit('reconnected', { wsKey, ws });
     } else {
@@ -325,7 +313,7 @@ export class WebsocketClient extends EventEmitter {
       this.emit('open', { wsKey, ws });
     }
 
-    this.setWsState(wsKey, READY_STATE_CONNECTED);
+    this.setWsState(wsKey, WsConnectionStateEnum.CONNECTED);
 
     const topics = [...this.wsStore.getTopics(wsKey)];
     if (topics.length) {
@@ -368,11 +356,11 @@ export class WebsocketClient extends EventEmitter {
       this.wsStore.delete(wsKey);
     }
 
-    if (wsConnectionState !== READY_STATE_CLOSING) {
+    if (wsConnectionState !== WsConnectionStateEnum.CLOSING) {
       this.reconnectWithDelay(wsKey, this.options.reconnectTimeout!, wsUrl);
       this.emit('reconnecting', { wsKey, event, ws });
     } else {
-      this.setWsState(wsKey, READY_STATE_INITIAL);
+      this.setWsState(wsKey, WsConnectionStateEnum.INITIAL);
       this.emit('close', { wsKey, event, ws });
     }
   }
@@ -601,8 +589,11 @@ export class WebsocketClient extends EventEmitter {
   ) {
     this.clearTimers(wsKey);
 
-    if (this.wsStore.getConnectionState(wsKey) !== READY_STATE_CONNECTING) {
-      this.setWsState(wsKey, READY_STATE_RECONNECTING);
+    if (
+      this.wsStore.getConnectionState(wsKey) !==
+      WsConnectionStateEnum.CONNECTING
+    ) {
+      this.setWsState(wsKey, WsConnectionStateEnum.RECONNECTING);
     }
 
     this.logger.info('Reconnecting to websocket with delay...', {
@@ -1601,7 +1592,9 @@ export class WebsocketClient extends EventEmitter {
 
     this.setWsState(
       wsKey,
-      isReconnecting ? READY_STATE_RECONNECTING : READY_STATE_CONNECTING
+      isReconnecting
+        ? WsConnectionStateEnum.RECONNECTING
+        : WsConnectionStateEnum.CONNECTING
     );
     const ws = this.connectToWsUrl(
       this.getWsBaseUrl(market, wsKey) + `/ws/${listenKey}`,
@@ -1667,7 +1660,9 @@ export class WebsocketClient extends EventEmitter {
 
       this.setWsState(
         wsKey,
-        isReconnecting ? READY_STATE_RECONNECTING : READY_STATE_CONNECTING
+        isReconnecting
+          ? WsConnectionStateEnum.RECONNECTING
+          : WsConnectionStateEnum.CONNECTING
       );
       const ws = this.connectToWsUrl(
         this.getWsBaseUrl(market, wsKey) + `/ws/${listenKey}`,
@@ -1719,7 +1714,9 @@ export class WebsocketClient extends EventEmitter {
 
       this.setWsState(
         wsKey,
-        isReconnecting ? READY_STATE_RECONNECTING : READY_STATE_CONNECTING
+        isReconnecting
+          ? WsConnectionStateEnum.RECONNECTING
+          : WsConnectionStateEnum.CONNECTING
       );
       const ws = this.connectToWsUrl(
         this.getWsBaseUrl(market, wsKey) + `/ws/${listenKey}`,
@@ -1776,7 +1773,9 @@ export class WebsocketClient extends EventEmitter {
       // Necessary so client knows this is a reconnect
       this.setWsState(
         wsKey,
-        isReconnecting ? READY_STATE_RECONNECTING : READY_STATE_CONNECTING
+        isReconnecting
+          ? WsConnectionStateEnum.RECONNECTING
+          : WsConnectionStateEnum.CONNECTING
       );
       const ws = this.connectToWsUrl(
         this.getWsBaseUrl(market, wsKey) + `/ws/${listenKey}`,
@@ -1831,7 +1830,9 @@ export class WebsocketClient extends EventEmitter {
       // Necessary so client knows this is a reconnect
       this.setWsState(
         wsKey,
-        isReconnecting ? READY_STATE_RECONNECTING : READY_STATE_CONNECTING
+        isReconnecting
+          ? WsConnectionStateEnum.RECONNECTING
+          : WsConnectionStateEnum.CONNECTING
       );
       const ws = this.connectToWsUrl(
         this.getWsBaseUrl(market, wsKey) + `/ws/${listenKey}`,

--- a/test/beautifier.test.ts
+++ b/test/beautifier.test.ts
@@ -1,5 +1,3 @@
-
-
 import Beautifier from '../src/util/beautifier';
 
 describe('Beautifier', () => {
@@ -12,17 +10,17 @@ describe('Beautifier', () => {
     describe('spot markets', () => {
       it('should beautify aggTrade events', () => {
         const data = {
-          "e": "aggTrade",
-          "E": 1627993414114,
-          "s": "BTCUSDT",
-          "a": 868283962,
-          "p": "38346.71000000",
-          "q": "0.00033800",
-          "f": 984198730,
-          "l": 984198730,
-          "T": 1627993414114,
-          "m": false,
-          "M": true
+          e: 'aggTrade',
+          E: 1627993414114,
+          s: 'BTCUSDT',
+          a: 868283962,
+          p: '38346.71000000',
+          q: '0.00033800',
+          f: 984198730,
+          l: 984198730,
+          T: 1627993414114,
+          m: false,
+          M: true,
         };
 
         expect(beautifier.beautifyWsMessage(data, data.e)).toStrictEqual({
@@ -36,34 +34,34 @@ describe('Beautifier', () => {
           lastTradeId: 984198730,
           time: 1627993414114,
           maker: false,
-          ignored: true
+          ignored: true,
         });
       });
 
       it('should beautify kline events', () => {
         const data = {
-          "e": "kline",
-          "E": 1627993846810,
-          "s": "BTCUSDT",
-          "k": {
-            "t": 1627993800000,
-            "T": 1627993859999,
-            "s": "BTCUSDT",
-            "i": "1m",
-            "f": 984204145,
-            "L": 984204989,
-            "o": "38231.29000000",
-            "c": "38183.30000000",
-            "h": "38289.46000000",
-            "l": "38173.86000000",
-            "v": "33.11807500",
-            "n": 845,
-            "x": false,
-            "q": "1266651.10253383",
-            "V": "16.86697300",
-            "Q": "645184.61913219",
-            "B": "0"
-          }
+          e: 'kline',
+          E: 1627993846810,
+          s: 'BTCUSDT',
+          k: {
+            t: 1627993800000,
+            T: 1627993859999,
+            s: 'BTCUSDT',
+            i: '1m',
+            f: 984204145,
+            L: 984204989,
+            o: '38231.29000000',
+            c: '38183.30000000',
+            h: '38289.46000000',
+            l: '38173.86000000',
+            v: '33.11807500',
+            n: 845,
+            x: false,
+            q: '1266651.10253383',
+            V: '16.86697300',
+            Q: '645184.61913219',
+            B: '0',
+          },
         };
 
         expect(beautifier.beautifyWsMessage(data, data.e)).toStrictEqual({
@@ -87,22 +85,22 @@ describe('Beautifier', () => {
             quoteVolume: 1266651.10253383,
             volumeActive: 16.866973,
             quoteVolumeActive: 645184.61913219,
-            ignored: 0
-          }
+            ignored: 0,
+          },
         });
       });
 
       it('should beautify 24hrMiniTicker events', () => {
         const data = {
-          "e": "24hrMiniTicker",
-          "E": 1627994248076,
-          "s": "BTCUSDT",
-          "c": "38217.55000000",
-          "o": "39271.61000000",
-          "h": "39975.96000000",
-          "l": "37703.75000000",
-          "v": "54555.81687900",
-          "q": "2122507393.62996085"
+          e: '24hrMiniTicker',
+          E: 1627994248076,
+          s: 'BTCUSDT',
+          c: '38217.55000000',
+          o: '39271.61000000',
+          h: '39975.96000000',
+          l: '37703.75000000',
+          v: '54555.81687900',
+          q: '2122507393.62996085',
         };
 
         expect(beautifier.beautifyWsMessage(data, data.e)).toStrictEqual({
@@ -114,48 +112,50 @@ describe('Beautifier', () => {
           high: 39975.96,
           low: 37703.75,
           baseAssetVolume: 54555.816879,
-          quoteAssetVolume: 2122507393.6299608
+          quoteAssetVolume: 2122507393.6299608,
         });
       });
 
       it('should beautify 24hrMiniTicker all symbol events', () => {
         const data = [
           {
-            "e": "24hrMiniTicker",
-            "E": 1627994306672,
-            "s": "ETHBTC",
-            "c": "0.06501800",
-            "o": "0.06576700",
-            "h": "0.06705000",
-            "l": "0.06382900",
-            "v": "156839.07700000",
-            "q": "10299.90420965"
+            e: '24hrMiniTicker',
+            E: 1627994306672,
+            s: 'ETHBTC',
+            c: '0.06501800',
+            o: '0.06576700',
+            h: '0.06705000',
+            l: '0.06382900',
+            v: '156839.07700000',
+            q: '10299.90420965',
           },
           {
-            "e": "24hrMiniTicker",
-            "E": 1627994306107,
-            "s": "BNBBTC",
-            "c": "0.00839200",
-            "o": "0.00840100",
-            "h": "0.00850000",
-            "l": "0.00834000",
-            "v": "112382.00000000",
-            "q": "945.41430656"
+            e: '24hrMiniTicker',
+            E: 1627994306107,
+            s: 'BNBBTC',
+            c: '0.00839200',
+            o: '0.00840100',
+            h: '0.00850000',
+            l: '0.00834000',
+            v: '112382.00000000',
+            q: '945.41430656',
           },
           {
-            "e": "24hrMiniTicker",
-            "E": 1627994306673,
-            "s": "BTCUSDT",
-            "c": "38212.23000000",
-            "o": "39306.52000000",
-            "h": "39975.96000000",
-            "l": "37703.75000000",
-            "v": "54532.31780600",
-            "q": "2121553403.37109243"
+            e: '24hrMiniTicker',
+            E: 1627994306673,
+            s: 'BTCUSDT',
+            c: '38212.23000000',
+            o: '39306.52000000',
+            h: '39975.96000000',
+            l: '37703.75000000',
+            v: '54532.31780600',
+            q: '2121553403.37109243',
           },
-        ]
+        ];
 
-        expect(beautifier.beautifyWsMessage(data, '24hrMiniTicker')).toStrictEqual([
+        expect(
+          beautifier.beautifyWsMessage(data, '24hrMiniTicker')
+        ).toStrictEqual([
           {
             eventType: '24hrMiniTicker',
             eventTime: 1627994306672,
@@ -165,7 +165,7 @@ describe('Beautifier', () => {
             high: 0.06705,
             low: 0.063829,
             baseAssetVolume: 156839.077,
-            quoteAssetVolume: 10299.90420965
+            quoteAssetVolume: 10299.90420965,
           },
           {
             eventType: '24hrMiniTicker',
@@ -176,7 +176,7 @@ describe('Beautifier', () => {
             high: 0.0085,
             low: 0.00834,
             baseAssetVolume: 112382,
-            quoteAssetVolume: 945.41430656
+            quoteAssetVolume: 945.41430656,
           },
           {
             eventType: '24hrMiniTicker',
@@ -187,36 +187,36 @@ describe('Beautifier', () => {
             high: 39975.96,
             low: 37703.75,
             baseAssetVolume: 54532.317806,
-            quoteAssetVolume: 2121553403.3710923
+            quoteAssetVolume: 2121553403.3710923,
           },
         ]);
       });
 
       it('should beautify 24hrTicker events', () => {
         const data = {
-          "e": "24hrTicker",
-          "E": 1627994384253,
-          "s": "BTCUSDT",
-          "p": "-1054.78000000",
-          "P": "-2.686",
-          "w": "38902.78793106",
-          "x": "39274.76000000",
-          "c": "38219.99000000",
-          "Q": "0.00101200",
-          "b": "38219.99000000",
-          "B": "1.94645600",
-          "a": "38220.00000000",
-          "A": "1.23539400",
-          "o": "39274.77000000",
-          "h": "39975.96000000",
-          "l": "37703.75000000",
-          "v": "54506.92287400",
-          "q": "2120471261.34204991",
-          "O": 1627907984234,
-          "C": 1627994384234,
-          "F": 982914985,
-          "L": 984213577,
-          "n": 1298593
+          e: '24hrTicker',
+          E: 1627994384253,
+          s: 'BTCUSDT',
+          p: '-1054.78000000',
+          P: '-2.686',
+          w: '38902.78793106',
+          x: '39274.76000000',
+          c: '38219.99000000',
+          Q: '0.00101200',
+          b: '38219.99000000',
+          B: '1.94645600',
+          a: '38220.00000000',
+          A: '1.23539400',
+          o: '39274.77000000',
+          h: '39975.96000000',
+          l: '37703.75000000',
+          v: '54506.92287400',
+          q: '2120471261.34204991',
+          O: 1627907984234,
+          C: 1627994384234,
+          F: 982914985,
+          L: 984213577,
+          n: 1298593,
         };
 
         expect(beautifier.beautifyWsMessage(data, data.e)).toStrictEqual({
@@ -242,177 +242,177 @@ describe('Beautifier', () => {
           closeTime: 1627994384234,
           firstTradeId: 982914985,
           lastTradeId: 984213577,
-          trades: 1298593
+          trades: 1298593,
         });
       });
 
       it('should beautify 24hrTicker all symbol events', () => {
         const data = [
           {
-            "e": "24hrTicker",
-            "E": 1627994408906,
-            "s": "UTKBTC",
-            "p": "0.00000013",
-            "P": "2.253",
-            "w": "0.00000595",
-            "x": "0.00000577",
-            "c": "0.00000590",
-            "Q": "8593.00000000",
-            "b": "0.00000589",
-            "B": "758.00000000",
-            "a": "0.00000590",
-            "A": "970.00000000",
-            "o": "0.00000577",
-            "h": "0.00000610",
-            "l": "0.00000575",
-            "v": "4838353.00000000",
-            "q": "28.78631787",
-            "O": 1627908003242,
-            "C": 1627994403242,
-            "F": 4024646,
-            "L": 4033272,
-            "n": 8627
+            e: '24hrTicker',
+            E: 1627994408906,
+            s: 'UTKBTC',
+            p: '0.00000013',
+            P: '2.253',
+            w: '0.00000595',
+            x: '0.00000577',
+            c: '0.00000590',
+            Q: '8593.00000000',
+            b: '0.00000589',
+            B: '758.00000000',
+            a: '0.00000590',
+            A: '970.00000000',
+            o: '0.00000577',
+            h: '0.00000610',
+            l: '0.00000575',
+            v: '4838353.00000000',
+            q: '28.78631787',
+            O: 1627908003242,
+            C: 1627994403242,
+            F: 4024646,
+            L: 4033272,
+            n: 8627,
           },
           {
-            "e": "24hrTicker",
-            "E": 1627994408834,
-            "s": "UTKUSDT",
-            "p": "-0.00060000",
-            "P": "-0.265",
-            "w": "0.23314481",
-            "x": "0.22690000",
-            "c": "0.22590000",
-            "Q": "31545.88000000",
-            "b": "0.22480000",
-            "B": "3452.34000000",
-            "a": "0.22590000",
-            "A": "2785.09000000",
-            "o": "0.22650000",
-            "h": "0.23970000",
-            "l": "0.22110000",
-            "v": "35221260.64000000",
-            "q": "8211654.05509200",
-            "O": 1627908008833,
-            "C": 1627994408833,
-            "F": 8308830,
-            "L": 8328242,
-            "n": 19413
+            e: '24hrTicker',
+            E: 1627994408834,
+            s: 'UTKUSDT',
+            p: '-0.00060000',
+            P: '-0.265',
+            w: '0.23314481',
+            x: '0.22690000',
+            c: '0.22590000',
+            Q: '31545.88000000',
+            b: '0.22480000',
+            B: '3452.34000000',
+            a: '0.22590000',
+            A: '2785.09000000',
+            o: '0.22650000',
+            h: '0.23970000',
+            l: '0.22110000',
+            v: '35221260.64000000',
+            q: '8211654.05509200',
+            O: 1627908008833,
+            C: 1627994408833,
+            F: 8308830,
+            L: 8328242,
+            n: 19413,
           },
           {
-            "e": "24hrTicker",
-            "E": 1627994409083,
-            "s": "XVSBTC",
-            "p": "-0.00001520",
-            "P": "-2.130",
-            "w": "0.00070793",
-            "x": "0.00071340",
-            "c": "0.00069850",
-            "Q": "1.58000000",
-            "b": "0.00069730",
-            "B": "6.00000000",
-            "a": "0.00069880",
-            "A": "56.71000000",
-            "o": "0.00071370",
-            "h": "0.00072530",
-            "l": "0.00068860",
-            "v": "40016.02000000",
-            "q": "28.32839274",
-            "O": 1627908009083,
-            "C": 1627994409083,
-            "F": 7524053,
-            "L": 7530455,
-            "n": 6403
+            e: '24hrTicker',
+            E: 1627994409083,
+            s: 'XVSBTC',
+            p: '-0.00001520',
+            P: '-2.130',
+            w: '0.00070793',
+            x: '0.00071340',
+            c: '0.00069850',
+            Q: '1.58000000',
+            b: '0.00069730',
+            B: '6.00000000',
+            a: '0.00069880',
+            A: '56.71000000',
+            o: '0.00071370',
+            h: '0.00072530',
+            l: '0.00068860',
+            v: '40016.02000000',
+            q: '28.32839274',
+            O: 1627908009083,
+            C: 1627994409083,
+            F: 7524053,
+            L: 7530455,
+            n: 6403,
           },
         ];
 
         expect(beautifier.beautifyWsMessage(data, '24hrTicker')).toStrictEqual([
           {
-            "baseAssetVolume": 4838353,
-            "bestAskPrice": 5.9e-06,
-            "bestAskQuantity": 970,
-            "bestBid": 5.89e-06,
-            "bestBidQuantity": 758,
-            "closeQuantity": 8593,
-            "closeTime": 1627994403242,
-            "currentClose": 5.9e-06,
-            "eventTime": 1627994408906,
-            "eventType": "24hrTicker",
-            "firstTradeId": 4024646,
-            "high": 6.1e-06,
-            "lastTradeId": 4033272,
-            "low": 5.75e-06,
-            "open": 5.77e-06,
-            "openTime": 1627908003242,
-            "previousClose": 5.77e-06,
-            "priceChange": 1.3e-07,
-            "priceChangePercent": 2.253,
-            "quoteAssetVolume": 28.78631787,
-            "symbol": "UTKBTC",
-            "trades": 8627,
-            "weightedAveragePrice": 5.95e-06
+            baseAssetVolume: 4838353,
+            bestAskPrice: 5.9e-6,
+            bestAskQuantity: 970,
+            bestBid: 5.89e-6,
+            bestBidQuantity: 758,
+            closeQuantity: 8593,
+            closeTime: 1627994403242,
+            currentClose: 5.9e-6,
+            eventTime: 1627994408906,
+            eventType: '24hrTicker',
+            firstTradeId: 4024646,
+            high: 6.1e-6,
+            lastTradeId: 4033272,
+            low: 5.75e-6,
+            open: 5.77e-6,
+            openTime: 1627908003242,
+            previousClose: 5.77e-6,
+            priceChange: 1.3e-7,
+            priceChangePercent: 2.253,
+            quoteAssetVolume: 28.78631787,
+            symbol: 'UTKBTC',
+            trades: 8627,
+            weightedAveragePrice: 5.95e-6,
           },
           {
-            "baseAssetVolume": 35221260.64,
-            "bestAskPrice": 0.2259,
-            "bestAskQuantity": 2785.09,
-            "bestBid": 0.2248,
-            "bestBidQuantity": 3452.34,
-            "closeQuantity": 31545.88,
-            "closeTime": 1627994408833,
-            "currentClose": 0.2259,
-            "eventTime": 1627994408834,
-            "eventType": "24hrTicker",
-            "firstTradeId": 8308830,
-            "high": 0.2397,
-            "lastTradeId": 8328242,
-            "low": 0.2211,
-            "open": 0.2265,
-            "openTime": 1627908008833,
-            "previousClose": 0.2269,
-            "priceChange": -0.0006,
-            "priceChangePercent": -0.265,
-            "quoteAssetVolume": 8211654.055092,
-            "symbol": "UTKUSDT",
-            "trades": 19413,
-            "weightedAveragePrice": 0.23314481
+            baseAssetVolume: 35221260.64,
+            bestAskPrice: 0.2259,
+            bestAskQuantity: 2785.09,
+            bestBid: 0.2248,
+            bestBidQuantity: 3452.34,
+            closeQuantity: 31545.88,
+            closeTime: 1627994408833,
+            currentClose: 0.2259,
+            eventTime: 1627994408834,
+            eventType: '24hrTicker',
+            firstTradeId: 8308830,
+            high: 0.2397,
+            lastTradeId: 8328242,
+            low: 0.2211,
+            open: 0.2265,
+            openTime: 1627908008833,
+            previousClose: 0.2269,
+            priceChange: -0.0006,
+            priceChangePercent: -0.265,
+            quoteAssetVolume: 8211654.055092,
+            symbol: 'UTKUSDT',
+            trades: 19413,
+            weightedAveragePrice: 0.23314481,
           },
           {
-            "baseAssetVolume": 40016.02,
-            "bestAskPrice": 0.0006988,
-            "bestAskQuantity": 56.71,
-            "bestBid": 0.0006973,
-            "bestBidQuantity": 6,
-            "closeQuantity": 1.58,
-            "closeTime": 1627994409083,
-            "currentClose": 0.0006985,
-            "eventTime": 1627994409083,
-            "eventType": "24hrTicker",
-            "firstTradeId": 7524053,
-            "high": 0.0007253,
-            "lastTradeId": 7530455,
-            "low": 0.0006886,
-            "open": 0.0007137,
-            "openTime": 1627908009083,
-            "previousClose": 0.0007134,
-            "priceChange": -1.52e-05,
-            "priceChangePercent": -2.13,
-            "quoteAssetVolume": 28.32839274,
-            "symbol": "XVSBTC",
-            "trades": 6403,
-            "weightedAveragePrice": 0.00070793
-          }
+            baseAssetVolume: 40016.02,
+            bestAskPrice: 0.0006988,
+            bestAskQuantity: 56.71,
+            bestBid: 0.0006973,
+            bestBidQuantity: 6,
+            closeQuantity: 1.58,
+            closeTime: 1627994409083,
+            currentClose: 0.0006985,
+            eventTime: 1627994409083,
+            eventType: '24hrTicker',
+            firstTradeId: 7524053,
+            high: 0.0007253,
+            lastTradeId: 7530455,
+            low: 0.0006886,
+            open: 0.0007137,
+            openTime: 1627908009083,
+            previousClose: 0.0007134,
+            priceChange: -1.52e-5,
+            priceChangePercent: -2.13,
+            quoteAssetVolume: 28.32839274,
+            symbol: 'XVSBTC',
+            trades: 6403,
+            weightedAveragePrice: 0.00070793,
+          },
         ]);
       });
 
       it('should beautify bookTicker events', () => {
         const data = {
-          "u": 12750097085,
-          "s": "BTCUSDT",
-          "b": "38296.94000000",
-          "B": "0.71796900",
-          "a": "38296.95000000",
-          "A": "0.34349700",
-          "e": "bookTicker"
+          u: 12750097085,
+          s: 'BTCUSDT',
+          b: '38296.94000000',
+          B: '0.71796900',
+          a: '38296.95000000',
+          A: '0.34349700',
+          e: 'bookTicker',
         };
 
         expect(beautifier.beautifyWsMessage(data, data.e)).toStrictEqual({
@@ -422,123 +422,69 @@ describe('Beautifier', () => {
           bidQty: 0.717969,
           askPrice: 38296.95,
           askQty: 0.343497,
-          eventType: 'bookTicker'
+          eventType: 'bookTicker',
         });
       });
 
       it('should beautify partialBookDepth events', () => {
         const data = {
-          "lastUpdateId": 12750129092,
-          "bids": [
-            [
-              "38272.32000000",
-              "0.00850000"
-            ],
-            [
-              "38270.02000000",
-              "0.08895200"
-            ],
-            [
-              "38270.01000000",
-              "0.00734100"
-            ],
-            [
-              "38270.00000000",
-              "0.01246300"
-            ],
-            [
-              "38267.97000000",
-              "0.00052200"
-            ]
+          lastUpdateId: 12750129092,
+          bids: [
+            ['38272.32000000', '0.00850000'],
+            ['38270.02000000', '0.08895200'],
+            ['38270.01000000', '0.00734100'],
+            ['38270.00000000', '0.01246300'],
+            ['38267.97000000', '0.00052200'],
           ],
-          "asks": [
-            [
-              "38272.33000000",
-              "0.32766000"
-            ],
-            [
-              "38272.38000000",
-              "0.32922300"
-            ],
-            [
-              "38272.40000000",
-              "0.28970300"
-            ],
-            [
-              "38275.68000000",
-              "0.00106700"
-            ],
-            [
-              "38275.69000000",
-              "0.08593700"
-            ]
+          asks: [
+            ['38272.33000000', '0.32766000'],
+            ['38272.38000000', '0.32922300'],
+            ['38272.40000000', '0.28970300'],
+            ['38275.68000000', '0.00106700'],
+            ['38275.69000000', '0.08593700'],
           ],
-          "e": "partialBookDepth"
+          e: 'partialBookDepth',
         };
 
         expect(beautifier.beautifyWsMessage(data, data.e)).toStrictEqual({
           lastUpdateId: 12750129092,
           bids: [
-            [ 38272.32, 0.0085 ],
-            [ 38270.02, 0.088952 ],
-            [ 38270.01, 0.007341 ],
-            [ 38270, 0.012463 ],
-            [ 38267.97, 0.000522 ]
+            [38272.32, 0.0085],
+            [38270.02, 0.088952],
+            [38270.01, 0.007341],
+            [38270, 0.012463],
+            [38267.97, 0.000522],
           ],
           asks: [
-            [ 38272.33, 0.32766 ],
-            [ 38272.38, 0.329223 ],
-            [ 38272.4, 0.289703 ],
-            [ 38275.68, 0.001067 ],
-            [ 38275.69, 0.085937 ]
+            [38272.33, 0.32766],
+            [38272.38, 0.329223],
+            [38272.4, 0.289703],
+            [38275.68, 0.001067],
+            [38275.69, 0.085937],
           ],
-          eventType: 'partialBookDepth'
+          eventType: 'partialBookDepth',
         });
       });
 
       it('should beautify depthUpdate events', () => {
         const data = {
-          "e": "depthUpdate",
-          "E": 1627994647377,
-          "s": "BTCUSDT",
-          "U": 12750140450,
-          "u": 12750140682,
-          "b": [
-            [
-              "38325.86000000",
-              "2.38819400"
-            ],
-            [
-              "38324.50000000",
-              "0.00106600"
-            ],
-            [
-              "38324.49000000",
-              "0.00000000"
-            ],
-            [
-              "38324.48000000",
-              "0.35000000"
-            ],
+          e: 'depthUpdate',
+          E: 1627994647377,
+          s: 'BTCUSDT',
+          U: 12750140450,
+          u: 12750140682,
+          b: [
+            ['38325.86000000', '2.38819400'],
+            ['38324.50000000', '0.00106600'],
+            ['38324.49000000', '0.00000000'],
+            ['38324.48000000', '0.35000000'],
           ],
-          "a": [
-            [
-              "38324.48000000",
-              "0.00000000"
-            ],
-            [
-              "38324.49000000",
-              "0.00000000"
-            ],
-            [
-              "38325.87000000",
-              "0.00452300"
-            ],
-            [
-              "38325.88000000",
-              "0.00000000"
-            ],
-          ]
+          a: [
+            ['38324.48000000', '0.00000000'],
+            ['38324.49000000', '0.00000000'],
+            ['38325.87000000', '0.00452300'],
+            ['38325.88000000', '0.00000000'],
+          ],
         };
 
         expect(beautifier.beautifyWsMessage(data, data.e)).toStrictEqual({
@@ -558,44 +504,44 @@ describe('Beautifier', () => {
             { price: 38324.49, quantity: 0 },
             { price: 38325.87, quantity: 0.004523 },
             { price: 38325.88, quantity: 0 },
-          ]
+          ],
         });
       });
 
       it('should beautify executionReport events', () => {
         const data = {
-          "e": "executionReport",
-          "E": 1627996666867,
-          "s": "1INCHUSDT",
-          "c": "web_1efb8fe046a14c8cb9b354322955249f",
-          "S": "BUY",
-          "o": "LIMIT",
-          "f": "GTC",
-          "q": "25.00000000",
-          "p": "1.50000000",
-          "P": "0.00000000",
-          "F": "0.00000000",
-          "g": -1,
-          "C": "web_a3d0420cfda744e5a303bcb5c62427a5",
-          "x": "CANCELED",
-          "X": "CANCELED",
-          "r": "NONE",
-          "i": 357107943,
-          "l": "0.00000000",
-          "z": "0.00000000",
-          "L": "0.00000000",
-          "n": "0",
-          "N": null,
-          "T": 1627996666866,
-          "t": -1,
-          "I": 744909634,
-          "w": false,
-          "m": false,
-          "M": false,
-          "O": 1627996656511,
-          "Z": "0.00000000",
-          "Y": "0.00000000",
-          "Q": "0.00000000"
+          e: 'executionReport',
+          E: 1627996666867,
+          s: '1INCHUSDT',
+          c: 'web_1efb8fe046a14c8cb9b354322955249f',
+          S: 'BUY',
+          o: 'LIMIT',
+          f: 'GTC',
+          q: '25.00000000',
+          p: '1.50000000',
+          P: '0.00000000',
+          F: '0.00000000',
+          g: -1,
+          C: 'web_a3d0420cfda744e5a303bcb5c62427a5',
+          x: 'CANCELED',
+          X: 'CANCELED',
+          r: 'NONE',
+          i: 357107943,
+          l: '0.00000000',
+          z: '0.00000000',
+          L: '0.00000000',
+          n: '0',
+          N: null,
+          T: 1627996666866,
+          t: -1,
+          I: 744909634,
+          w: false,
+          m: false,
+          M: false,
+          O: 1627996656511,
+          Z: '0.00000000',
+          Y: '0.00000000',
+          Q: '0.00000000',
         };
 
         expect(beautifier.beautifyWsMessage(data, data.e)).toStrictEqual({
@@ -628,34 +574,34 @@ describe('Beautifier', () => {
           isMaker: false,
           ignoreThis2: false,
           orderCreationTime: 1627996656511,
-          cumulativeQuoteAssetTransactedQty: 0,
+          cummulativeQuoteAssetTransactedQty: 0,
           lastQuoteAssetTransactedQty: 0,
-          orderQuoteQty: 0
+          orderQuoteQty: 0,
         });
       });
 
       it('should beautify spot outboundAccountPosition events', () => {
         const data = {
-          "e": "outboundAccountPosition",
-          "E": 1627984442064,
-          "u": 1627984442064,
-          "B": [
+          e: 'outboundAccountPosition',
+          E: 1627984442064,
+          u: 1627984442064,
+          B: [
             {
-              "a": "BNB",
-              "f": "0.21811546",
-              "l": "0.00000000"
+              a: 'BNB',
+              f: '0.21811546',
+              l: '0.00000000',
             },
             {
-              "a": "USDT",
-              "f": "542.02628447",
-              "l": "37.50000000"
+              a: 'USDT',
+              f: '542.02628447',
+              l: '37.50000000',
             },
             {
-              "a": "1INCH",
-              "f": "0.00116000",
-              "l": "0.00000000"
-            }
-          ]
+              a: '1INCH',
+              f: '0.00116000',
+              l: '0.00000000',
+            },
+          ],
         };
 
         expect(beautifier.beautifyWsMessage(data, data.e)).toStrictEqual({
@@ -671,11 +617,11 @@ describe('Beautifier', () => {
             {
               asset: 'USDT',
               availableBalance: 542.02628447,
-              onOrderBalance: 37.50000000,
+              onOrderBalance: 37.5,
             },
             {
               asset: '1INCH',
-              availableBalance: 0.00116000,
+              availableBalance: 0.00116,
               onOrderBalance: 0,
             },
           ],
@@ -684,11 +630,11 @@ describe('Beautifier', () => {
 
       it('should beautify spot balanceUpdate events', () => {
         const data = {
-          "e": "balanceUpdate",         //Event Type
-          "E": 1573200697110,           //Event Time
-          "a": "BTC",                   //Asset
-          "d": "100.00000000",          //Balance Delta
-          "T": 1573200697068            //Clear Time
+          e: 'balanceUpdate', //Event Type
+          E: 1573200697110, //Event Time
+          a: 'BTC', //Asset
+          d: '100.00000000', //Balance Delta
+          T: 1573200697068, //Clear Time
         };
 
         expect(beautifier.beautifyWsMessage(data, data.e)).toStrictEqual({
@@ -702,28 +648,29 @@ describe('Beautifier', () => {
 
       it('should beautify spot listStatus events', () => {
         const data = {
-          "e": "listStatus",                //Event Type
-          "E": 1564035303637,               //Event Time
-          "s": "ETHBTC",                    //Symbol
-          "g": 2,                           //OrderListId
-          "c": "OCO",                       //Contingency Type
-          "l": "EXEC_STARTED",              //List Status Type
-          "L": "EXECUTING",                 //List Order Status
-          "r": "NONE",                      //List Reject Reason
-          "C": "F4QN4G8DlFATFlIUQ0cjdD",    //List Client Order ID
-          "T": 1564035303625,               //Transaction Time
-          "O": [                            //An array of objects
+          e: 'listStatus', //Event Type
+          E: 1564035303637, //Event Time
+          s: 'ETHBTC', //Symbol
+          g: 2, //OrderListId
+          c: 'OCO', //Contingency Type
+          l: 'EXEC_STARTED', //List Status Type
+          L: 'EXECUTING', //List Order Status
+          r: 'NONE', //List Reject Reason
+          C: 'F4QN4G8DlFATFlIUQ0cjdD', //List Client Order ID
+          T: 1564035303625, //Transaction Time
+          O: [
+            //An array of objects
             {
-              "s": "ETHBTC",                //Symbol
-              "i": 17,                      // orderId
-              "c": "AJYsMjErWJesZvqlJCTUgL" //ClientOrderId
+              s: 'ETHBTC', //Symbol
+              i: 17, // orderId
+              c: 'AJYsMjErWJesZvqlJCTUgL', //ClientOrderId
             },
             {
-              "s": "ETHBTC",
-              "i": 18,
-              "c": "bfYPSQdLoqAJeNrOr9adzq"
-            }
-          ]
+              s: 'ETHBTC',
+              i: 18,
+              c: 'bfYPSQdLoqAJeNrOr9adzq',
+            },
+          ],
         };
 
         expect(beautifier.beautifyWsMessage(data, data.e)).toStrictEqual({
@@ -747,219 +694,219 @@ describe('Beautifier', () => {
               symbol: data.O[1].s,
               orderId: data.O[1].i,
               clientOrderId: data.O[1].c,
-            }
-          ]
+            },
+          ],
         });
       });
 
       it('should beautify USDM futures ACCOUNT_UPDATE events', () => {
         const data = {
-          "e": "ACCOUNT_UPDATE",
-          "T": 1628067033652,
-          "E": 1628067033658,
-          "a": {
-            "B": [
+          e: 'ACCOUNT_UPDATE',
+          T: 1628067033652,
+          E: 1628067033658,
+          a: {
+            B: [
               {
-                "a": "USDT",
-                "wb": "16.35030230",
-                "cw": "16.35030230",
-                "bc": "0.00012480"
-              }
+                a: 'USDT',
+                wb: '16.35030230',
+                cw: '16.35030230',
+                bc: '0.00012480',
+              },
             ],
-            "P": [],
-            "m": "ADMIN_DEPOSIT"
-          }
+            P: [],
+            m: 'ADMIN_DEPOSIT',
+          },
         };
 
         expect(beautifier.beautifyWsMessage(data, data.e)).toStrictEqual({
-          "eventTime": 1628067033658,
-          "eventType": "ACCOUNT_UPDATE",
-          "transactionId": 1628067033652,
-          "updateData": {
-            "updateEventType": "ADMIN_DEPOSIT",
-            "updatedBalances": [
+          eventTime: 1628067033658,
+          eventType: 'ACCOUNT_UPDATE',
+          transactionId: 1628067033652,
+          updateData: {
+            updateEventType: 'ADMIN_DEPOSIT',
+            updatedBalances: [
               {
-                "asset": "USDT",
-                "balanceChange": 0.0001248,
-                "crossWalletBalance": 16.3503023,
-                "walletBalance": 16.3503023,
+                asset: 'USDT',
+                balanceChange: 0.0001248,
+                crossWalletBalance: 16.3503023,
+                walletBalance: 16.3503023,
               },
             ],
-            "updatedPositions": [],
+            updatedPositions: [],
           },
         });
       });
 
       it('should beautify USDM futures MARGIN_CALL events', () => {
         const data = {
-          "e":"MARGIN_CALL",      // Event Type
-          "E":1587727187525,      // Event Time
-          "cw":"3.16812045",      // Cross Wallet Balance. Only pushed with crossed position margin call
-          "p":[                   // Position(s) of Margin Call
+          e: 'MARGIN_CALL', // Event Type
+          E: 1587727187525, // Event Time
+          cw: '3.16812045', // Cross Wallet Balance. Only pushed with crossed position margin call
+          p: [
+            // Position(s) of Margin Call
             {
-              "s":"ETHUSDT",      // Symbol
-              "ps":"LONG",        // Position Side
-              "pa":"1.327",       // Position Amount
-              "mt":"CROSSED",     // Margin Type
-              "iw":"0",           // Isolated Wallet (if isolated position)
-              "mp":"187.17127",   // Mark Price
-              "up":"-1.166074",   // Unrealized PnL
-              "mm":"1.614445"     // Maintenance Margin Required
-            }
-          ]
-      };
+              s: 'ETHUSDT', // Symbol
+              ps: 'LONG', // Position Side
+              pa: '1.327', // Position Amount
+              mt: 'CROSSED', // Margin Type
+              iw: '0', // Isolated Wallet (if isolated position)
+              mp: '187.17127', // Mark Price
+              up: '-1.166074', // Unrealized PnL
+              mm: '1.614445', // Maintenance Margin Required
+            },
+          ],
+        };
 
         expect(beautifier.beautifyWsMessage(data, data.e)).toStrictEqual({
-          "eventType": "MARGIN_CALL",
-          "eventTime": 1587727187525,
-          "crossWalletBalance": Number(data.cw),
-          "positions": [
+          eventType: 'MARGIN_CALL',
+          eventTime: 1587727187525,
+          crossWalletBalance: Number(data.cw),
+          positions: [
             {
-              "symbol": "ETHUSDT",
-              "positionSide": "LONG",
-              "positionAmount": Number(data.p[0].pa),
-              "marginType": "CROSSED",
-              "isolatedWalletAmount": Number(data.p[0].iw),
-              "markPrice": Number(data.p[0].mp),
-              "unrealisedPnl": Number(data.p[0].up),
-              "maintenanceMarginRequired": Number(data.p[0].mm),
+              symbol: 'ETHUSDT',
+              positionSide: 'LONG',
+              positionAmount: Number(data.p[0].pa),
+              marginType: 'CROSSED',
+              isolatedWalletAmount: Number(data.p[0].iw),
+              markPrice: Number(data.p[0].mp),
+              unrealisedPnl: Number(data.p[0].up),
+              maintenanceMarginRequired: Number(data.p[0].mm),
             },
-          ]
+          ],
         });
       });
 
       it('should beautify USDM futures ORDER_TRADE_UPDATE events', () => {
         const data = {
-          "e":"ORDER_TRADE_UPDATE",     // Event Type
-          "E":1568879465651,            // Event Time
-          "T":1568879465650,            // Transaction Time
-          "o":{
-            "s":"BTCUSDT",              // Symbol
-            "c":"TEST",                 // Client Order Id
-              // special client order id:
-              // starts with "autoclose-": liquidation order
-              // "adl_autoclose": ADL auto close order
-            "S":"SELL",                 // Side
-            "o":"TRAILING_STOP_MARKET", // Order Type
-            "f":"GTC",                  // Time in Force
-            "q":"0.001",                // Original Quantity
-            "p":"0",                    // Original Price
-            "ap":"0",                   // Average Price
-            "sp":"7103.04",             // Stop Price. Please ignore with TRAILING_STOP_MARKET order
-            "x":"NEW",                  // Execution Type
-            "X":"NEW",                  // Order Status
-            "i":8886774,                // Order Id
-            "l":"0",                    // Order Last Filled Quantity
-            "z":"0",                    // Order Filled Accumulated Quantity
-            "L":"0",                    // Last Filled Price
-            "N":"USDT",             // Commission Asset, will not push if no commission
-            "n":"0",                // Commission, will not push if no commission
-            "T":1568879465651,          // Order Trade Time
-            "t":0,                      // Trade Id
-            "b":"0",                    // Bids Notional
-            "a":"9.91",                 // Ask Notional
-            "m":false,                  // Is this trade the maker side?
-            "R":false,                  // Is this reduce only
-            "wt":"CONTRACT_PRICE",      // Stop Price Working Type
-            "ot":"TRAILING_STOP_MARKET",    // Original Order Type
-            "ps":"LONG",                        // Position Side
-            "cp":false,                     // If Close-All, pushed with conditional order
-            "AP":"7476.89",             // Activation Price, only puhed with TRAILING_STOP_MARKET order
-            "cr":"5.0",                 // Callback Rate, only puhed with TRAILING_STOP_MARKET order
-            "rp":"0"                            // Realized Profit of the trade
-          }
+          e: 'ORDER_TRADE_UPDATE', // Event Type
+          E: 1568879465651, // Event Time
+          T: 1568879465650, // Transaction Time
+          o: {
+            s: 'BTCUSDT', // Symbol
+            c: 'TEST', // Client Order Id
+            // special client order id:
+            // starts with "autoclose-": liquidation order
+            // "adl_autoclose": ADL auto close order
+            S: 'SELL', // Side
+            o: 'TRAILING_STOP_MARKET', // Order Type
+            f: 'GTC', // Time in Force
+            q: '0.001', // Original Quantity
+            p: '0', // Original Price
+            ap: '0', // Average Price
+            sp: '7103.04', // Stop Price. Please ignore with TRAILING_STOP_MARKET order
+            x: 'NEW', // Execution Type
+            X: 'NEW', // Order Status
+            i: 8886774, // Order Id
+            l: '0', // Order Last Filled Quantity
+            z: '0', // Order Filled Accumulated Quantity
+            L: '0', // Last Filled Price
+            N: 'USDT', // Commission Asset, will not push if no commission
+            n: '0', // Commission, will not push if no commission
+            T: 1568879465651, // Order Trade Time
+            t: 0, // Trade Id
+            b: '0', // Bids Notional
+            a: '9.91', // Ask Notional
+            m: false, // Is this trade the maker side?
+            R: false, // Is this reduce only
+            wt: 'CONTRACT_PRICE', // Stop Price Working Type
+            ot: 'TRAILING_STOP_MARKET', // Original Order Type
+            ps: 'LONG', // Position Side
+            cp: false, // If Close-All, pushed with conditional order
+            AP: '7476.89', // Activation Price, only puhed with TRAILING_STOP_MARKET order
+            cr: '5.0', // Callback Rate, only puhed with TRAILING_STOP_MARKET order
+            rp: '0', // Realized Profit of the trade
+          },
         };
 
         expect(beautifier.beautifyWsMessage(data, data.e)).toStrictEqual({
-          "eventTime": 1568879465651,
-          "eventType": "ORDER_TRADE_UPDATE",
-          "order": {
-            "asksNotional": 9.91,
-            "averagePrice": 0,
-            "bidsNotional": 0,
-            "clientOrderId": "TEST",
-            "commissionAmount": 0,
-            "commissionAsset": "USDT",
-            "executionType": "NEW",
-            "isCloseAll": false,
-            "isMakerTrade": false,
-            "isReduceOnly": false,
-            "lastFilledPrice": 0,
-            "lastFilledQuantity": 0,
-            "orderFilledAccumulatedQuantity": 0,
-            "orderId": 8886774,
-            "orderSide": "SELL",
-            "orderStatus": "NEW",
-            "orderTradeTime": 1568879465651,
-            "orderType": "TRAILING_STOP_MARKET",
-            "originalOrderType": "TRAILING_STOP_MARKET",
-            "originalPrice": 0,
-            "originalQuantity": 0.001,
-            "positionSide": "LONG",
-            "realisedProfit": 0,
-            "stopPrice": 7103.04,
-            "stopPriceWorkingType": "CONTRACT_PRICE",
-            "symbol": "BTCUSDT",
-            "timeInForce": "GTC",
-            "tradeId": 0,
-            "trailingStopActivationPrice": 7476.89,
-            "trailingStopCallbackRate": 5,
+          eventTime: 1568879465651,
+          eventType: 'ORDER_TRADE_UPDATE',
+          order: {
+            asksNotional: 9.91,
+            averagePrice: 0,
+            bidsNotional: 0,
+            clientOrderId: 'TEST',
+            commissionAmount: 0,
+            commissionAsset: 'USDT',
+            executionType: 'NEW',
+            isCloseAll: false,
+            isMakerTrade: false,
+            isReduceOnly: false,
+            lastFilledPrice: 0,
+            lastFilledQuantity: 0,
+            orderFilledAccumulatedQuantity: 0,
+            orderId: 8886774,
+            orderSide: 'SELL',
+            orderStatus: 'NEW',
+            orderTradeTime: 1568879465651,
+            orderType: 'TRAILING_STOP_MARKET',
+            originalOrderType: 'TRAILING_STOP_MARKET',
+            originalPrice: 0,
+            originalQuantity: 0.001,
+            positionSide: 'LONG',
+            realisedProfit: 0,
+            stopPrice: 7103.04,
+            stopPriceWorkingType: 'CONTRACT_PRICE',
+            symbol: 'BTCUSDT',
+            timeInForce: 'GTC',
+            tradeId: 0,
+            trailingStopActivationPrice: 7476.89,
+            trailingStopCallbackRate: 5,
           },
-          "transactionTime": 1568879465650,
+          transactionTime: 1568879465650,
         });
       });
 
       it('should beautify USDM futures ACCOUNT_CONFIG_UPDATE events', () => {
         const data = {
-          "e":"ACCOUNT_CONFIG_UPDATE",       // Event Type
-          "E":1611646737479,                 // Event Time
-          "T":1611646737476,                 // Transaction Time
-          "ac":{
-            "s":"BTCUSDT",                     // symbol
-            "l":25                             // leverage
+          e: 'ACCOUNT_CONFIG_UPDATE', // Event Type
+          E: 1611646737479, // Event Time
+          T: 1611646737476, // Transaction Time
+          ac: {
+            s: 'BTCUSDT', // symbol
+            l: 25, // leverage
           },
-          'ai': {
+          ai: {
             j: true,
-          }
+          },
         };
 
         expect(beautifier.beautifyWsMessage(data, data.e)).toStrictEqual({
-          eventType: "ACCOUNT_CONFIG_UPDATE",
+          eventType: 'ACCOUNT_CONFIG_UPDATE',
           eventTime: data.E,
           transactionTime: data.T,
           assetConfiguration: {
-            symbol: "BTCUSDT",
+            symbol: 'BTCUSDT',
             leverage: 25,
           },
           accountConfiguration: {
             isMultiAssetsMode: true,
-          }
+          },
         });
       });
 
       it('should include unrecognised properties as is', () => {
         const data = {
-          "e":"ACCOUNT_CONFIG_UPDATE",       // Event Type
-          "E":1611646737479,                 // Event Time
-          "T":1611646737476,                 // Transaction Time
-          "ac":{
-            "s":"BTCUSDT",                     // symbol
-            "l":25                             // leverage
+          e: 'ACCOUNT_CONFIG_UPDATE', // Event Type
+          E: 1611646737479, // Event Time
+          T: 1611646737476, // Transaction Time
+          ac: {
+            s: 'BTCUSDT', // symbol
+            l: 25, // leverage
           },
-          'ai': {
+          ai: {
             j: true,
             diffProp: 55, // this value was not expected by the beautifier and shoudl be left in touched
           },
-          'unkn': true,// this value was not expected by the beautifier and shoudl be left in touched
-
+          unkn: true, // this value was not expected by the beautifier and shoudl be left in touched
         };
 
         expect(beautifier.beautifyWsMessage(data, data.e)).toStrictEqual({
-          eventType: "ACCOUNT_CONFIG_UPDATE",
+          eventType: 'ACCOUNT_CONFIG_UPDATE',
           eventTime: data.E,
           transactionTime: data.T,
           assetConfiguration: {
-            symbol: "BTCUSDT",
+            symbol: 'BTCUSDT',
             leverage: 25,
           },
           accountConfiguration: {
@@ -980,6 +927,5 @@ describe('Beautifier', () => {
         });
       });
     });
-
   });
 });


### PR DESCRIPTION
## Summary
- Add 1s kline interval to type. Fixes #258.
- Add savings endpoints from #246 (thanks for the initial PR @Mateo-P)
- Migrate ws client updates from bybit connector:
  - Set default handler for internal error event, in case user isn't listening to it. Prevents crashes from missing handler, fixes #248. https://github.com/tiagosiebler/bybit-api/commit/750db0232ca9034b98c8902322c82863449aba2b
  - Improve resilience & stability in reconnect workflows, based on improvements in bybit connector:
    - https://github.com/tiagosiebler/bybit-api/commit/d3b2c65c2260bdceabba3814059f2fd62c0cc000
    - https://github.com/tiagosiebler/bybit-api/commit/7c6d02ea8b86ed898a074683b269384f8300d525
  - Improve type safety around ws client internals (state enum, timer tracking, ws store types)
- Fix "cumulative/cummulative" typo in REST responses for spot

## Breaking Changes
- Disable time sync mechanism by default, in line with my other connectors. Fixes #260 (when caused by the time sync mechanism). This is likely to be deprecated completely in future.
-`cumulativeQuoteAssetTransactedQty` has been renamed to `cummulativeQuoteAssetTransactedQty` in the websocket beautifier. The type has been updated too. Fixes #230. Adopts #225 (thanks @felds for the original PR).
