### PR TITLE
feat: WebsocketClient support agents

### DIFF
--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -52,6 +52,10 @@ export interface WSClientConfigurableOptions {
   reconnectTimeout?: number;
   restOptions?: RestClientOptions;
   requestOptions?: AxiosRequestConfig;
+  wsOptions?: {
+    protocols?: string[];
+    agent?: any;
+  } 
   wsUrl?: string;
 }
 
@@ -219,8 +223,10 @@ export class WebsocketClient extends EventEmitter {
       `connectToWsUrl(): Opening WS connection to URL: ${url}`,
       { ...loggerCategory, wsRefKey }
     );
+    
+    const { protocols = [], ...wsOptions } = this.options.wsOptions || {};
 
-    const ws = new WebSocket(url);
+    const ws = new WebSocket(url, protocols, wsOptions);
     this.wsUrlKeyMap[url] = wsRefKey;
 
     if (typeof ws.on === 'function') {


### PR DESCRIPTION
## Summary
<!-- Add a brief description of the pr: -->
WebsocketClient support proxy 
## Additional Information
```ts
import { isWsFormatted24hrTicker, isWsFormattedKline } from "binance";
import EventEmitter from "events";
const { SocksProxyAgent } = require('socks-proxy-agent');
import { outLogger } from "ROOT/common/logger";
import { WebsocketClient } from "ROOT/lib/binance"; // build local for test
import { Period } from "./interface";


export class BinanceWebSocket {
  /** @see https://github.com/tiagosiebler/binance/blob/master/src/websocket-client.ts */
  wsClient: WebsocketClient
  constructor() {
    this.init()
  }
  init() {
    const agent = new SocksProxyAgent(process.env.http_proxy);
    const wsClient = new WebsocketClient({
      beautify: false,
      wsOptions: {
        agent: agent
      }
    }, {
      silly: (...params) => {
        outLogger.info('ws silly', ...params);
      },
      debug: (...params) => {
        outLogger.info('ws debug', ...params);
      },
      notice: (...params) => {
        outLogger.info('ws notice', ...params);
      },
      info: (...params) => {
        outLogger.info('ws info', ...params);
      },
      warning: (...params) => {
        outLogger.warn('ws warning', ...params);
      },
      error: (...params) => {
        outLogger.error('ws error', ...params);
      }
    });
    this.wsClient = wsClient;

    wsClient.on('open', (data) => {
      outLogger.info('connection opened open:', data.wsKey);
   
    });
    wsClient.on('reply', (data) => {
      outLogger.info('log reply: ', JSON.stringify(data, null, 2));
    });
    wsClient.on('reconnecting', (data) => {
      outLogger.info('ws automatically reconnecting.... ', data?.wsKey );
    });
    wsClient.on('reconnected', (data) => {
      outLogger.info('ws has reconnected ', data?.wsKey );
    });
    wsClient.on('message', (data) => {
      outLogger.info('raw message received ', JSON.stringify(data, null, 2));
    });
    wsClient.subscribeKlines("BTCUSDT", '1m', 'usdm');
    wsClient.on('formattedMessage', (data) => {
      // manually handle events and narrow down to desired types
      if (!Array.isArray(data) && data.eventType === 'kline') {
        console.log('kline received ', data.kline);
      }

      // or use a supplied type guard (if available - not all type guards have been written yet)
      if (isWsFormattedKline(data)) {
        console.log('kline received ', data.kline);
        return;
      }

      if (isWsFormatted24hrTicker(data)) {
        console.log('24hrTicker received ', data);
        return;
      }

      console.log('log formattedMessage: ', data);
    });
  }

}


```