### PR TITLE
feat(types/spot): add 'baseCommissionPrecision' and 'quoteCommissionPrecision' to SymbolExchangeInfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.13.13",
+  "version": "2.13.14",
   "description": "Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -534,6 +534,8 @@ export interface SymbolExchangeInfo {
   quoteAsset: string;
   quotePrecision: number;
   quoteAssetPrecision: number;
+  baseCommissionPrecision: number;
+  quoteCommissionPrecision: number;
   orderTypes: OrderType[];
   icebergAllowed: boolean;
   ocoAllowed: boolean;


### PR DESCRIPTION
## Summary
`SymbolExchangeInfo` is currently missing `baseCommissionPrecision` and `quoteCommissionPrecision` props.
https://developers.binance.com/docs/binance-spot-api-docs/rest-api/public-api-endpoints#exchange-information
