### PR TITLE
fix: rename activationPrice to activatePrice in FuturesNewAlgoOrderParams

### DIFF
--- a/src/types/futures.ts
+++ b/src/types/futures.ts
@@ -1011,7 +1011,7 @@ export interface FuturesNewAlgoOrderParams {
   closePosition?: BooleanString;
   priceProtect?: BooleanString;
   reduceOnly?: BooleanString;
-  activationPrice?: numberInString;
+  activatePrice?: numberInString;
   callbackRate?: numberInString;
   clientAlgoId?: string; // ^[\.A-Z\:/a-z0-9_-]{1,36}$
   selfTradePreventionMode?: SelfTradePreventionMode;


### PR DESCRIPTION
## Summary
Fix incorrect parameter name in FuturesNewAlgoOrderParams.

According to Binance documentation, the correct parameter name is activatePrice, not activationPrice.

Fixes #647

## Additional Information

## PR Checklist

As part of the PR, make sure you have:
- [ ] No breaking changes / documented all breaking changes clearly.
- [ ] Updated & checked that all tests pass.
- [ ] Increased the version number in the package.json <!-- Only if your changes need to be published to npm -->
- [ ] Checked `npm install` runs without issue.
- [ ] Included the package-lock.json, if it changed after npm install <!-- The version number should update, if you also updated the package.json version number -->
- [ ] Checked `npm run build` runs without issue.
- [ ] Updated the endpoint map (optional, if you know how).
- [ ] Run llms.txt generator (optional, if you know how).
