### PR TITLE
v2.11.0: feat(): improved type resolution for order submit/amend methods & add "submitNewOrderList" method and related types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.10.4",
+  "version": "2.11.0",
   "description": "Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -197,6 +197,8 @@ import {
   OrderResponse,
   OrderListResponse,
   OrderResponseTypeFor,
+  OrderList,
+  CancelOrderListResult,
 } from './types/spot';
 
 import {
@@ -884,23 +886,23 @@ export class MainClient extends BaseRestClient {
     return this.postPrivate('/api/v3/orderList/oco', params);
   }
 
-  cancelOCO(params: CancelOCOParams): Promise<any> {
+  cancelOCO(params: CancelOCOParams): Promise<CancelOrderListResult> {
     this.validateOrderId(params, 'newClientOrderId');
     return this.deletePrivate('api/v3/orderList', params);
   }
 
-  getOCO(params?: GetOCOParams): Promise<any> {
+  getOCO(params?: GetOCOParams): Promise<OrderList> {
     return this.getPrivate('api/v3/orderList', params);
   }
 
-  getAllOCO(params?: BasicFromPaginatedParams): Promise<any> {
+  getAllOCO(params?: BasicFromPaginatedParams): Promise<OrderList[]> {
     return this.getPrivate('api/v3/allOrderList', params);
   }
 
   /**
    * Query open OCO
    */
-  getAllOpenOCO(): Promise<any> {
+  getAllOpenOCO(): Promise<OrderList[]> {
     return this.getPrivate('api/v3/openOrderList');
   }
 

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -23,6 +23,7 @@ import {
   SymbolArrayParam,
   NewOrderListParams,
   OrderResponseType,
+  OrderType,
 } from './types/shared';
 
 import {
@@ -195,6 +196,7 @@ import {
   SORTestOrderResponse,
   OrderResponse,
   OrderListResponse,
+  OrderResponseTypeFor,
 } from './types/spot';
 
 import {
@@ -819,20 +821,27 @@ export class MainClient extends BaseRestClient {
    *
    **/
 
-  testNewOrder(params: NewSpotOrderParams): Promise<{}> {
+  testNewOrder<
+    T extends OrderType,
+    RT extends OrderResponseType | undefined = undefined,
+  >(params: NewSpotOrderParams<T, RT>): Promise<{}> {
     this.validateOrderId(params, 'newClientOrderId');
     return this.postPrivate('api/v3/order/test', params);
   }
 
-  replaceOrder(
-    params: ReplaceSpotOrderParams,
+  replaceOrder<
+    T extends OrderType,
+    RT extends OrderResponseType | undefined = undefined,
+  >(
+    params: ReplaceSpotOrderParams<T, RT>,
   ): Promise<ReplaceSpotOrderResultSuccess> {
     return this.postPrivate('api/v3/order/cancelReplace', params);
   }
 
-  submitNewOrder(
-    params: NewSpotOrderParams,
-  ): Promise<OrderResponseACK | OrderResponseResult | OrderResponseFull> {
+  submitNewOrder<
+    T extends OrderType,
+    RT extends OrderResponseType | undefined = undefined,
+  >(params: NewSpotOrderParams<T, RT>): Promise<OrderResponseTypeFor<RT, T>> {
     this.validateOrderId(params, 'newClientOrderId');
     return this.postPrivate('api/v3/order', params);
   }
@@ -987,9 +996,10 @@ export class MainClient extends BaseRestClient {
     return this.get('sapi/v1/margin/priceIndex', params);
   }
 
-  marginAccountNewOrder(
-    params: NewSpotOrderParams,
-  ): Promise<OrderResponseACK | OrderResponseResult | OrderResponseFull> {
+  marginAccountNewOrder<
+    T extends OrderType,
+    RT extends OrderResponseType | undefined = undefined,
+  >(params: NewSpotOrderParams<T, RT>): Promise<OrderResponseTypeFor<RT, T>> {
     this.validateOrderId(params, 'newClientOrderId');
     return this.postPrivate('sapi/v1/margin/order', params);
   }
@@ -1448,11 +1458,11 @@ export class MainClient extends BaseRestClient {
    */
   private validateOrderId(
     params:
-      | NewSpotOrderParams
+      | NewSpotOrderParams<any, any>
       | CancelOrderParams
       | NewOCOParams
       | CancelOCOParams
-      | NewOrderListParams,
+      | NewOrderListParams<any>,
     orderIdProperty: OrderIdProperty,
   ): void {
     const apiCategory = 'spot';

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -21,6 +21,8 @@ import {
   RowsWithTotal,
   CoinStartEndLimit,
   SymbolArrayParam,
+  NewOrderListParams,
+  OrderResponseType,
 } from './types/shared';
 
 import {
@@ -191,6 +193,8 @@ import {
   NewSpotSOROrderParams,
   SOROrderResponseFull,
   SORTestOrderResponse,
+  OrderResponse,
+  OrderListResponse,
 } from './types/spot';
 
 import {
@@ -862,6 +866,15 @@ export class MainClient extends BaseRestClient {
     return this.postPrivate('api/v3/order/oco', params);
   }
 
+  submitNewOrderList<T extends OrderResponseType>(
+    params: NewOrderListParams<T>,
+  ): Promise<OrderListResponse<T>> {
+    this.validateOrderId(params, 'listClientOrderId');
+    this.validateOrderId(params, 'aboveClientOrderId');
+    this.validateOrderId(params, 'belowClientOrderId');
+    return this.postPrivate('/api/v3/orderList/oco', params);
+  }
+
   cancelOCO(params: CancelOCOParams): Promise<any> {
     this.validateOrderId(params, 'newClientOrderId');
     return this.deletePrivate('api/v3/orderList', params);
@@ -1438,7 +1451,8 @@ export class MainClient extends BaseRestClient {
       | NewSpotOrderParams
       | CancelOrderParams
       | NewOCOParams
-      | CancelOCOParams,
+      | CancelOCOParams
+      | NewOrderListParams,
     orderIdProperty: OrderIdProperty,
   ): void {
     const apiCategory = 'spot';

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -834,7 +834,7 @@ export class MainClient extends BaseRestClient {
     RT extends OrderResponseType | undefined = undefined,
   >(
     params: ReplaceSpotOrderParams<T, RT>,
-  ): Promise<ReplaceSpotOrderResultSuccess> {
+  ): Promise<ReplaceSpotOrderResultSuccess<T, RT>> {
     return this.postPrivate('api/v3/order/cancelReplace', params);
   }
 

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -883,7 +883,7 @@ export class MainClient extends BaseRestClient {
     this.validateOrderId(params, 'listClientOrderId');
     this.validateOrderId(params, 'aboveClientOrderId');
     this.validateOrderId(params, 'belowClientOrderId');
-    return this.postPrivate('/api/v3/orderList/oco', params);
+    return this.postPrivate('api/v3/orderList/oco', params);
   }
 
   cancelOCO(params: CancelOCOParams): Promise<CancelOrderListResult> {

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -246,7 +246,9 @@ export interface NewOCOParams {
   sideEffectType?: SideEffects;
 }
 
-export interface NewOrderListParams<T extends OrderResponseType> {
+export interface NewOrderListParams<
+  T extends OrderResponseType = OrderResponseType,
+> {
   symbol: string;
   listClientOrderId?: string;
   side: OrderSide;

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -46,7 +46,9 @@ export type OrderIdProperty =
   | 'newClientOrderId'
   | 'listClientOrderId'
   | 'limitClientOrderId'
-  | 'stopClientOrderId';
+  | 'stopClientOrderId'
+  | 'aboveClientOrderId'
+  | 'belowClientOrderId';
 
 export type OrderSide = 'BUY' | 'SELL';
 
@@ -80,6 +82,11 @@ export type OrderType =
   | 'STOP_LOSS_LIMIT'
   | 'TAKE_PROFIT'
   | 'TAKE_PROFIT_LIMIT';
+
+export type OrderListOrderType =
+  | 'STOP_LOSS_LIMIT'
+  | 'STOP_LOSS'
+  | 'LIMIT_MAKER';
 
 export type SelfTradePreventionMode =
   | 'EXPIRE_TAKER'
@@ -237,6 +244,33 @@ export interface NewOCOParams {
   isIsolated?: StringBoolean;
   /** Define a side effect, only for margin trading */
   sideEffectType?: SideEffects;
+}
+
+export interface NewOrderListParams<T extends OrderResponseType = 'ACK'> {
+  symbol: string;
+  listClientOrderId?: string;
+  side: OrderSide;
+  quantity: number;
+  aboveType: OrderListOrderType;
+  aboveClientOrderId?: string;
+  aboveIcebergQty?: number;
+  abovePrice?: number;
+  aboveStopPrice?: number;
+  aboveTrailingDelta?: number;
+  aboveTimeInForce?: OrderTimeInForce;
+  aboveStrategyId?: number;
+  aboveStrategyType?: number;
+  belowType: OrderListOrderType;
+  belowClientOrderId?: string;
+  belowIcebergQty?: number;
+  belowPrice?: number;
+  belowStopPrice?: number;
+  belowTrailingDelta?: number;
+  belowTimeInForce?: OrderTimeInForce;
+  belowStrategyId?: number;
+  belowStrategyType?: number;
+  newOrderRespType?: T;
+  selfTradePreventionMode?: SelfTradePreventionMode;
 }
 
 export interface SymbolFromPaginatedRequestFromId {

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -81,6 +81,12 @@ export type OrderType =
   | 'TAKE_PROFIT'
   | 'TAKE_PROFIT_LIMIT';
 
+export type SelfTradePreventionMode =
+  | 'EXPIRE_TAKER'
+  | 'EXPIRE_MAKER'
+  | 'EXPIRE_BOTH'
+  | 'NONE';
+
 export interface BasicAssetParam {
   asset: string;
 }

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -246,7 +246,7 @@ export interface NewOCOParams {
   sideEffectType?: SideEffects;
 }
 
-export interface NewOrderListParams<T extends OrderResponseType = 'ACK'> {
+export interface NewOrderListParams<T extends OrderResponseType> {
   symbol: string;
   listClientOrderId?: string;
   side: OrderSide;

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -434,7 +434,7 @@ export type CancelRestrictions = 'ONLY_NEW' | 'ONLY_PARTIALLY_FILLED';
 export type CancelReplaceMode = 'STOP_ON_FAILURE' | 'ALLOW_FAILURE';
 
 export interface ReplaceSpotOrderParams<
-  T extends OrderType,
+  T extends OrderType = OrderType,
   RT extends OrderResponseType | undefined = undefined,
 > extends NewSpotOrderParams<T, RT> {
   cancelReplaceMode: CancelReplaceMode;
@@ -813,7 +813,7 @@ export interface ReplaceSpotOrderResultError {
 }
 
 export interface ReplaceSpotOrderResultSuccess<
-  T extends OrderType,
+  T extends OrderType = OrderType,
   RT extends OrderResponseType | undefined = undefined,
 > extends GenericReplaceSpotOrderResult<
     CancelSpotOrderResult,

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -706,6 +706,12 @@ export interface OrderResponseFull {
   fills: OrderFill[];
 }
 
+export interface OrderListOrder {
+  symbol: string;
+  orderId: number;
+  clientOrderId: string;
+}
+
 export interface OrderListResponse<RT extends OrderResponseType = 'ACK'> {
   orderListId: number;
   contingencyType: 'OCO';
@@ -714,11 +720,23 @@ export interface OrderListResponse<RT extends OrderResponseType = 'ACK'> {
   listClientOrderId: string;
   transactionTime: number;
   symbol: string;
-  orders: [
-    { symbol: string; orderId: number; clientOrderId: string },
-    { symbol: string; orderId: number; clientOrderId: string },
-  ];
+  orders: [OrderListOrder, OrderListOrder];
   orderReports: [OrderResponseTypeFor<RT>, OrderResponseTypeFor<RT>];
+}
+
+export interface OrderList {
+  orderListId: number;
+  contingencyType: 'OCO';
+  listStatusType: OCOOrderStatus;
+  listOrderStatus: OCOOrderStatus;
+  listClientOrderId: string;
+  transactionTime: number;
+  symbol: string;
+  orders: [OrderListOrder, OrderListOrder];
+}
+
+export interface CancelOrderListResult extends OrderList {
+  orderReports: [CancelSpotOrderResult, CancelSpotOrderResult];
 }
 
 export interface SOROrderFill {

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -430,15 +430,18 @@ export interface NewSpotOrderParams<
   sideEffectType?: SideEffects;
 }
 
+export type CancelRestrictions = 'ONLY_NEW' | 'ONLY_PARTIALLY_FILLED';
+export type CancelReplaceMode = 'STOP_ON_FAILURE' | 'ALLOW_FAILURE';
+
 export interface ReplaceSpotOrderParams<
   T extends OrderType,
   RT extends OrderResponseType | undefined = undefined,
 > extends NewSpotOrderParams<T, RT> {
-  cancelReplaceMode: 'STOP_ON_FAILURE' | 'ALLOW_FAILURE';
+  cancelReplaceMode: CancelReplaceMode;
   cancelNewClientOrderId?: string;
   cancelOrigClientOrderId?: string;
   cancelOrderId?: number;
-  cancelRestrictions?: 'ONLY_NEW' | 'ONLY_PARTIALLY_FILLED';
+  cancelRestrictions?: CancelRestrictions;
 }
 
 export interface GetOCOParams {
@@ -460,11 +463,7 @@ export interface NewSpotSOROrderParams {
   strategyType?: number;
   icebergQty?: number;
   newOrderRespType?: OrderResponseType;
-  selfTradePreventionMode?:
-    | 'EXPIRE_TAKER'
-    | 'EXPIRE_MAKER'
-    | 'EXPIRE_BOTH'
-    | 'NONE';
+  selfTradePreventionMode?: SelfTradePreventionMode;
 }
 
 export type APILockTriggerCondition = 'GCR' | 'IFER' | 'UFR';
@@ -532,17 +531,8 @@ export interface SymbolExchangeInfo {
   isMarginTradingAllowed: boolean;
   filters: SymbolFilter[];
   permissions: ('SPOT' | 'MARGIN')[];
-  defaultSelfTradePreventionMode:
-    | 'NONE'
-    | 'EXPIRE_TAKER'
-    | 'EXPIRE_BOTH'
-    | 'EXPIRE_MAKER';
-  allowedSelfTradePreventionModes: (
-    | 'NONE'
-    | 'EXPIRE_TAKER'
-    | 'EXPIRE_BOTH'
-    | 'EXPIRE_MAKER'
-  )[];
+  defaultSelfTradePreventionMode: SelfTradePreventionMode;
+  allowedSelfTradePreventionModes: SelfTradePreventionMode[];
 }
 
 export interface ExchangeInfo {

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -3,6 +3,8 @@ import {
   ExchangeSymbol,
   GenericCodeMsgError,
   numberInString,
+  OCOOrderStatus,
+  OCOStatus,
   OrderBookRow,
   OrderResponseType,
   OrderSide,
@@ -622,6 +624,19 @@ export interface SymbolOrderBookTicker {
   askQty: numberInString;
 }
 
+export type OrderResponse =
+  | OrderResponseACK
+  | OrderResponseResult
+  | OrderResponseFull;
+
+export type OrderResponseTypeFor<T extends OrderResponseType> = T extends 'ACK'
+  ? OrderResponseACK
+  : T extends 'RESULT'
+  ? OrderResponseResult
+  : T extends 'FULL'
+  ? OrderResponseFull
+  : OrderResponseACK;
+
 export interface OrderResponseACK {
   symbol: string;
   orderId: number;
@@ -675,6 +690,21 @@ export interface OrderResponseFull {
   workingTime: number;
   selfTradePreventionMode: SelfTradePreventionMode;
   fills: OrderFill[];
+}
+
+export interface OrderListResponse<T extends OrderResponseType = 'ACK'> {
+  orderListId: number;
+  contingencyType: 'OCO';
+  listStatusType: OCOStatus;
+  listOrderStatus: OCOOrderStatus;
+  listClientOrderId: string;
+  transactionTime: number;
+  symbol: string;
+  orders: [
+    { symbol: string; orderId: number; clientOrderId: string },
+    { symbol: string; orderId: number; clientOrderId: string },
+  ];
+  orderReports: [OrderResponseTypeFor<T>, OrderResponseTypeFor<T>];
 }
 
 export interface SOROrderFill {
@@ -738,10 +768,7 @@ export interface ReplaceSpotOrderNewFailure
 }
 
 export interface ReplaceSpotOrderCancelAllowFailure
-  extends GenericReplaceSpotOrderResult<
-    GenericCodeMsgError,
-    OrderResponseACK | OrderResponseResult | OrderResponseFull
-  > {
+  extends GenericReplaceSpotOrderResult<GenericCodeMsgError, OrderResponse> {
   cancelResult: 'FAILURE';
   newOrderResult: 'SUCCESS';
 }
@@ -764,10 +791,7 @@ export interface ReplaceSpotOrderResultError {
 }
 
 export interface ReplaceSpotOrderResultSuccess
-  extends GenericReplaceSpotOrderResult<
-    CancelSpotOrderResult,
-    OrderResponseACK | OrderResponseResult | OrderResponseFull
-  > {
+  extends GenericReplaceSpotOrderResult<CancelSpotOrderResult, OrderResponse> {
   cancelResult: 'SUCCESS';
   newOrderResult: 'SUCCESS';
 }

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -409,7 +409,7 @@ export interface ExchangeInfoParams {
 }
 
 export interface NewSpotOrderParams<
-  T extends OrderType,
+  T extends OrderType = OrderType,
   RT extends OrderResponseType | undefined = undefined,
 > {
   symbol: string;

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -10,6 +10,7 @@ import {
   OrderTimeInForce,
   OrderType,
   RateLimiter,
+  SelfTradePreventionMode,
   SideEffects,
   StringBoolean,
   SymbolFilter,
@@ -643,6 +644,8 @@ export interface OrderResponseResult {
   timeInForce: OrderTimeInForce;
   type: OrderType;
   side: OrderSide;
+  workingTime: number;
+  selfTradePreventionMode: SelfTradePreventionMode;
 }
 
 export interface OrderFill {
@@ -669,6 +672,8 @@ export interface OrderResponseFull {
   marginBuyBorrowAmount?: number;
   marginBuyBorrowAsset?: string;
   isIsolated?: boolean;
+  workingTime: number;
+  selfTradePreventionMode: SelfTradePreventionMode;
   fills: OrderFill[];
 }
 
@@ -773,6 +778,7 @@ export interface CancelSpotOrderResult {
   orderId: number;
   orderListId: number;
   clientOrderId: string;
+  transactTime: number;
   price: numberInString;
   origQty: numberInString;
   executedQty: numberInString;
@@ -782,6 +788,7 @@ export interface CancelSpotOrderResult {
   type: OrderType;
   side: OrderSide;
   isIsolated?: boolean;
+  selfTradePreventionMode: SelfTradePreventionMode;
 }
 
 export interface SpotOrder {

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -6,6 +6,7 @@ import {
   OCOOrderStatus,
   OCOStatus,
   OrderBookRow,
+  OrderListOrderType,
   OrderResponseType,
   OrderSide,
   OrderStatus,
@@ -407,10 +408,13 @@ export interface ExchangeInfoParams {
   symbols?: string[];
 }
 
-export interface NewSpotOrderParams {
+export interface NewSpotOrderParams<
+  T extends OrderType,
+  RT extends OrderResponseType | undefined = undefined,
+> {
   symbol: string;
   side: OrderSide;
-  type: OrderType;
+  type: T;
   timeInForce?: OrderTimeInForce;
   quantity?: number;
   quoteOrderQty?: number;
@@ -419,12 +423,15 @@ export interface NewSpotOrderParams {
   stopPrice?: number;
   trailingDelta?: number;
   icebergQty?: number;
-  newOrderRespType?: OrderResponseType;
+  newOrderRespType?: RT;
   isIsolated?: StringBoolean;
   sideEffectType?: SideEffects;
 }
 
-export interface ReplaceSpotOrderParams extends NewSpotOrderParams {
+export interface ReplaceSpotOrderParams<
+  T extends OrderType,
+  RT extends OrderResponseType | undefined = undefined,
+> extends NewSpotOrderParams<T, RT> {
   cancelReplaceMode: 'STOP_ON_FAILURE' | 'ALLOW_FAILURE';
   cancelNewClientOrderId?: string;
   cancelOrigClientOrderId?: string;
@@ -629,11 +636,16 @@ export type OrderResponse =
   | OrderResponseResult
   | OrderResponseFull;
 
-export type OrderResponseTypeFor<T extends OrderResponseType> = T extends 'ACK'
+export type OrderResponseTypeFor<
+  RT extends OrderResponseType | undefined = undefined,
+  T extends OrderType | undefined = undefined,
+> = RT extends 'ACK'
   ? OrderResponseACK
-  : T extends 'RESULT'
+  : RT extends 'RESULT'
   ? OrderResponseResult
-  : T extends 'FULL'
+  : RT extends 'FULL'
+  ? OrderResponseFull
+  : T extends 'MARKET' | 'LIMIT'
   ? OrderResponseFull
   : OrderResponseACK;
 
@@ -692,7 +704,7 @@ export interface OrderResponseFull {
   fills: OrderFill[];
 }
 
-export interface OrderListResponse<T extends OrderResponseType = 'ACK'> {
+export interface OrderListResponse<RT extends OrderResponseType = 'ACK'> {
   orderListId: number;
   contingencyType: 'OCO';
   listStatusType: OCOStatus;
@@ -704,7 +716,7 @@ export interface OrderListResponse<T extends OrderResponseType = 'ACK'> {
     { symbol: string; orderId: number; clientOrderId: string },
     { symbol: string; orderId: number; clientOrderId: string },
   ];
-  orderReports: [OrderResponseTypeFor<T>, OrderResponseTypeFor<T>];
+  orderReports: [OrderResponseTypeFor<RT>, OrderResponseTypeFor<RT>];
 }
 
 export interface SOROrderFill {

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -727,7 +727,7 @@ export interface OrderListResponse<RT extends OrderResponseType = 'ACK'> {
 export interface OrderList {
   orderListId: number;
   contingencyType: 'OCO';
-  listStatusType: OCOOrderStatus;
+  listStatusType: OCOStatus;
   listOrderStatus: OCOOrderStatus;
   listClientOrderId: string;
   transactionTime: number;

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -804,8 +804,13 @@ export interface ReplaceSpotOrderResultError {
     | ReplaceSpotOrderCancelAllFailure;
 }
 
-export interface ReplaceSpotOrderResultSuccess
-  extends GenericReplaceSpotOrderResult<CancelSpotOrderResult, OrderResponse> {
+export interface ReplaceSpotOrderResultSuccess<
+  T extends OrderType,
+  RT extends OrderResponseType | undefined = undefined,
+> extends GenericReplaceSpotOrderResult<
+    CancelSpotOrderResult,
+    OrderResponseTypeFor<RT, T>
+  > {
   cancelResult: 'SUCCESS';
   newOrderResult: 'SUCCESS';
 }

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -420,6 +420,8 @@ export interface NewSpotOrderParams<
   quoteOrderQty?: number;
   price?: number;
   newClientOrderId?: string;
+  strategyId?: number;
+  strategyType?: number;
   stopPrice?: number;
   trailingDelta?: number;
   icebergQty?: number;

--- a/src/types/websockets.ts
+++ b/src/types/websockets.ts
@@ -18,6 +18,7 @@ import {
   OrderStatus,
   OrderTimeInForce,
   OrderType,
+  SelfTradePreventionMode,
 } from './shared';
 
 export type WsMarket =
@@ -480,6 +481,8 @@ export interface WsMessageSpotUserDataExecutionReportEventRaw
   Z: numberInString;
   Y: numberInString;
   Q: numberInString;
+  W: number;
+  V: SelfTradePreventionMode;
 }
 
 export interface WsMessageSpotUserDataExecutionReportEventFormatted
@@ -516,6 +519,8 @@ export interface WsMessageSpotUserDataExecutionReportEventFormatted
   cummulativeQuoteAssetTransactedQty: number;
   lastQuoteAssetTransactedQty: number;
   orderQuoteQty: number;
+  workingTime: number;
+  selfTradePreventionMode: SelfTradePreventionMode;
 }
 
 export interface OrderObjectRaw {

--- a/src/util/beautifier-maps.ts
+++ b/src/util/beautifier-maps.ts
@@ -357,6 +357,8 @@ export const BEAUTIFIER_EVENT_MAP = {
     Z: 'cummulativeQuoteAssetTransactedQty',
     Y: 'lastQuoteAssetTransactedQty',
     Q: 'orderQuoteQty',
+    W: 'workingTime',
+    V: 'selfTradePreventionMode',
   },
   tradeEvent: {
     e: 'eventType',

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -57,6 +57,7 @@ export interface WSClientConfigurableOptions {
     agent?: any;
   };
   wsUrl?: string;
+  baseUrl?: string;
 }
 
 export interface WebsocketClientOptions extends WSClientConfigurableOptions {

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -57,7 +57,6 @@ export interface WSClientConfigurableOptions {
     agent?: any;
   };
   wsUrl?: string;
-  baseUrl?: string;
 }
 
 export interface WebsocketClientOptions extends WSClientConfigurableOptions {


### PR DESCRIPTION
## Summary


- Add `submitNewOrderList()` because `New OCO` is [deprecated on Binance API](https://binance-docs.github.io/apidocs/spot/en/#new-oco-deprecated-trade).
- Make `sumbitNewOrder()` and `replaceOrder()` generic to have correct report type for the response.
- Add missing types of `workingTime`, `selfTradePreventionMode` and `transactTime`.
- Add missing fields `W` and `V` to the `executionReport`.
- Add the `OrderResponse` type for convenience.
- Add generic `OrderResponseTypeFor<T>` for a better developer experience. Please take a look at the example below.
- Add typing for "OCO" methods having `any`.
- Add `baseUrl` to the `WSClientConfigurableOptions`, so it can be used to subscribe to SpotUserDataStream on Testnet. Closes #414 
- Detach types: `CancelRestrictions`, `CancelReplaceMode`
- Prevent repeated inline use of `SelfTradePreventionMode`

## Example

Thanks to the new generic type, the new `submitNewOrderList` method returns a response with the exact TypeScript type based on the `newOrderRespType` parameter. If `newOrderRespType` is not provided, it defaults to the minimum `ACK`, not to mislead the developer.

```ts
// See https://binance-docs.github.io/apidocs/spot/en/#new-order-list-oco-trade

const responseA = await client.submitNewOrderList({ ...args, newOrderRespType: "FULL" });
const executedQtyA = responseA[0].executedQty; // responseA has correct type of "OrderResponseFull"

// TypeScript will warn the wrong type for the below code
const responseB = await client.submitNewOrderList({ ...args, newOrderRespType: "ACK" });
const executedQtyB = responseB[0].executedQty; // TYPING ERROR: responseB is type of "OrderResponseACK"

const responseC = await client.submitNewOrderList({ ...args }); // Defaults to "OrderResponseACK"
```

```ts
const responseA = await client.submitNewOrder({ ...args, type: "MARKET" }); // FULL
const responseB = await client.submitNewOrder({ ...args, type: "MARKET", newOrderRespType: "ACK" }); // ACK


const responseC = await client.submitNewOrder({ ...args, type: "STOP_LOSS" }); // ACK
const responseD = await client.submitNewOrder({ ...args, type: "STOP_LOSS", newOrderRespType: "FULL" }); // FULL
```

NOTE: I could have divided the features into multiple PRs, but since some of the changes modified the same files, I didn't want to mess with Git conflicts, so I divided them into multiple commits.