### PR TITLE
v2.2.10: fix usdm exchange info symbol filter types. add 2 utlility methods for lazy filter lookup on exchange info

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "description": "Node.js connector for Binance's REST APIs and WebSockets, with TypeScript & integration tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,5 @@ export * from './usdm-client';
 export * from './util/requestUtils';
 export * from './util/typeGuards';
 export * from './util/WsStore';
+export * from './util/usdm';
 export * from './websocket-client';

--- a/src/types/futures.ts
+++ b/src/types/futures.ts
@@ -11,7 +11,12 @@ import {
   OrderTimeInForce,
   OrderType,
   RateLimiter,
-  SymbolFilter,
+  SymbolIcebergPartsFilter,
+  SymbolLotSizeFilter,
+  SymbolMarketLotSizeFilter,
+  SymbolMaxIcebergOrdersFilter,
+  SymbolMaxPositionFilter,
+  SymbolPriceFilter,
 } from './shared';
 
 export type FuturesContractType =
@@ -214,6 +219,40 @@ export type ContractStatus =
   | 'SETTLING'
   | 'CLOSE';
 
+export interface FuturesSymbolPercentPriceFilter {
+  filterType: 'PERCENT_PRICE';
+  multiplierUp: numberInString;
+  multiplierDown: numberInString;
+  multiplierDecimal: numberInString;
+}
+
+export interface FuturesSymbolMaxOrdersFilter {
+  filterType: 'MAX_NUM_ORDERS';
+  limit: number;
+}
+
+export interface FuturesSymbolMaxAlgoOrdersFilter {
+  filterType: 'MAX_NUM_ALGO_ORDERS';
+  limit: number;
+}
+
+export interface FuturesSymbolMinNotionalFilter {
+  filterType: 'MIN_NOTIONAL';
+  notional: numberInString;
+}
+
+export type FuturesSymbolFilter =
+  | SymbolPriceFilter
+  | FuturesSymbolPercentPriceFilter
+  | SymbolLotSizeFilter
+  | FuturesSymbolMinNotionalFilter
+  | SymbolIcebergPartsFilter
+  | SymbolMarketLotSizeFilter
+  | FuturesSymbolMaxOrdersFilter
+  | FuturesSymbolMaxAlgoOrdersFilter
+  | SymbolMaxIcebergOrdersFilter
+  | SymbolMaxPositionFilter;
+
 export interface FuturesSymbolExchangeInfo {
   symbol: string;
   pair: string;
@@ -234,7 +273,7 @@ export interface FuturesSymbolExchangeInfo {
   underlyingSubType: string[]; // DEFI / NFT / BSC / HOT / etc
   settlePlan: number;
   triggerProtect: numberInString;
-  filters: SymbolFilter[];
+  filters: FuturesSymbolFilter[];
   OrderType: OrderType[];
   timeInForce: OrderTimeInForce[];
   liquidationFee: numberInString;

--- a/src/util/beautifier.ts
+++ b/src/util/beautifier.ts
@@ -72,6 +72,7 @@ export default class Beautifier {
       'minQty',
       'multiplierDown',
       'multiplierUp',
+      'multiplierDecimal',
       'newTraderRebateCommission',
       'notional',
       'oldTraderRebateCommission',

--- a/src/util/usdm/exchangeInfo.ts
+++ b/src/util/usdm/exchangeInfo.ts
@@ -1,0 +1,43 @@
+import {
+  FuturesExchangeInfo,
+  FuturesSymbolMinNotionalFilter,
+} from '../../types/futures';
+
+/** Get min notional filter for a USDM futures symbol */
+export function getUSDMFuturesSymbolMinNotional(
+  exchangeInfo: FuturesExchangeInfo,
+  symbol: string
+): number | null {
+  const specs = exchangeInfo.symbols.find((sym) => sym.symbol === symbol);
+  if (!specs) {
+    return null;
+  }
+
+  const filterType = 'MIN_NOTIONAL';
+  const filter = specs.filters.find(
+    (filter) => filter.filterType === filterType
+  ) as FuturesSymbolMinNotionalFilter;
+
+  if (!filter) {
+    return null;
+  }
+
+  return Number(filter.notional);
+}
+
+/** Returns an object where keys are USDM Futures symbols and values are min notionals for that symbol */
+export function getUSDMFuturesMinNotionalSymbolMap(
+  exchangeInfo: FuturesExchangeInfo
+): Record<string, number> {
+  const minNotionals = exchangeInfo.symbols.reduce((res, spec) => {
+    const filter = spec.filters.find(
+      (filter) => filter.filterType === 'MIN_NOTIONAL'
+    ) as FuturesSymbolMinNotionalFilter;
+    if (filter) {
+      res[spec.symbol] = filter.notional;
+    }
+    return res;
+  }, {});
+
+  return minNotionals;
+}

--- a/src/util/usdm/index.ts
+++ b/src/util/usdm/index.ts
@@ -1,0 +1,1 @@
+export * from './exchangeInfo';


### PR DESCRIPTION

## Summary
<!-- Add a brief description of the pr: -->
- fix usdm exchange info symbol filter types. 
- add 2 utlility methods for lazy filter lookup on futures exchange info (getUSDMFuturesSymbolMinNotional & getUSDMFuturesMinNotionalSymbolMap)

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
