### PR TITLE
fix SpotBalanceFormatted definition

### DIFF
--- a/src/types/websockets.ts
+++ b/src/types/websockets.ts
@@ -371,9 +371,9 @@ export interface WsMessageSpotOutboundAccountPositionRaw extends WsSharedBase {
 }
 
 interface SpotBalanceFormatted {
-  a: string;
-  f: number;
-  l: number;
+  asset: string;
+  availableBalance: number;
+  onOrderBalance: number;
 }
 
 export interface WsMessageSpotOutboundAccountPositionFormatted


### PR DESCRIPTION
Hello, I think the properties for the SpotBalanceFormatted interface are wrong
It corresponds to the SpotBalanceRaw definition ( probably a copy / paste that hasn't been edited then ^^ )
I changed them with the properties I get when I print my object in the console