### PR TITLE
Changed candles to trades in js docs

### DIFF
--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -1479,7 +1479,7 @@ export class WebsocketClient extends EventEmitter {
   }
 
   /**
-   * Subscribe to candles for a symbol in spot markets.
+   * Subscribe to trades for a symbol in spot markets.
    */
   public subscribeSpotTrades(
     symbol: string,


### PR DESCRIPTION
## Summary
Maybe a leftover from a copy and paste of the signature. On `subscribeSpotTrades` the comment says that it subscribes to candles, while instead it should say trades.
