### PR TITLE
fix(v2.15.10): params in getIsolatedMarginAccountInfo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "2.15.8",
+  "version": "2.15.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "2.15.8",
+      "version": "2.15.10",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.15.9",
+  "version": "2.15.10",
   "description": "Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -1281,7 +1281,7 @@ export class MainClient extends BaseRestClient {
   getIsolatedMarginAccountInfo(params?: {
     symbols?: string;
   }): Promise<IsolatedMarginAccountInfo> {
-    return this.getPrivate('sapi/v1/margin/isolated/account', { params });
+    return this.getPrivate('sapi/v1/margin/isolated/account', params);
   }
 
   getIsolatedMarginFeeData(


### PR DESCRIPTION
## Summary
Symbols were not taken into account in `MainClient::getIsolatedMarginAccountInfo` because of the extra curly braces

## Additional Information
No breaking changes. Symbols will now be taken into account
