### PR TITLE
Add v2 method "Add IP Restriction for Sub-Account API key"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "2.11.4",
+  "version": "2.11.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "2.11.4",
+      "version": "2.11.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.11.4",
+  "version": "2.11.5",
   "description": "Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -29,6 +29,7 @@ import {
 import {
   AccountInformation,
   AddBSwapLiquidityParams,
+  AddIpRestriction,
   AggregateTrade,
   AllCoinsInformationResponse,
   ApiKeyBrokerSubAccount,
@@ -138,7 +139,7 @@ import {
   SubAccountListParams,
   SubAccountListResponse,
   SubAccountMarginAccountDetail,
-  SubAccountnableOrDisableIPRestriction,
+  SubAccountEnableOrDisableIPRestriction,
   SubAccountsMarginAccountSummary,
   SubAccountSpotAssetsSummary,
   SubAccountSpotAssetsSummaryParams,
@@ -538,7 +539,7 @@ export class MainClient extends BaseRestClient {
 
   subAccountEnableOrDisableIPRestriction(
     params: EnableOrDisableIPRestrictionForSubAccountParams,
-  ): Promise<SubAccountnableOrDisableIPRestriction> {
+  ): Promise<SubAccountEnableOrDisableIPRestriction> {
     return this.postPrivate(
       'sapi/v1/sub-account/subAccountApi/ipRestriction',
       params,
@@ -546,7 +547,7 @@ export class MainClient extends BaseRestClient {
   }
 
   subAccountAddIPList(
-    params: SubAccountnableOrDisableIPRestriction,
+    params: SubAccountEnableOrDisableIPRestriction,
   ): Promise<SubAccountAddOrDeleteIPList> {
     return this.postPrivate(
       'sapi/v1/sub-account/subAccountApi/ipRestriction/ipList',
@@ -554,9 +555,18 @@ export class MainClient extends BaseRestClient {
     );
   }
 
+  subAccountAddIPRestriction(
+    params: AddIpRestriction,
+  ): Promise<SubAccountEnableOrDisableIPRestriction> {
+    return this.postPrivate(
+      'sapi/v2/sub-account/subAccountApi/ipRestriction',
+      params,
+    );
+  }
+
   getSubAccountIPRestriction(
     params: BasicSubAccount,
-  ): Promise<SubAccountnableOrDisableIPRestriction> {
+  ): Promise<SubAccountEnableOrDisableIPRestriction> {
     return this.getPrivate(
       'sapi/v1/sub-account/subAccountApi/ipRestriction',
       params,
@@ -564,8 +574,8 @@ export class MainClient extends BaseRestClient {
   }
 
   subAccountDeleteIPList(
-    params: SubAccountnableOrDisableIPRestriction,
-  ): Promise<SubAccountnableOrDisableIPRestriction> {
+    params: SubAccountEnableOrDisableIPRestriction,
+  ): Promise<SubAccountEnableOrDisableIPRestriction> {
     return this.deletePrivate(
       'sapi/v1/sub-account/subAccountApi/ipRestriction/ipList',
       params,

--- a/src/types/futures.ts
+++ b/src/types/futures.ts
@@ -595,6 +595,7 @@ export interface FuturesAccountInformation {
   canDeposit: boolean;
   canWithdraw: boolean;
   updateTime: numberInString;
+  multiAssetsMargin: boolean;
   totalInitialMargin: numberInString;
   totalMaintMargin: numberInString;
   totalWalletBalance: numberInString;

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -1557,7 +1557,13 @@ export interface EnableOrDisableIPRestrictionForSubAccountParams
   ipRestrict: boolean;
 }
 
-export interface SubAccountnableOrDisableIPRestriction {
+export interface AddIpRestriction
+  extends BasicSubAccount {
+  status: string;
+  ipAddress: string;
+}
+
+export interface SubAccountEnableOrDisableIPRestriction {
   ipRestrict: boolean;
   ipList: string[];
   updateTime: number;


### PR DESCRIPTION
## Summary
1. Added **v2** method "Add IP Restriction for Sub-Account API key". ref https://developers.binance.com/docs/sub_account/api-management/Add-IP-Restriction-for-Sub-Account-API-key
2. Added boolean field `multiAssetsMargin` to futures account info response. ref https://developers.binance.com/docs/derivatives/usds-margined-futures/account/rest-api/Account-Information-V2
3. Fixed typo in interface name `SubAccountnableOrDisableIPRestriction`-> `SubAccountEnableOrDisableIPRestriction`> (missing E in word Enable)

