### PR TITLE
fix(v2.15.6, #507): correct handling for symbols array in rolling window tickers endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "2.15.4",
+  "version": "2.15.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "2.15.3",
+      "version": "2.15.6",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.15.5",
+  "version": "2.15.6",
   "description": "Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -739,6 +739,13 @@ export class MainClient extends BaseRestClient {
   getRollingWindowTicker(
     params: RollingWindowTickerParams,
   ): Promise<TradingDayTickerFull[] | TradingDayTickerMini[]> {
+    if (params && params['symbols'] && Array.isArray(params['symbols'])) {
+      const symbols = (params as SymbolArrayParam).symbols;
+      const symbolsQueryParam = JSON.stringify(symbols);
+
+      return this.get('api/v3/ticker?symbols=' + symbolsQueryParam);
+    }
+
     return this.get('api/v3/ticker', params);
   }
 

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -740,9 +740,7 @@ export class MainClient extends BaseRestClient {
     params: RollingWindowTickerParams,
   ): Promise<TradingDayTickerFull[] | TradingDayTickerMini[]> {
     if (params && params['symbols'] && Array.isArray(params['symbols'])) {
-      const symbols = (params as SymbolArrayParam).symbols;
-      const symbolsQueryParam = JSON.stringify(symbols);
-
+      const symbolsQueryParam = JSON.stringify(params.symbols);
       return this.get('api/v3/ticker?symbols=' + symbolsQueryParam);
     }
 


### PR DESCRIPTION
## Summary
Fixes how the "symbols" array parameter is built into a request for the rolling window ticker endpoint:
```
    const rollingTicker = await client.getRollingWindowTicker({
      symbols: ['BTCUSDT', 'ETHUSDT'],
      windowSize: '5m',
      type: 'MINI',
    });
    console.log('getRollingWindowTicker', rollingTicker);
```

Fixes #507.
<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
