### PR TITLE
Update old margin SAPI interfaces as per docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "2.11.1",
+      "version": "2.11.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -79,7 +79,6 @@ import {
   ExchangeInfoParams,
   FixedAndActivityProjectParams,
   FixedAndActivityProjectPositionParams,
-  FlexibleSavingBasicParams,
   FuturesPositionRisk,
   GetApiKeyBrokerSubAccountParams,
   GetBrokerInfoResponse,
@@ -92,22 +91,15 @@ import {
   IsolatedMarginAccountTransferParams,
   LeftDailyPurchaseQuotaFlexibleProductResponse,
   MarginAccountLoanParams,
-  MarginRecordResponse,
   MarginTransactionResponse,
   NewSpotOrderParams,
   OrderBookResponse,
-  OrderResponseACK,
-  OrderResponseFull,
-  OrderResponseResult,
   TransferBrokerSubAccountParams,
   TransferBrokerSubAccount,
-  PurchaseFlexibleProductParams,
   PurchaseFlexibleProductResponse,
   PurchaseRecordParams,
   QueryCrossMarginAccountDetailsParams,
-  QueryCrossMarginPairParams,
   QueryCrossMarginPairResponse,
-  QueryMarginAssetParams,
   QueryMarginAssetResponse,
   QueryMarginPriceIndexResponse,
   QueryMarginRecordParams,
@@ -115,7 +107,6 @@ import {
   QueryMaxTransferOutAmountResponse,
   RawAccountTrade,
   RawTrade,
-  RedeemFlexibleProductParams,
   RemoveBSwapLiquidityParams,
   SpotOrder,
   StakingBasicParams,
@@ -199,6 +190,8 @@ import {
   OrderResponseTypeFor,
   OrderList,
   CancelOrderListResult,
+  GetMarginAccountBorrowRepayRecordsParams,
+  MarginAccountRecord,
 } from './types/spot';
 
 import {
@@ -954,34 +947,16 @@ export class MainClient extends BaseRestClient {
    *
    **/
 
-  crossMarginAccountTransfer(
-    params: CrossMarginAccountTransferParams,
-  ): Promise<MarginTransactionResponse> {
-    return this.postPrivate('sapi/v1/margin/transfer', params);
-  }
-
-  marginAccountBorrow(
+  submitMarginAccountBorrowRepay(
     params: MarginAccountLoanParams,
   ): Promise<MarginTransactionResponse> {
-    return this.postPrivate('sapi/v1/margin/loan', params);
+    return this.postPrivate('sapi/v1/margin/borrow-repay', params);
   }
 
-  marginAccountRepay(
-    params: MarginAccountLoanParams,
-  ): Promise<MarginTransactionResponse> {
-    return this.postPrivate('sapi/v1/margin/repay', params);
-  }
-
-  queryMarginAsset(
-    params: QueryMarginAssetParams,
-  ): Promise<QueryMarginAssetResponse> {
-    return this.get('sapi/v1/margin/asset', params);
-  }
-
-  queryCrossMarginPair(
-    params: QueryCrossMarginPairParams,
-  ): Promise<QueryCrossMarginPairResponse> {
-    return this.get('sapi/v1/margin/pair', params);
+  getMarginAccountBorrowRepayRecords(
+    params: GetMarginAccountBorrowRepayRecordsParams,
+  ): Promise<{ rows: MarginAccountRecord[]; total: number }> {
+    return this.getPrivate('sapi/v1/margin/borrow-repay', params);
   }
 
   getAllMarginAssets(): Promise<QueryMarginAssetResponse[]> {
@@ -1022,13 +997,13 @@ export class MainClient extends BaseRestClient {
 
   queryLoanRecord(
     params: QueryMarginRecordParams,
-  ): Promise<MarginRecordResponse> {
+  ): Promise<{ rows: MarginAccountRecord[]; total: number }> {
     return this.getPrivate('sapi/v1/margin/loan', params);
   }
 
   queryRepayRecord(
     params: QueryMarginRecordParams,
-  ): Promise<MarginRecordResponse> {
+  ): Promise<{ rows: MarginAccountRecord[]; total: number }> {
     return this.getPrivate('sapi/v1/margin/repay', params);
   }
 

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -993,14 +993,18 @@ export class MainClient extends BaseRestClient {
     return this.deletePrivate('sapi/v1/margin/openOrders', params);
   }
 
-  // TODO - https://binance-docs.github.io/apidocs/spot/en/#get-cross-margin-transfer-history-user_data
-
+  /**
+   * @deprecated on 2024-01-09, use getMarginAccountBorrowRepayRecords() instead
+   */
   queryLoanRecord(
     params: QueryMarginRecordParams,
   ): Promise<{ rows: MarginAccountRecord[]; total: number }> {
     return this.getPrivate('sapi/v1/margin/loan', params);
   }
 
+  /**
+   * @deprecated on 2024-01-09, use getMarginAccountBorrowRepayRecords() instead
+   */
   queryRepayRecord(
     params: QueryMarginRecordParams,
   ): Promise<{ rows: MarginAccountRecord[]; total: number }> {
@@ -1063,6 +1067,9 @@ export class MainClient extends BaseRestClient {
     return this.getPrivate('sapi/v1/margin/maxTransferable', params);
   }
 
+  /**
+   * @deprecated on 2024-01-09, use submitUniversalTransfer() instead
+   */
   isolatedMarginAccountTransfer(
     params: IsolatedMarginAccountTransferParams,
   ): Promise<MarginTransactionResponse> {

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -896,9 +896,10 @@ export interface MarginTransactionResponse {
 
 export interface MarginAccountLoanParams {
   asset: string;
-  isIsolated?: StringBoolean;
-  symbol?: string;
+  isIsolated: StringBoolean;
+  symbol: string;
   amount: number;
+  type: 'BORROW' | 'REPAY';
 }
 
 export interface QueryMarginAssetParams {
@@ -945,20 +946,26 @@ export interface QueryMarginRecordParams {
   archived?: boolean;
 }
 
-export type LoanStatus = 'PENDING' | 'CONFIRMED' | 'FAILED';
-
-export interface MarginRecordParams {
+export interface GetMarginAccountBorrowRepayRecordsParams {
+  asset?: string;
   isolatedSymbol?: string;
-  txId: number;
-  asset: string;
-  principal: numberInString;
-  timestamp: number;
-  status: LoanStatus;
+  txId?: number;
+  startTime?: number;
+  endTime?: number;
+  current?: number;
+  size?: number;
+  type: 'BORROW' | 'REPAY';
 }
 
-export interface MarginRecordResponse {
-  rows: Array<MarginRecordParams>;
-  total: number;
+export type LoanStatus = 'PENDING' | 'CONFIRMED' | 'FAILED';
+
+export interface MarginAccountRecord {
+  isolatedSymbol?: string;
+  asset: string;
+  principal: numberInString;
+  status: LoanStatus;
+  timestamp: number;
+  txId: number;
 }
 
 export interface QueryCrossMarginAccountDetailsParams {
@@ -969,7 +976,7 @@ export interface QueryCrossMarginAccountDetailsParams {
   totalNetAssetOfBtc: numberInString;
   tradeEnabled: boolean;
   transferEnabled: boolean;
-  userAssets: Array<MarginBalance>;
+  userAssets: MarginBalance[];
 }
 
 export interface BasicMarginAssetParams {


### PR DESCRIPTION
## Summary
From docs:


### 2024-01-09

According to the [announcement](https://www.binance.com/en/support/announcement/updates-on-binance-margin-sapi-endpoints-2024-03-31-a1868c686ce7448da8c3061a82a87b0c), Binance Margin will remove the following SAPI interfaces at 4:00 on March 31, 2024 (UTC). Please switch to the corresponding alternative interfaces in time:

POST /sapi/v1/margin/transfer will be removed, please replace with POST /sapi/v1/asset/transfer universal transfer
POST /sapi/v1/margin/isolated/transfer will be removed, please replace with POST /sapi/v1/asset/transfer universal transfer
POST /sapi/v1/margin/loan will be removed, please replace with the new POST /sapi/v1/margin/borrow-repay borrowing and repayment interface
POST /sapi/v1/margin/repay will be removed, please replace with the new POST /sapi/v1/margin/borrow-repay borrowing and repayment interface
GET /sapi/v1/margin/isolated/transfer will be removed, please replace it with GET /sapi/v1/margin/transfer to get total margin transfer history
GET /sapi/v1/margin/asset will be removed, please replace with GET /sapi/v1/margin/allAssets
GET /sapi/v1/margin/pair will be removed, please replace with GET /sapi/v1/margin/allPairs
GET /sapi/v1/margin/isolated/pair will be removed, please replace with GET /sapi/v1/margin/isolated/allPairs
GET /sapi/v1/margin/loan will be removed, please replace with GET /sapi/v1/margin/borrow-repay
GET /sapi/v1/margin/repay will be removed, please replace with GET /sapi/v1/margin/borrow-repay
GET /sapi/v1/margin/dribblet will be removed, please replace with GET /sapi/v1/asset/dribblet
GET /sapi/v1/margin/dust will be removed, please replace with POST /sapi/v1/asset/dust-btc
POST /sapi/v1/margin/dust will be removed, please replace with POST /sapi/v1/asset/dust
