### PR TITLE
fix(typo): rename getAccountComissionRate to getAccountCommissionRate

### DIFF
--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -532,7 +532,7 @@ This table includes all endpoints from the official Exchange API docs and corres
 | [getBalance()](https://github.com/tiagosiebler/binance/blob/master/src/usdm-client.ts#L484) | :closed_lock_with_key:  | GET | `fapi/v2/balance` |
 | [getAccountInformationV3()](https://github.com/tiagosiebler/binance/blob/master/src/usdm-client.ts#L488) | :closed_lock_with_key:  | GET | `fapi/v3/account` |
 | [getAccountInformation()](https://github.com/tiagosiebler/binance/blob/master/src/usdm-client.ts#L496) | :closed_lock_with_key:  | GET | `fapi/v2/account` |
-| [getAccountComissionRate()](https://github.com/tiagosiebler/binance/blob/master/src/usdm-client.ts#L500) | :closed_lock_with_key:  | GET | `fapi/v1/commissionRate` |
+| [getAccountCommissionRate()](https://github.com/tiagosiebler/binance/blob/master/src/usdm-client.ts#L500) | :closed_lock_with_key:  | GET | `fapi/v1/commissionRate` |
 | [getFuturesAccountConfig()](https://github.com/tiagosiebler/binance/blob/master/src/usdm-client.ts#L506) | :closed_lock_with_key:  | GET | `fapi/v1/accountConfig` |
 | [getFuturesSymbolConfig()](https://github.com/tiagosiebler/binance/blob/master/src/usdm-client.ts#L510) | :closed_lock_with_key:  | GET | `fapi/v1/symbolConfig` |
 | [getUserForceOrders()](https://github.com/tiagosiebler/binance/blob/master/src/usdm-client.ts#L514) | :closed_lock_with_key:  | GET | `fapi/v1/rateLimit/order` |
@@ -623,7 +623,7 @@ This table includes all endpoints from the official Exchange API docs and corres
 | [setIsolatedPositionMargin()](https://github.com/tiagosiebler/binance/blob/master/src/coinm-client.ts#L423) | :closed_lock_with_key:  | POST | `dapi/v1/positionMargin` |
 | [getPositionMarginChangeHistory()](https://github.com/tiagosiebler/binance/blob/master/src/coinm-client.ts#L429) | :closed_lock_with_key:  | GET | `dapi/v1/positionMargin/history` |
 | [getBalance()](https://github.com/tiagosiebler/binance/blob/master/src/coinm-client.ts#L440) | :closed_lock_with_key:  | GET | `dapi/v1/balance` |
-| [getAccountComissionRate()](https://github.com/tiagosiebler/binance/blob/master/src/coinm-client.ts#L444) | :closed_lock_with_key:  | GET | `dapi/v1/commissionRate` |
+| [getAccountCommissionRate()](https://github.com/tiagosiebler/binance/blob/master/src/coinm-client.ts#L444) | :closed_lock_with_key:  | GET | `dapi/v1/commissionRate` |
 | [getAccountInformation()](https://github.com/tiagosiebler/binance/blob/master/src/coinm-client.ts#L450) | :closed_lock_with_key:  | GET | `dapi/v1/account` |
 | [getNotionalAndLeverageBrackets()](https://github.com/tiagosiebler/binance/blob/master/src/coinm-client.ts#L457) | :closed_lock_with_key:  | GET | `dapi/v2/leverageBracket` |
 | [getCurrentPositionMode()](https://github.com/tiagosiebler/binance/blob/master/src/coinm-client.ts#L466) | :closed_lock_with_key:  | GET | `dapi/v1/positionSide/dual` |

--- a/examples/apidoc/CoinMClient/getAccountComissionRate.js
+++ b/examples/apidoc/CoinMClient/getAccountComissionRate.js
@@ -11,7 +11,7 @@ const client = new CoinMClient({
   apiSecret: 'insert_api_secret_here',
 });
 
-client.getAccountComissionRate(params)
+client.getAccountCommissionRate(params)
   .then((response) => {
     console.log(response);
   })

--- a/examples/apidoc/USDMClient/getAccountComissionRate.js
+++ b/examples/apidoc/USDMClient/getAccountComissionRate.js
@@ -11,7 +11,7 @@ const client = new USDMClient({
   apiSecret: 'insert_api_secret_here',
 });
 
-client.getAccountComissionRate(params)
+client.getAccountCommissionRate(params)
   .then((response) => {
     console.log(response);
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.13.11",
+  "version": "2.13.12",
   "description": "Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/coinm-client.ts
+++ b/src/coinm-client.ts
@@ -441,6 +441,15 @@ export class CoinMClient extends BaseRestClient {
     return this.getPrivate('dapi/v1/balance');
   }
 
+  /**
+   * @deprecated Please use `getAccountCommissionRate()` instead. This will be removed in the next major release.
+   */
+  getAccountComissionRate(
+    params: BasicSymbolParam,
+  ): Promise<UserCommissionRate> {
+    return this.getPrivate('dapi/v1/commissionRate', params);
+  }
+
   getAccountCommissionRate(
     params: BasicSymbolParam,
   ): Promise<UserCommissionRate> {

--- a/src/coinm-client.ts
+++ b/src/coinm-client.ts
@@ -441,7 +441,7 @@ export class CoinMClient extends BaseRestClient {
     return this.getPrivate('dapi/v1/balance');
   }
 
-  getAccountComissionRate(
+  getAccountCommissionRate(
     params: BasicSymbolParam,
   ): Promise<UserCommissionRate> {
     return this.getPrivate('dapi/v1/commissionRate', params);

--- a/src/usdm-client.ts
+++ b/src/usdm-client.ts
@@ -497,6 +497,15 @@ export class USDMClient extends BaseRestClient {
     return this.getPrivate('fapi/v2/account');
   }
 
+  /**
+   * @deprecated Please use `getAccountCommissionRate()` instead. This will be removed in the next major release.
+   */
+  getAccountComissionRate(
+    params: BasicSymbolParam,
+  ): Promise<UserCommissionRate> {
+    return this.getPrivate('fapi/v1/commissionRate', params);
+  }
+
   getAccountCommissionRate(
     params: BasicSymbolParam,
   ): Promise<UserCommissionRate> {

--- a/src/usdm-client.ts
+++ b/src/usdm-client.ts
@@ -497,7 +497,7 @@ export class USDMClient extends BaseRestClient {
     return this.getPrivate('fapi/v2/account');
   }
 
-  getAccountComissionRate(
+  getAccountCommissionRate(
     params: BasicSymbolParam,
   ): Promise<UserCommissionRate> {
     return this.getPrivate('fapi/v1/commissionRate', params);

--- a/test/futures-usdm/private.test.ts
+++ b/test/futures-usdm/private.test.ts
@@ -95,8 +95,8 @@ describe('Private Futures USDM REST API Endpoints', () => {
       });
     });
 
-    it('getAccountComissionRate()', async () => {
-      expect(await api.getAccountComissionRate({ symbol })).toMatchObject({
+    it('getAccountCommissionRate()', async () => {
+      expect(await api.getAccountCommissionRate({ symbol })).toMatchObject({
         makerCommissionRate: expect.any(String),
         symbol: expect.any(String),
         takerCommissionRate: expect.any(String),


### PR DESCRIPTION
## Summary
Correct typo in function name from `getAccountComissionRate` to `getAccountCommissionRate`
