### PR TITLE
fix FuturesPositionTrade type

### DIFF
--- a/src/types/futures.ts
+++ b/src/types/futures.ts
@@ -638,10 +638,11 @@ export interface FuturesPosition {
 
 export interface FuturesPositionTrade {
   buyer: boolean;
-  commision: numberInString;
-  commisionAsset: string;
+  commission: numberInString;
+  commissionAsset: string;
   id: number;
   maker: boolean;
+  marginAsset: string;
   orderId: number;
   price: numberInString;
   qty: numberInString;


### PR DESCRIPTION
fix typos and add `marginAsset`

example trade:
```ts
{
    symbol: "BTCUSDT",
    id: 123,
    orderId: 123,
    side: "SELL",
    price: 26832.5,
    qty: 0.025,
    realizedPnl: "0",
    marginAsset: "USDT",
    quoteQty: "670.81250",
    commission: 0.00113016,
    commissionAsset: "BNB",
    time: 1695237604838,
    positionSide: "BOTH",
    buyer: false,
    maker: false
  }
```


Example code used:
```ts
import { USDMClient } from "binance";

const key = process.env.APIKEY || "";
const secret = process.env.APISECRET || "";

const usdmClient = new USDMClient({
  api_key: key,
  api_secret: secret,
  beautifyResponses: true,
});

(async () => {
  try {
    const todayAtMidnight = new Date().setHours(0, 0, 0, 0);
    const startTime = new Date(todayAtMidnight).getTime();

    // @ts-ignore
    const trades = await usdmClient.getAccountTrades({ startTime });
    console.log(trades);
    console.log("number of trades:", trades.length);
  } catch (e) {
    console.error("Error: request failed: ", e);
  }

})();
```