### PR TITLE
Add support for RSA Keys

### DIFF
--- a/src/util/node-support.ts
+++ b/src/util/node-support.ts
@@ -1,7 +1,11 @@
-import { createHmac } from 'crypto';
+import { createHmac, createSign } from 'crypto';
 import * as browserMethods from './browser-support';
 
 export async function signMessage(message: string, secret: string): Promise<string> {
+  if (secret.includes('BEGIN PRIVATE KEY') && typeof createSign === 'function') {
+    return createSign('RSA-SHA256').update(message).sign(secret, 'base64');
+  }
+
   if (typeof createHmac === 'function') {
     return createHmac('sha256', secret)
     .update(message)


### PR DESCRIPTION
This PR will add support for RSA keys.
The web implementation is based on the [MDN KPCS8](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey#pkcs_8_import).

I've verified the node and browser result with the following command: 'echo -n 'TESTSTRING' | openssl dgst -sha256 -sign ./private_key.pem  | openssl enc -base64 -A'

Closes #284 
