### PR TITLE
fix: Update websocket-client.ts

### DIFF
--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -549,11 +549,11 @@ export class WebsocketClient extends EventEmitter {
     }
   }
 
-  public closeAll(force?: boolean) {
+  public closeAll(willReconnect?: boolean) {
     const keys = this.wsStore.getKeys();
     this.logger.info(`Closing all ws connections: ${keys}`);
     keys.forEach((key) => {
-      this.close(key, force);
+      this.close(key, willReconnect);
     });
   }
 


### PR DESCRIPTION
## Summary
<!-- Add a brief description of the pr: -->
Fixes #366 
Updated the parameter name `force` to `willReconnect` of method `closeAll()`, which will be consistent with parameter name for methods `closeWs()` and `close()`.
## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
