### PR TITLE
fix: position margin type

### DIFF
--- a/src/types/futures.ts
+++ b/src/types/futures.ts
@@ -613,7 +613,7 @@ export interface FuturesCoinMAccountInformation {
 
 export interface FuturesPosition {
   entryPrice: numberInString;
-  marginType: Lowercase<MarginType>;
+  marginType: 'isolated' | 'cross';
   isAutoAddMargin: 'false' | 'true';
   isolatedMargin: numberInString;
   leverage: numberInString;


### PR DESCRIPTION
## Summary
Position info cross margin type should be 'cross', not 'crossed'.

## Additional Information
See. https://binance-docs.github.io/apidocs/futures/en/#position-information-v2-user_data response has "marginType": "cross".

Changing futures marginType is different from get the marginType of positionInfo.

