### PR TITLE
Check ws.readyState at ping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -296,8 +296,10 @@ export class WebsocketClient extends EventEmitter {
       }
 
       // Binance allows unsolicited pongs, so we send both (though we expect a pong in response to our ping if the connection is still alive)
-      ws.ping();
-      ws.pong();
+      if (ws.readyState === 1) {
+        ws.ping();
+        ws.pong();
+      }
     } catch (e) {
       this.logger.error(`Failed to send WS ping`, {
         ...loggerCategory,

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -299,6 +299,11 @@ export class WebsocketClient extends EventEmitter {
       if (ws.readyState === 1) {
         ws.ping();
         ws.pong();
+      } else {
+        this.logger.silly(
+          `WS ready state not open - refusing to send WS ping`,
+          { ...loggerCategory, wsKey, readyState: ws?.readyState },
+        );
       }
     } catch (e) {
       this.logger.error(`Failed to send WS ping`, {


### PR DESCRIPTION
## Summary
`WebsocketClient`, before sending ping and pong, will make sure the WebSocket's `readyState`  is `OPEN`. This will avoid unnecesarry errors when sending ping/pong while WebSocket is not ready (such as `CONNECTING` or `CLOSING` states).

## Additional Information
Closes #384 