### PR TITLE
Improve typings of SymbolExchangeInfo

### DIFF
--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -450,14 +450,20 @@ export interface SymbolExchangeInfo {
   baseAsset: string;
   baseAssetPrecision: number;
   quoteAsset: string;
+  quotePrecision: number;
   quoteAssetPrecision: number;
   orderTypes: OrderType[];
   icebergAllowed: boolean;
   ocoAllowed: boolean;
+  quoteOrderQtyMarketAllowed: boolean;
+  allowTrailingStop: boolean;
+  cancelReplaceAllowed: boolean;
   isSpotTradingAllowed: boolean;
   isMarginTradingAllowed: boolean;
   filters: SymbolFilter[];
   permissions: ('SPOT' | 'MARGIN')[];
+  defaultSelfTradePreventionMode: 'NONE' | 'EXPIRE_TAKER' | 'EXPIRE_BOTH' | 'EXPIRE_MAKER'
+  allowedSelfTradePreventionModes: ('NONE' | 'EXPIRE_TAKER' | 'EXPIRE_BOTH' | 'EXPIRE_MAKER')[];
 }
 
 export interface ExchangeInfo {


### PR DESCRIPTION
Add missing typings for `SymbolExchangeInfo`

See [change log](https://binance-docs.github.io/apidocs/spot/en/#change-log):

> 2022-12-05
> 
> Changes to GET /api/v3/exchangeInfo
> New fields defaultSelfTradePreventionMode and allowedSelfTradePreventionModes

> 2022-06-15
>
> GET /api/v3/exchangeInfo returns new field cancelReplaceAllowed in symbols list.

> 2019-11-13
> 
> Rest API
> 
> api/v3/exchangeInfo has new fields:
> quoteOrderQtyMarketAllowed
> baseCommissionPrecision
> quoteCommissionPrecision