### PR TITLE
Add return type to `getKlines`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "2.1.6",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "2.1.6",
+      "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Node.js connector for Binance's REST APIs and WebSockets, with TypeScript & integration tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -11,6 +11,7 @@ import {
   GetOrderParams,
   HistoricalTradesParams,
   KlinesParams,
+  Kline,
   NewOCOParams,
   OrderBookParams,
   OrderIdProperty,
@@ -688,7 +689,7 @@ export class MainClient extends BaseRestClient {
     return this.get('api/v3/aggTrades', params);
   }
 
-  getKlines(params: KlinesParams): Promise<any> {
+  getKlines(params: KlinesParams): Promise<Kline[]> {
     return this.get('api/v3/klines', params);
   }
 

--- a/src/types/futures.ts
+++ b/src/types/futures.ts
@@ -277,21 +277,6 @@ export interface AggregateFuturesTrade {
   M: boolean;
 }
 
-export type FuturesKline = [
-  number, // open time
-  numberInString, // open
-  numberInString, // high
-  numberInString, // low
-  numberInString, // close
-  numberInString, // volume
-  number, // close time
-  numberInString, // quote asset volume
-  number, // number of trades
-  numberInString, // taker buy base asset vol
-  numberInString, // taker buy quote asest vol
-  numberInString // ignore?
-];
-
 export interface MarkPrice {
   symbol: string;
   markPrice: numberInString;

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -157,6 +157,8 @@ export type Kline = [
   numberInString // ignore?
 ];
 
+/** @deprecated `FuturesKline` will be removed soon. Use `Kline` instead. **/
+export type FuturesKline = Kline;
 export interface RecentTradesParams {
   symbol: string;
   limit?: number;

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -141,6 +141,22 @@ export interface KlinesParams {
   endTime?: number;
   limit?: number;
 }
+
+export type Kline = [
+  number, // open time
+  numberInString, // open
+  numberInString, // high
+  numberInString, // low
+  numberInString, // close
+  numberInString, // volume
+  number, // close time
+  numberInString, // quote asset volume
+  number, // number of trades
+  numberInString, // taker buy base asset vol
+  numberInString, // taker buy quote asset vol
+  numberInString // ignore?
+];
+
 export interface RecentTradesParams {
   symbol: string;
   limit?: number;

--- a/src/usdm-client.ts
+++ b/src/usdm-client.ts
@@ -8,6 +8,7 @@ import {
   OrderBookParams,
   HistoricalTradesParams,
   KlinesParams,
+  Kline,
   RecentTradesParams,
   CancelOrderParams,
   CancelOCOParams,
@@ -37,7 +38,6 @@ import {
   FuturesOrderBook,
   RawFuturesTrade,
   AggregateFuturesTrade,
-  FuturesKline,
   FundingRateHistory,
   FuturesSymbolOrderBookTicker,
   OpenInterest,
@@ -134,23 +134,21 @@ export class USDMClient extends BaseRestClient {
     return this.get('fapi/v1/aggTrades', params);
   }
 
-  getKlines(params: KlinesParams): Promise<FuturesKline[]> {
+  getKlines(params: KlinesParams): Promise<Kline[]> {
     return this.get('fapi/v1/klines', params);
   }
 
   getContinuousContractKlines(
     params: ContinuousContractKlinesParams
-  ): Promise<FuturesKline[]> {
+  ): Promise<Kline[]> {
     return this.get('fapi/v1/continuousKlines', params);
   }
 
-  getIndexPriceKlines(params: IndexPriceKlinesParams): Promise<FuturesKline[]> {
+  getIndexPriceKlines(params: IndexPriceKlinesParams): Promise<Kline[]> {
     return this.get('fapi/v1/indexPriceKlines', params);
   }
 
-  getMarkPriceKlines(
-    params: SymbolKlinePaginatedParams
-  ): Promise<FuturesKline[]> {
+  getMarkPriceKlines(params: SymbolKlinePaginatedParams): Promise<Kline[]> {
     return this.get('fapi/v1/markPriceKlines', params);
   }
 


### PR DESCRIPTION
## Summary
PR adds (reuses from futures) `Kline` type to spot `getKlines` function.