### PR TITLE
fix(v3.2.0): update options ws connectivity and example, audit dependency bump

### DIFF
--- a/examples/WebSockets/ws-public.ts
+++ b/examples/WebSockets/ws-public.ts
@@ -279,28 +279,44 @@ import {
     );
 
     /**
-     * Subscribe to each available european options market data websocket topic, the new way:
+     * Subscribe to each available options market data websocket topic, the new way:
      *
-     * https://developers.binance.com/docs/derivatives/option/websocket-market-streams/New-Symbol-Info
-     *
+     * https://developers.binance.com/docs/derivatives/options-trading/websocket-market-streams/New-Symbol-Info
      * https://eapi.binance.com/eapi/v1/exchangeInfo
      */
-    const optionsAsset = 'ETH';
-    const optionsExpiration = '250328';
-    const optionsSymbol = 'BTC-250328-140000-C';
+
+    const optionsAsset = 'ethusdt';
+    const optionsExpiration = '260128'; // YYMMDD
+    const optionsSymbol = 'ETH-260128-3000-C';
+    const optionsSymbol2 = 'ETH-260129-2950-C';
+    const KlineInterval = '1m';
     await wsClient.subscribe(
       [
-        'option_pair',
+        '!optionSymbol',
         `${optionsAsset}@openInterest@${optionsExpiration}`,
-        `${optionsAsset}@markPrice`,
-        `${optionsSymbol}@kline_1m`,
-        `${optionsAsset}@ticker@${optionsExpiration}`,
-        `${symbol}@index`,
-        `${optionsAsset}@trade`,
-        `${optionsSymbol}@depth100`,
+        `${optionsAsset}@optionMarkPrice`,
+        `${optionsSymbol}@kline_${KlineInterval}`,
+        `${optionsSymbol2}@kline_${KlineInterval}`,
+        '!index@arr',
+        `${symbol}@bookTicker`,
+        `${symbol}@optionTicker`,
+        `${symbol}@optionTrade`,
+        `${symbol}@depth5@100ms`,
+        `${symbol}@depth@100ms`,
       ],
       'eoptions',
     );
+
+    // You can send raw commands, such as asking for list of active subscriptions after 5 seconds. Use with caution:
+    // setTimeout(() => {
+    //   wsClient.tryWsSend(
+    //     'eoptions',
+    //     JSON.stringify({
+    //       method: 'LIST_SUBSCRIPTIONS',
+    //       id: Date.now(),
+    //     }),
+    //   );
+    // }, 1000 * 5);
 
     // /**
     //  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "3.1.9",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "3.1.9",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",
@@ -2602,9 +2602,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -8514,9 +8514,9 @@
       "dev": true
     },
     "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true
     },
     "diff-sequences": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "3.1.9",
+  "version": "3.2.0",
   "description": "Professional Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/util/websockets/websocket-util.ts
+++ b/src/util/websockets/websocket-util.ts
@@ -167,9 +167,10 @@ export const WS_KEY_URL_MAP: Record<WsKey, string> = {
   coinmWSAPI: 'wss://ws-dapi.binance.com',
   coinmWSAPITestnet: 'coinmWSAPITestnet',
 
-  // https://developers.binance.com/docs/derivatives/option/websocket-market-streams
-  // https://developers.binance.com/docs/derivatives/option/user-data-streams
-  eoptions: 'wss://nbstream.binance.com/eoptions',
+  // https://developers.binance.com/docs/derivatives/options-trading/websocket-market-streams
+  // https://developers.binance.com/docs/derivatives/options-trading/user-data-streams
+  eoptions: 'wss://fstream.binance.com',
+  // eoptions: 'wss://nbstream.binance.com/eoptions',
   // optionsTestnet: 'wss://testnetws.binanceops.com',
 
   // https://developers.binance.com/docs/derivatives/portfolio-margin/user-data-streams
@@ -303,9 +304,9 @@ export function getWsURLSuffix(
     case 'eoptions':
       switch (connectionType) {
         case 'market':
-          return '/stream';
+          return '/market/stream';
         case 'userData':
-          return '/ws';
+          return '/private/ws';
         default: {
           throw neverGuard(
             connectionType,


### PR DESCRIPTION
## Summary
- Old options wss url is nowhere to be seen in the API docs anymore. Only one mention in the changelog from a few years ago but no deprecation notice. 
- Shifted to the url mentioned in the docs and updated the example with the new topic formats. Seems to be working again.
- Minor dependency bump after audit.
<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

## PR Checklist

As part of the PR, make sure you have:
- [ ] No breaking changes / documented all breaking changes clearly.
- [ ] Updated & checked that all tests pass.
- [ ] Increased the version number in the package.json <!-- Only if your changes need to be published to npm -->
- [ ] Checked `npm install` runs without issue.
- [ ] Included the package-lock.json, if it changed after npm install <!-- The version number should update, if you also updated the package.json version number -->
- [ ] Checked `npm run build` runs without issue.
- [ ] Updated the endpoint map (optional, if you know how).
- [ ] Run llms.txt generator (optional, if you know how).
