### PR TITLE
feat(v3.3.1): add support for WS API user data stream for RSA & HMAC keys

### DIFF
--- a/examples/WebSockets/Private(userdata)/ws-userdata-wsapi.ts
+++ b/examples/WebSockets/Private(userdata)/ws-userdata-wsapi.ts
@@ -137,7 +137,7 @@ async function main() {
     beautify: true,
 
     // Enforce testnet ws connections, regardless of supplied wsKey:
-    testnet: true,
+    // testnet: true,
 
     // Note: unless you set this to false, the SDK will automatically call
     // the `subscribeUserDataStream()` method again if reconnected (if you called it before):

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Professional Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types/websockets/ws-api.ts
+++ b/src/types/websockets/ws-api.ts
@@ -172,6 +172,7 @@ export const WS_API_Operations = [
   'userDataStream.ping',
   'userDataStream.stop',
   'userDataStream.subscribe',
+  'userDataStream.subscribe.signature',
   'userDataStream.unsubscribe',
 ] as const;
 
@@ -419,6 +420,7 @@ export interface WsAPITopicRequestParamMap<TWSKey = WsKey> {
   'userDataStream.ping': WSAPIUserDataListenKeyRequest;
   'userDataStream.stop': WSAPIUserDataListenKeyRequest;
   'userDataStream.subscribe': void;
+  'userDataStream.subscribe.signature': { timestamp: number };
   'userDataStream.unsubscribe': void;
 }
 /**
@@ -562,5 +564,6 @@ export interface WsAPIOperationResponseMap {
   'userDataStream.ping': WSAPIResponse<object>;
   'userDataStream.stop': WSAPIResponse<object>;
   'userDataStream.subscribe': WSAPIResponse<object>;
+  'userDataStream.subscribe.signature': WSAPIResponse<object>;
   'userDataStream.unsubscribe': WSAPIResponse<object>;
 }


### PR DESCRIPTION
## Summary
- Effective on 2026-02-20 07:00 (UTC), Binance's listenKey mechanism for Spot will be discontinued.
- Users are expected to migrate to the WebSocket API user data stream.
- This PR adds full support for RSA & HMAC keys to the WebSocket API user data stream integration.
- Example: https://siebly.io/examples/Binance/WebSockets/Private(userdata)/ws-userdata-wsapi.ts#L158-L162
- Binance announcement here: https://www.binance.com/en/support/announcement/detail/80b38c8954bf4965b21eeb3c5fc6edfa?utm_source=EnglishTelegram&utm_medium=GlobalCommunity&utm_campaign=AnnouncementBot

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

## PR Checklist

As part of the PR, make sure you have:
- [ ] No breaking changes / documented all breaking changes clearly.
- [ ] Updated & checked that all tests pass.
- [ ] Increased the version number in the package.json <!-- Only if your changes need to be published to npm -->
- [ ] Checked `npm install` runs without issue.
- [ ] Included the package-lock.json, if it changed after npm install <!-- The version number should update, if you also updated the package.json version number -->
- [ ] Checked `npm run build` runs without issue.
- [ ] Updated the endpoint map (optional, if you know how).
- [ ] Run llms.txt generator (optional, if you know how).
