### PR TITLE
Gets sub account transaction history

### DIFF
--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -557,7 +557,7 @@ export class MainClient extends BaseRestClient {
     return this.postPrivate('sapi/v1/broker/subAccount', params);
   }
 
-  GetBrokerSubAccountHistory(
+  getBrokerSubAccountHistory(
     params: GetBrokerSubAccountHistoryParams
   ): Promise<BrokerSubAccountHistory[]> {
     return this.getPrivate('sapi/v1/broker/transfer', params);

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -35,6 +35,7 @@ import {
   BasicSubAccount,
   BasicTimeRangeParam,
   BrokerSubAccount,
+  BrokerSubAccountHistory,
   BSwapLiquidity,
   BSwapOperations,
   BSwapOperationsParams,
@@ -76,6 +77,7 @@ import {
   GetApiKeyBrokerSubAccountParams,
   GetBrokerInfoResponse,
   GetBrokerSubAccountParams,
+  GetBrokerSubAccountHistoryParams,
   GetOCOParams,
   GetUniversalTransferBrokerParams,
   IsolatedMarginAccountInfo,
@@ -168,6 +170,7 @@ import {
   WithdrawHistory,
   WithdrawHistoryParams,
   WithdrawParams,
+  
 } from './types/spot';
 
 import {
@@ -552,6 +555,12 @@ export class MainClient extends BaseRestClient {
     params: CreateBrokerSubAccountParams
   ): Promise<BrokerSubAccount> {
     return this.postPrivate('sapi/v1/broker/subAccount', params);
+  }
+
+  GetBrokerSubAccountHistory(
+    params: GetBrokerSubAccountHistoryParams
+  ): Promise<BrokerSubAccountHistory[]> {
+    return this.getPrivate('sapi/v1/broker/transfer', params);
   }
 
   getBrokerSubAccount(

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -1,4 +1,4 @@
-import { ARNString } from 'aws-sdk/clients/cognitoidentity';
+
 import {
   ExchangeFilter,
   ExchangeSymbol,

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -1,3 +1,4 @@
+import { ARNString } from 'aws-sdk/clients/cognitoidentity';
 import {
   ExchangeFilter,
   ExchangeSymbol,
@@ -811,6 +812,15 @@ export interface SubAccountList {
   isAssetManagementSubAccount: boolean;
 }
 
+export interface SubAccountTransferHistoryList {
+  fromId?: string;
+  toId?: string;
+  startTime?: number;
+  endTime?: number;
+  page?: number;
+  limit?: number;
+}
+
 export interface SubAccountBasicTransfer {
   from: string;
   to: string;
@@ -901,6 +911,15 @@ export interface BasicSubAccount {
 
 export interface CreateSubAccountParams {
   subAccountString: string;
+}
+
+export interface GetBrokerSubAccountHistoryParams {
+  fromId?: string;
+  toId?: string;
+  startTime?: number;
+  endTime?: number;
+  page?: number;
+  limit?: number;
 }
 
 export interface CreateBrokerSubAccountParams {
@@ -1009,6 +1028,10 @@ export interface ChangePermissionApiKeyBrokerSubAccountResponse {
 
 export interface VirtualSubAccount {
   email: string;
+}
+
+export interface BrokerSubAccountHistory {
+  subAccountsHistory: SubAccountTransferHistoryList[]
 }
 
 export interface BrokerSubAccount {


### PR DESCRIPTION
Signed-off-by: MartoMcfly <martinpelaez@hotmail.es>

## Summary
PR contains a feature which allows to to get the transfer history for sub accounts by calling the broker transfer api sapi/v1/broker/transfer

## Additional Information
PR dosent generate any major changes and dosent moddify the behavior of the repo :)
