### PR TITLE
v2.5.0: fix(#310) return type on notional brackets endpoint to match what actually happens

### DIFF
--- a/examples/rest-usdm-order.ts
+++ b/examples/rest-usdm-order.ts
@@ -1,0 +1,33 @@
+import { USDMClient } from '../src/index';
+
+// or
+// import { USDMClient } from 'binance';
+
+const key = process.env.APIKEY || 'APIKEY';
+const secret = process.env.APISECRET || 'APISECRET';
+
+const client = new USDMClient({
+  // api_key: 'apikeyhere',
+  // api_secret: 'apisecrethere',
+  api_secret: secret,
+  api_key: key,
+  beautifyResponses: true,
+});
+
+async function start() {
+  try {
+    // To open a short position - if you don't have a position yet, and your account is set to one-way mode, just place a sell order to open a short position
+    const result = await client.submitNewOrder({
+      side: 'SELL',
+      symbol: 'BTCUSDT',
+      type: 'MARKET',
+      quantity: 0.001,
+    });
+
+    console.log('market sell result: ', result);
+  } catch (e) {
+    console.error('market sell failed: ', e);
+  }
+}
+
+start();

--- a/examples/rest-usdm-private-get.ts
+++ b/examples/rest-usdm-private-get.ts
@@ -1,0 +1,32 @@
+import { USDMClient } from '../src/index';
+// import axios from 'axios';
+
+// or
+// import { USDMClient } from 'binance';
+
+const key = process.env.APIKEY || 'APIKEY';
+const secret = process.env.APISECRET || 'APISECRET';
+
+const client = new USDMClient({
+  api_key: key,
+  api_secret: secret,
+  beautifyResponses: true,
+  disableTimeSync: true,
+});
+
+(async () => {
+  try {
+    const allNotionalBrackets = await client.getNotionalAndLeverageBrackets();
+    console.log('allNotionalBrackets: ', allNotionalBrackets);
+
+    const btcNotionalBrackets = await client.getNotionalAndLeverageBrackets({
+      symbol: 'BTCUSDT',
+    });
+    console.log(
+      'btcNotionalBrackets: ',
+      JSON.stringify(btcNotionalBrackets, null, 2)
+    );
+  } catch (e) {
+    console.error('request failed: ', e);
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Complete & robust node.js SDK for Binance's REST APIs and WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/usdm-client.ts
+++ b/src/usdm-client.ts
@@ -363,9 +363,12 @@ export class USDMClient extends BaseRestClient {
     return this.getPrivate('fapi/v1/income', params);
   }
 
+  /**
+   * Contrary to what the docs say - if symbol is provided, this returns an array with length 1 (assuming the symbol exists)
+   */
   getNotionalAndLeverageBrackets(
     params?: Partial<BasicSymbolParam>
-  ): Promise<SymbolLeverageBracketsResult[] | SymbolLeverageBracketsResult> {
+  ): Promise<SymbolLeverageBracketsResult[]> {
     return this.getPrivate('fapi/v1/leverageBracket', params);
   }
 


### PR DESCRIPTION
## Summary
- #310 pointed out the REST API always returns an array, even when providing a symbol. 
- This updates the return type to match reality.

<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
