### PR TITLE
fix(v2.5.7, #507): fix missing parameters when passing symbols in rolling tickers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "2.15.6",
+  "version": "2.15.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "2.15.6",
+      "version": "2.15.7",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.15.6",
+  "version": "2.15.7",
   "description": "Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -740,8 +740,13 @@ export class MainClient extends BaseRestClient {
     params: RollingWindowTickerParams,
   ): Promise<TradingDayTickerFull[] | TradingDayTickerMini[]> {
     if (params && params['symbols'] && Array.isArray(params['symbols'])) {
-      const symbolsQueryParam = JSON.stringify(params.symbols);
-      return this.get('api/v3/ticker?symbols=' + symbolsQueryParam);
+      const { symbols, ...otherParams } = params;
+      const symbolsQueryParam = JSON.stringify(symbols);
+
+      return this.get(
+        'api/v3/ticker?symbols=' + symbolsQueryParam,
+        otherParams,
+      );
     }
 
     return this.get('api/v3/ticker', params);


### PR DESCRIPTION
## Summary
<!-- Add a brief description of the pr: -->
Fixes missing parameters when "symbols" property is used with rolling tickers. Fixes issue discussed in #507.

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
