### PR TITLE
v2.6.1: feat() add 3 missing ignoreable properties to futures order trade update. Add timestamps to built in logger.

### DIFF
--- a/examples/util/README.md
+++ b/examples/util/README.md
@@ -1,0 +1,3 @@
+# Utilities
+
+These are miscellaneous utilities used by some of the examples in this repo. These do not represent best practices and are merely for easier demonstrations.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "2.5.1",
+  "version": "2.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "2.5.1",
+      "version": "2.6.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Complete & robust node.js SDK for Binance's REST APIs and WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,21 +1,20 @@
 export type LogParams = null | any;
 
 export const DefaultLogger = {
-  silly: (...params: LogParams): void => {
-  },
+  silly: (...params: LogParams): void => {},
   debug: (...params: LogParams): void => {
-    console.log(params);
+    console.log(new Date(), params);
   },
   notice: (...params: LogParams): void => {
-    console.log(params);
+    console.log(new Date(), params);
   },
   info: (...params: LogParams): void => {
-    console.info(params);
+    console.info(new Date(), params);
   },
   warning: (...params: LogParams): void => {
-    console.error(params);
+    console.error(new Date(), params);
   },
   error: (...params: LogParams): void => {
-    console.error(params);
-  }
+    console.error(new Date(), params);
+  },
 };

--- a/src/types/websockets.ts
+++ b/src/types/websockets.ts
@@ -759,6 +759,9 @@ export interface WsMessageFuturesUserDataTradeUpdateEventFormatted
     trailingStopActivationPrice: number;
     trailingStopCallbackRate: number;
     realisedProfit: number;
+    pP?: boolean; // ignore
+    si?: number; // ignore
+    ss?: number; // ignore
   };
 }
 


### PR DESCRIPTION

## Summary
<!-- Add a brief description of the pr: -->
- feat() add 3 missing ignoreable properties to futures order trade update. 
- feat() Add timestamps to built in logger.

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
