### PR TITLE
Add `page` to  `GetIncomeHistoryParams`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "2.11.2",
+      "version": "2.11.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "description": "Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types/futures.ts
+++ b/src/types/futures.ts
@@ -205,6 +205,7 @@ export interface GetIncomeHistoryParams {
   startTime?: number;
   endTime?: number;
   limit?: number;
+  page?: number;
 }
 
 export interface IncomeHistory {


### PR DESCRIPTION
## Summary
- Futures method "Get Income History" supports `page` param
- Adding `page` to interface `GetIncomeHistoryParams`
- Reference https://developers.binance.com/docs/derivatives/usds-margined-futures/account/rest-api/Get-Income-History


