### PR TITLE
v2.4.0: feat(#305, #242) complete CoinM futures support in REST client

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@
 
 [1]: https://www.npmjs.com/package/binance
 
-Node.js connector for the Binance APIs and WebSockets, with TypeScript & browser support.
+Node.js SDK for the Binance APIs and WebSockets, with TypeScript & browser support.
 
 - Extremely robust & performant connector with significant trading volume in production (livenet).
 - Actively maintained with a modern, promise-driven interface.
 - Support for seamless HMAC and RSA authentication.
   - Passing a private key as a secret will automatically revert to RSA authentication.
-- Supports REST APIs for Binance Spot, Margin, Isolated Margin & USDM Futures.
+- Supports REST APIs for Binance Spot, Margin, Isolated Margin, USDM & CoinM Futures.
   - Strongly typed on most requests and responses.
-- Supports Websockets for Binance Spot, Margin, Isolated Margin & USDM Futures.
+- Supports Websockets for Binance Spot, Margin, Isolated Margin & USDM & CoinM Futures.
   - Event driven messaging.
   - Smart websocket persistence
     - Automatically handle silent websocket disconnections through timed heartbeats, including the scheduled 24hr disconnect.
@@ -27,7 +27,7 @@ Node.js connector for the Binance APIs and WebSockets, with TypeScript & browser
   - Optional:
     - Automatic beautification of Websocket events (from one-letter keys to descriptive words, and strings with floats to numbers).
     - Automatic beautification of REST responses (parsing numbers in strings to numbers).
-- Heavy end-to-end testing with real API calls.
+- Heavy automated end-to-end testing with real API calls.
   - End-to-end testing before any release.
   - Real API calls in e2e tests.
 - Proxy support via axios integration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "2.3.4",
+  "version": "2.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "2.3.4",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "binance",
-  "version": "2.3.4",
-  "description": "Node.js connector for Binance's REST APIs and WebSockets, with TypeScript & integration tests.",
+  "version": "2.4.0",
+  "description": "Complete & robust node.js SDK for Binance's REST APIs and WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -17,6 +17,7 @@ import {
   OrderIdProperty,
   RecentTradesParams,
   SymbolFromPaginatedRequestFromId,
+  SymbolPrice,
 } from './types/shared';
 
 import {
@@ -163,7 +164,6 @@ import {
   SubAccountUSDMPositionRisk,
   SubAccountUSDMSummary,
   SymbolOrderBookTicker,
-  SymbolPrice,
   SymbolTradeFee,
   SystemStatusResponse,
   UniversalTransferBrokerParams,
@@ -174,7 +174,6 @@ import {
   WithdrawHistory,
   WithdrawHistoryParams,
   WithdrawParams,
-  
 } from './types/spot';
 
 import {

--- a/src/types/futures.ts
+++ b/src/types/futures.ts
@@ -59,6 +59,24 @@ export interface FuturesDataPaginatedParams {
   endTime?: number;
 }
 
+export interface FuturesCoinMTakerBuySellVolumeParams {
+  pair: string;
+  contractType: 'ALL' | 'CURRENT_QUARTER' | 'NEXT_QUARTER' | 'PERPETUAL';
+  period: '5m' | '15m' | '30m' | '1h' | '2h' | '4h' | '6h' | '12h' | '1d';
+  limit?: number;
+  startTime?: number;
+  endTime?: number;
+}
+
+export interface FuturesCoinMBasisParams {
+  pair: string;
+  contractType: 'CURRENT_QUARTER' | 'NEXT_QUARTER' | 'PERPETUAL';
+  period: '5m' | '15m' | '30m' | '1h' | '2h' | '4h' | '6h' | '12h' | '1d';
+  limit?: number;
+  startTime?: number;
+  endTime?: number;
+}
+
 export enum EnumDualSideMode {
   HedgeMode = 'true',
   OneWayMode = 'false',
@@ -106,6 +124,15 @@ export interface NewFuturesOrderParams<numberType = number> {
   workingType?: WorkingType;
   priceProtect?: BooleanStringCapitalised;
   newOrderRespType?: OrderResponseType;
+}
+
+export interface ModifyFuturesOrderParams<numberType = number> {
+  orderId?: number;
+  origClientOrderId?: string;
+  symbol: string;
+  side: OrderSide;
+  quantity?: numberType;
+  price?: numberType;
 }
 
 export enum EnumPositionMarginChangeType {
@@ -422,6 +449,31 @@ export interface OrderResult {
   priceProtect: boolean;
 }
 
+export interface ModifyFuturesOrderResult {
+  orderId: number;
+  symbol: string;
+  pair: string;
+  status: OrderStatus;
+  clientOrderId: string;
+  price: numberInString;
+  avgPrice: numberInString;
+  origQty: numberInString;
+  executedQty: numberInString;
+  cumQty: numberInString;
+  cumBase: numberInString;
+  timeInForce: OrderTimeInForce;
+  type: FuturesOrderType;
+  reduceOnly: boolean;
+  closePosition: boolean;
+  side: OrderSide;
+  positionSide: PositionSide;
+  stopPrice: numberInString;
+  workingType: WorkingType;
+  priceProtect: boolean;
+  origType: FuturesOrderType;
+  updateTime: number;
+}
+
 export interface CancelFuturesOrderResult {
   clientOrderId: string;
   cumQty: numberInString;
@@ -463,6 +515,18 @@ export interface FuturesAccountBalance {
   marginAvailable: boolean;
   updateTime: numberInString;
 }
+
+export interface FuturesCoinMAccountBalance {
+  accountAlias: string;
+  asset: string;
+  balance: numberInString;
+  withdrawAvailable: numberInString;
+  crossWalletBalance: numberInString;
+  crossUnPnl: numberInString;
+  availableBalance: numberInString;
+  updateTime: number;
+}
+
 export interface FuturesAccountAsset {
   asset: string;
   walletBalance: numberInString;
@@ -500,6 +564,22 @@ export interface FuturesAccountPosition {
   askNotional: numberInString;
 }
 
+export interface FuturesCoinMAccountPosition {
+  symbol: string;
+  positionAmt: numberInString;
+  initialMargin: numberInString;
+  maintMargin: numberInString;
+  unrealizedProfit: numberInString;
+  positionInitialMargin: numberInString;
+  openOrderInitialMargin: numberInString;
+  leverage: numberInString;
+  isolated: boolean;
+  positionSide: PositionSide;
+  entryPrice: numberInString;
+  maxQty: numberInString;
+  updateTime: number;
+}
+
 export interface FuturesAccountInformation {
   feeTier: numberInString;
   canTrade: boolean;
@@ -519,6 +599,16 @@ export interface FuturesAccountInformation {
   maxWithdrawAmount: numberInString;
   assets: FuturesAccountAsset[];
   positions: FuturesAccountPosition[];
+}
+
+export interface FuturesCoinMAccountInformation {
+  assets: Omit<FuturesAccountAsset, 'marginAvailable' | 'updateTime'>[];
+  positions: FuturesCoinMAccountPosition[];
+  canTrade: boolean;
+  canDeposit: boolean;
+  canWithdraw: boolean;
+  feeTier: number;
+  updateTime: number;
 }
 
 export interface FuturesPosition {
@@ -625,4 +715,30 @@ export interface ChangeStats24hr {
   firstId: number; // First tradeId
   lastId: number; // Last tradeId
   count: number;
+}
+
+export interface OrderAmendmentDetailPrice {
+  before: numberInString;
+  after: numberInString;
+}
+
+export interface OrderAmendmentDetailQty {
+  before: numberInString;
+  after: numberInString;
+}
+
+export interface OrderAmendmentDetail {
+  price: OrderAmendmentDetailPrice;
+  origQty: OrderAmendmentDetailQty;
+  count: number;
+}
+
+export interface OrderAmendment {
+  amendmentId: number;
+  symbol: string;
+  pair: string;
+  orderId: number;
+  clientOrderId: string;
+  time: number;
+  amendment: OrderAmendmentDetail;
 }

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -97,6 +97,11 @@ export interface BasicSymbolPaginatedParams {
   limit?: number;
 }
 
+export interface SymbolPrice {
+  symbol: string;
+  price: numberInString;
+}
+
 // used by spot and usdm
 export interface OrderBookParams {
   symbol: string;
@@ -126,6 +131,16 @@ export interface GetOrderParams {
   orderId?: number;
   origClientOrderId?: string;
   isIsolated?: StringBoolean;
+}
+
+export interface GetOrderModifyHistoryParams {
+  symbol: string;
+  orderId?: number;
+  origClientOrderId?: string;
+  isIsolated?: StringBoolean;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
 }
 
 export interface HistoricalTradesParams {

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -1,4 +1,3 @@
-
 import {
   ExchangeFilter,
   ExchangeSymbol,
@@ -535,11 +534,6 @@ export interface DailyChangeStatistic {
   count: number;
 }
 
-export interface SymbolPrice {
-  symbol: string;
-  price: numberInString;
-}
-
 export interface SymbolOrderBookTicker {
   symbol: string;
   bidPrice: numberInString;
@@ -826,17 +820,17 @@ export interface SubAccountList {
 }
 
 export interface SubAccountDepositHistoryList {
-  subAccountId: string,
-  amount: string,
-  coin: string,
-  network: string,
-  status: number,
-  address: string,
-  addressTag: string,
-  txId: string,
-  insertTime: number,
-  sourceAddress: string,
-  confirmTimes: string
+  subAccountId: string;
+  amount: string;
+  coin: string;
+  network: string;
+  status: number;
+  address: string;
+  addressTag: string;
+  txId: string;
+  insertTime: number;
+  sourceAddress: string;
+  confirmTimes: string;
 }
 
 export interface SubAccountTransferHistoryList {
@@ -1069,7 +1063,7 @@ export interface VirtualSubAccount {
 }
 
 export interface BrokerSubAccountHistory {
-  subAccountsHistory: SubAccountTransferHistoryList[]
+  subAccountsHistory: SubAccountTransferHistoryList[];
 }
 
 export interface BrokerSubAccount {

--- a/src/usdm-client.ts
+++ b/src/usdm-client.ts
@@ -17,6 +17,7 @@ import {
   OrderIdProperty,
   GetAllOrdersParams,
   GenericCodeMsgError,
+  SymbolPrice,
 } from './types/shared';
 
 import {
@@ -74,7 +75,6 @@ import {
 } from './util/requestUtils';
 
 import BaseRestClient from './util/BaseRestClient';
-import { SymbolPrice } from './types/spot';
 
 export class USDMClient extends BaseRestClient {
   private clientId: BinanceBaseUrlKey;
@@ -134,6 +134,21 @@ export class USDMClient extends BaseRestClient {
     return this.get('fapi/v1/aggTrades', params);
   }
 
+  /**
+   * Index Price and Mark Price
+   */
+  getMarkPrice(
+    params?: Partial<BasicSymbolParam>
+  ): Promise<MarkPrice | MarkPrice[]> {
+    return this.get('fapi/v1/premiumIndex', params);
+  }
+
+  getFundingRateHistory(
+    params?: Partial<BasicSymbolPaginatedParams>
+  ): Promise<FundingRateHistory[]> {
+    return this.get('fapi/v1/fundingRate', params);
+  }
+
   getKlines(params: KlinesParams): Promise<Kline[]> {
     return this.get('fapi/v1/klines', params);
   }
@@ -152,19 +167,16 @@ export class USDMClient extends BaseRestClient {
     return this.get('fapi/v1/markPriceKlines', params);
   }
 
-  getMarkPrice(
-    params?: Partial<BasicSymbolParam>
-  ): Promise<MarkPrice | MarkPrice[]> {
-    return this.get('fapi/v1/premiumIndex', params);
-  }
-
-  getFundingRateHistory(
-    params?: Partial<BasicSymbolPaginatedParams>
-  ): Promise<FundingRateHistory[]> {
-    return this.get('fapi/v1/fundingRate', params);
-  }
-
+  /**
+   * @deprecated use get24hrChangeStatistics() instead (method without the typo)
+   */
   get24hrChangeStatististics(
+    params?: Partial<BasicSymbolParam>
+  ): Promise<ChangeStats24hr | ChangeStats24hr[]> {
+    return this.get24hrChangeStatistics(params);
+  }
+
+  get24hrChangeStatistics(
     params?: Partial<BasicSymbolParam>
   ): Promise<ChangeStats24hr | ChangeStats24hr[]> {
     return this.get('fapi/v1/ticker/24hr', params);


### PR DESCRIPTION
## Summary
<!-- Add a brief description of the pr: -->
- feat(#305, #242) complete CoinM futures support in REST client. Thanks to efforts from @eugeneglova in making this happen.

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
