### PR TITLE
fix(v2.13.18, #482): pass-through number type for submit multiple orders endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "2.13.17",
+  "version": "2.13.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "2.13.17",
+      "version": "2.13.18",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",
@@ -2241,10 +2241,11 @@
       "peer": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -7511,9 +7512,9 @@
       "peer": true
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.13.17",
+  "version": "2.13.18",
   "description": "Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/usdm-client.ts
+++ b/src/usdm-client.ts
@@ -321,8 +321,8 @@ export class USDMClient extends BaseRestClient {
    *
    * Known issue: `quantity` and `price` should be sent as strings
    */
-  submitMultipleOrders(
-    orders: NewFuturesOrderParams<string>[],
+  submitMultipleOrders<TNumberType = number>(
+    orders: NewFuturesOrderParams<TNumberType>[],
   ): Promise<(NewOrderResult | NewOrderError)[]> {
     const stringOrders = orders.map((order) => {
       const orderToStringify = { ...order };


### PR DESCRIPTION
## Summary
<!-- Add a brief description of the pr: -->
Some fields for new orders can be string or number (unofficially). The existing type was unintentionally strict (on the wrong side of this). Now it allows string or number and defaults to string.

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
