### PR TITLE
update types : EnumDepositStatus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "2.15.0",
+      "version": "2.15.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "description": "Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -223,7 +223,10 @@ export interface TransferBrokerSubAccount {
 export enum EnumDepositStatus {
   Pending = 0,
   CreditedButCannotWithdraw = 6,
+  WrongDeposit = 7,
+  WaitingUserConfirm = 8,
   Success = 1,
+  Rejected = 2,
 }
 
 export type DepositStatusCode = `${EnumDepositStatus}`;


### PR DESCRIPTION
I added some new entries to EnumDepositStatus in /types/spot.d.ts as the doc says at [this link](https://developers.binance.com/docs/wallet/capital/deposite-history)

The following entries were missing : 

- WrongDeposit = 7
- WaitingUserConfirm = 8
- Rejected = 2

![image](https://github.com/user-attachments/assets/10a1626c-b305-495c-95d9-db3cc5f3606e)
