### PR TITLE
fix(v2.15.14): fixes #527 issue with max order ID length from portfolio margin, fixes #523 & #526 issue with number handling from multiple orders endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "2.15.13",
+  "version": "2.15.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "2.15.13",
+      "version": "2.15.14",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "2.15.13",
+  "version": "2.15.14",
   "description": "Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/util/requestUtils.ts
+++ b/src/util/requestUtils.ts
@@ -88,7 +88,7 @@ export function getOrderIdPrefix(network: BinanceBaseUrlKey): string {
 }
 
 export function generateNewOrderId(network: BinanceBaseUrlKey): string {
-  const id = nanoid(25);
+  const id = nanoid(22);
   const prefixedId = 'x-' + getOrderIdPrefix(network) + id;
 
   return prefixedId;


### PR DESCRIPTION
- fixes #527 issue with max order ID length from portfolio margin, 
- fixes #523 & #526 issue with number handling from multiple orders endpoint, by automatically parsing number quantity and price to string, but only if (a string, defined, has a value that's not 0). Tested to be working:

```
client.submitMultipleOrders([
      {
        side: 'BUY',
        symbol: 'BTCUSDT',
        type: 'MARKET',
        quantity: 0.01,
        positionSide: 'LONG',
      },
      {
        side: 'BUY',
        symbol: 'BTCUSDT',
        type: 'MARKET',
        quantity: 0.01,
        positionSide: 'LONG',
      },
    ]);
    ```
