### PR TITLE
v2.2.11: fix(#290): fixes & improvements for websocket listenkey keep alive failure handling & teardown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "description": "Node.js connector for Binance's REST APIs and WebSockets, with TypeScript & integration tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/util/ws-utils.ts
+++ b/src/util/ws-utils.ts
@@ -1,8 +1,13 @@
 import WebSocket from 'isomorphic-ws';
 
-export function terminateWs(ws: WebSocket | unknown) {
+/**
+ * #168: ws.terminate() is undefined in browsers.
+ * This only works in node.js, not in browsers.
+ * Does nothing if `ws` is undefined.
+ */
+export function safeTerminateWs(ws: WebSocket | unknown) {
   // #168: ws.terminate() undefined in browsers
-  if (typeof ws?.terminate === 'function') {
+  if (typeof ws?.terminate === 'function' && ws) {
     ws.terminate();
   }
 }

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -528,12 +528,12 @@ export class WebsocketClient extends EventEmitter {
     );
 
     this.clearTimers(wsKey);
+    this.getWs(wsKey)?.close();
 
     const { listenKey } = getContextFromWsKey(wsKey);
     if (listenKey) {
       this.teardownUserDataListenKey(listenKey, this.getWs(wsKey));
     } else {
-      this.getWs(wsKey)?.close();
       safeTerminateWs(this.getWs(wsKey));
     }
   }

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -694,6 +694,9 @@ export class WebsocketClient extends EventEmitter {
     }
 
     if (state.keepAliveTimer) {
+      this.logger.silly(
+        `Clearing old listen key interval timer for ${listenKey}`
+      );
       clearInterval(state.keepAliveTimer);
     }
   }
@@ -869,11 +872,10 @@ export class WebsocketClient extends EventEmitter {
     isTestnet?: boolean
   ) {
     const listenKeyState = this.getListenKeyState(listenKey, market);
-    // this.logger.silly(`setKeepAliveListenKeytimer for ${market} listenKey ${wsKey}`);
 
-    if (listenKeyState.keepAliveTimer) {
-      clearInterval(listenKeyState.keepAliveTimer);
-    }
+    this.clearUserDataKeepAliveTimer(listenKey);
+
+    this.logger.silly(`Created new listen key interval timer for ${listenKey}`);
 
     // Set timer to keep WS alive every 50 minutes
     // @ts-ignore
@@ -1799,8 +1801,12 @@ export class WebsocketClient extends EventEmitter {
       const { listenKey } = await restClient.getFuturesUserDataListenKey();
 
       const market: WsMarket = isTestnet ? 'usdmTestnet' : 'usdm';
-      const streamName = 'userData';
-      const wsKey = [market, streamName, listenKey].join('_');
+      const wsKey = getWsKeyWithContext(
+        market,
+        'userData',
+        undefined,
+        listenKey
+      );
 
       if (!forceNewConnection && this.wsStore.isWsConnecting(wsKey)) {
         this.logger.silly(
@@ -1856,8 +1862,12 @@ export class WebsocketClient extends EventEmitter {
       ).getFuturesUserDataListenKey();
 
       const market: WsMarket = isTestnet ? 'coinmTestnet' : 'coinm';
-      const streamName = 'userData';
-      const wsKey = [market, streamName, listenKey].join('_');
+      const wsKey = getWsKeyWithContext(
+        market,
+        'userData',
+        undefined,
+        listenKey
+      );
 
       if (!forceNewConnection && this.wsStore.isWsConnecting(wsKey)) {
         this.logger.silly(


### PR DESCRIPTION
## Summary
- Fix inconsistent wsKey construction for futures user data streams.
- Fix connection teardown/respawn, when listen key keep alive fails repeatedly.
- Fix userdata teardown when close & closeAll() methods are used to close connections.

<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
