### PR TITLE
fix(#297): exchangeInfo accepts symbols as param

### DIFF
--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -690,7 +690,7 @@ export class MainClient extends BaseRestClient {
     if (symbol) {
       urlSuffix += '?symbol=' + symbol;
     } else if (symbols) {
-      urlSuffix += '?' + symbols;
+      urlSuffix += '?symbols=' + symbols;
     }
 
     return this.get('api/v3/exchangeInfo' + urlSuffix);


### PR DESCRIPTION
## Summary
fix #297 

## Additional Information
Old behavior: 
`Not all sent parameters were read; read '0' parameter(s) but was sent '1'.`

New behavior:
No Error
