### PR TITLE
extend GetFlexibleRewardsHistoryParams field type with 'ALL' option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -2894,7 +2894,7 @@ export interface GetFlexibleRewardsHistoryParams {
   asset?: string;
   startTime?: number;
   endTime?: number;
-  type: 'BONUS' | 'REALTIME' | 'REWARDS';
+  type: 'BONUS' | 'REALTIME' | 'REWARDS' | 'ALL';
   current?: number;
   size?: number;
 }


### PR DESCRIPTION
## Summary

extend GetFlexibleRewardsHistoryParams field type with 'ALL' option according to https://developers.binance.com/docs/simple_earn/history/Get-Flexible-Rewards-History

