### PR TITLE
Add "array of symbols" signature to `getSymbolPriceTicker`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "2.9.3",
+  "version": "2.9.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "2.9.3",
+      "version": "2.9.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "binance",
-  "version": "2.9.5",
   "version": "2.10.3",
   "description": "Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -782,9 +782,28 @@ export class MainClient extends BaseRestClient {
   }
 
   getSymbolPriceTicker(
-    params?: Partial<BasicSymbolParam>,
+    params: BasicSymbolParam,
+  ): Promise<SymbolPrice>;
+
+  getSymbolPriceTicker(
+    params?: SymbolArrayParam,
+  ): Promise<SymbolPrice[]>;
+
+  getSymbolPriceTicker(
+    params?: Partial<BasicSymbolParam> | Partial<SymbolArrayParam>,
   ): Promise<SymbolPrice | SymbolPrice[]> {
-    return this.get('api/v3/ticker/price', params);
+    if (params && typeof params['symbol'] === 'string') {
+      return this.get('api/v3/ticker/price', params);
+    }
+
+    if (params && params['symbols'] && Array.isArray(params['symbols'])) {
+      const symbols = (params as SymbolArrayParam).symbols;
+      const symbolsQueryParam = JSON.stringify(symbols);
+
+      return this.get('api/v3/ticker/price?symbols=' + symbolsQueryParam);
+    }
+
+    return this.get('api/v3/ticker/price');
   }
 
   getSymbolOrderBookTicker(


### PR DESCRIPTION
## Summary
`api/v3/ticker/price` (`getSymbolPriceTicker`) supports an array of symbols just like `api/v3/ticker/24hr` (`get24hrChangeStatististics`) https://binance-docs.github.io/apidocs/spot/en/#symbol-price-ticker
