### PR TITLE
fix(v3.1.3, #600): handle risk of circular reference in WS API Client exception handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Professional Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types/websockets/ws-general.ts
+++ b/src/types/websockets/ws-general.ts
@@ -1,4 +1,5 @@
 import { AxiosRequestConfig } from 'axios';
+import { ClientRequestArgs } from 'http';
 import WebSocket from 'isomorphic-ws';
 
 import { RestClientOptions } from '../../util/requestUtils';
@@ -168,7 +169,7 @@ export interface WSClientConfigurableOptions {
   wsOptions?: {
     protocols?: string[];
     agent?: any;
-  };
+  } & Partial<WebSocket.ClientOptions | ClientRequestArgs>;
 
   wsUrl?: string;
 

--- a/src/websocket-api-client.ts
+++ b/src/websocket-api-client.ts
@@ -1237,7 +1237,17 @@ export class WebsocketAPIClient {
           console.info(new Date(), 'ws has authenticated ', data?.wsKey);
         })
         .on('exception', (data) => {
-          console.error(new Date(), 'ws exception: ', JSON.stringify(data));
+          try {
+            // Blind JSON.stringify can fail on circular references
+            console.error(
+              new Date(),
+              'ws exception: ',
+              JSON.stringify(data),
+              // JSON.stringify({ ...data, target: 'WebSocket' }),
+            );
+          } catch {
+            console.error(new Date(), 'ws exception: ', data);
+          }
         });
     }
   }


### PR DESCRIPTION

## Summary
- Fixes #600 - crash if exception includes WebSocket reference, when using WebsocketAPIClient
<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

## PR Checklist

As part of the PR, make sure you have:
- [ ] No breaking changes / documented all breaking changes clearly.
- [ ] Updated & checked that all tests pass.
- [ ] Increased the version number in the package.json <!-- Only if your changes need to be published to npm -->
- [ ] Checked `npm install` runs without issue.
- [ ] Included the package-lock.json, if it changed after npm install <!-- The version number should update, if you also updated the package.json version number -->
- [ ] Checked `npm run build` runs without issue.
- [ ] Updated the endpoint map (optional, if you know how).
- [ ] Run llms.txt generator (optional, if you know how).
