### PR TITLE
v2.10.0: fix(#402) ws diff book depth update speed for futures. Change default update speed to 100ms.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "2.9.3",
+  "version": "2.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "2.9.3",
+      "version": "2.10.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.9.6",
+  "version": "2.10.0",
   "description": "Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -1593,11 +1593,16 @@ export class WebsocketClient extends EventEmitter {
   }
 
   /**
-   * Subscribe to spot orderbook depth updates to locally manage an order book.
+   * Subscribe to orderbook depth updates to locally manage an order book.
+   *
+   * Note that the updatems parameter depends on which market you're trading
+   *
+   * - Spot: https://binance-docs.github.io/apidocs/spot/en/#diff-depth-stream
+   * - USDM Futures: https://binance-docs.github.io/apidocs/futures/en/#diff-book-depth-streams
    */
   public subscribeDiffBookDepth(
     symbol: string,
-    updateMs: 1000 | 100 = 1000,
+    updateMs: 100 | 250 | 500 | 1000 = 100,
     market: 'spot' | 'usdm' | 'coinm',
     forceNewConnection?: boolean,
   ): WebSocket {


### PR DESCRIPTION

## Summary
<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
