### PR TITLE
feat(v3.5.0, #653): add support for Binance USDM Futures base URL split & migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 [1]: https://www.npmjs.com/package/binance
 
 > [!TIP]
-> Upcoming change: As part of the [Siebly.io](https://siebly.io/?ref=ghbinance) brand, this SDK will soon be hosted under the [Siebly.io GitHub organisation](https://github.com/sieblyio). The migration is seamless and requires no user changes.
+> Upcoming change: As part of the [Siebly.io](https://siebly.io/) brand, this SDK will soon be hosted under the [Siebly.io GitHub organisation](https://github.com/sieblyio). The migration is seamless and requires no user changes.
 
 Updated & performant JavaScript & Node.js SDK for the Binance REST APIs and WebSockets:
 
@@ -55,6 +55,7 @@ Updated & performant JavaScript & Node.js SDK for the Binance REST APIs and WebS
   - Real API calls in e2e tests.
 - Proxy support via axios integration.
 - Active community support & collaboration in telegram: [Node.js Algo Traders](https://t.me/nodetraders).
+- QuickStart Guide: https://siebly.io/sdk/binance/javascript
 
 ## Table of Contents
 

--- a/examples/WebSockets/Private(userdata)/ws-userdata-listenkey.ts
+++ b/examples/WebSockets/Private(userdata)/ws-userdata-listenkey.ts
@@ -35,7 +35,7 @@ import {
   // Optional, hook and customise logging behavior
   const logger = {
     ...DefaultLogger,
-    trace: (msg: string, context?: any) => {
+    trace: (msg: string, context?: unknown) => {
       if (ignoredTraceLogMsgs.includes(msg)) {
         return;
       }
@@ -156,18 +156,24 @@ import {
    * Once subscribed, you don't need to do anything else. Listen-key keep-alive, refresh, reconnects, etc are all automatically handled by the SDK.
    */
 
-  // Example 1: Spot, by default, routes to the "main" wss domain "wss://stream.binance.com:9443".
-  // No parameters needed, just call the subscribe function.
-  wsClient.subscribeSpotUserDataStream();
+  /**
+   * Example 1: Spot, by default, routes to the "main" wss domain "wss://stream.binance.com:9443".
+   * No parameters needed, just call the subscribe function.
+   *
+   * Note: the listen key workflow is deprecated for "spot" markets. Use the
+   * WebSocket API `userDataStream.subscribe` workflow instead (only available
+   * in spot right now). See `subscribeUserDataStream()` in the WebsocketAPIClient.
+   */
+  // wsClient.subscribeSpotUserDataStream();
 
   // // Example 2: Optional: subscribe to spot via other wss domains
-  wsClient.subscribeSpotUserDataStream('main2'); // routed to "wss://stream.binance.com:443"
+  // wsClient.subscribeSpotUserDataStream('main2'); // routed to "wss://stream.binance.com:443"
 
   // // Example 3: cross margin
-  wsClient.subscribeCrossMarginUserDataStream();
+  // wsClient.subscribeCrossMarginUserDataStream();
 
-  // Example 4: isolated margin
-  wsClient.subscribeIsolatedMarginUserDataStream('BTCUSDC');
+  // // Example 4: isolated margin
+  // wsClient.subscribeIsolatedMarginUserDataStream('BTCUSDC');
 
   /**
    * Futures
@@ -180,10 +186,10 @@ import {
   wsClient.subscribeCoinFuturesUserDataStream();
 
   // Example 7: portfolio margin
-  // wsClient.subscribePortfolioMarginUserDataStream();
+  wsClient.subscribePortfolioMarginUserDataStream();
 
   // Example 8: portfolio margin pro
-  // wsClient.subscribePortfolioMarginUserDataStream('portfolioMarginProUserData');
+  wsClient.subscribePortfolioMarginUserDataStream('portfolioMarginProUserData');
 
   // after 15 seconds, kill user data connections one by one (or all at once)
   setTimeout(() => {

--- a/examples/WebSockets/Public/ws-usdm-market.ts
+++ b/examples/WebSockets/Public/ws-usdm-market.ts
@@ -1,0 +1,255 @@
+import {
+  DefaultLogger,
+  isWsDiffBookDepthEventFormatted,
+  isWsPartialBookDepthEventFormatted,
+  WebsocketClient,
+  WS_KEY_MAP,
+} from '../../../src';
+
+// or, with the npm package
+/*
+import {
+  DefaultLogger,
+  isWsDiffBookDepthEventFormatted,
+  isWsPartialBookDepthEventFormatted,
+  WebsocketClient,
+  WS_KEY_MAP,
+} from 'binance';
+*/
+
+(async () => {
+  // Without typescript:
+  // const logger = {
+  const logger: DefaultLogger = {
+    ...DefaultLogger,
+    trace: (...params) => {
+      // A simple way to suppress heartbeats but receive all other traces
+      // if (params[0].includes('ping') || params[0].includes('pong')) {
+      //   return;
+      // }
+      console.log('\n', new Date(), 'trace ', ...params);
+    },
+  };
+
+  const wsClient = new WebsocketClient(
+    {
+      // Optional: when enabled, the SDK will try to format incoming data into more readable objects.
+      // Beautified data is emitted via the "formattedMessage" event
+      beautify: true,
+    },
+    logger, // Optional: customise logging behaviour by extending or overwriting the default logger implementation
+  );
+
+  // Raw unprocessed incoming data, e.g. if you have the beautifier disabled
+  wsClient.on('message', (data) => {
+    // console.log('raw message received ', JSON.stringify(data, null, 2));
+    console.log('raw message received ', JSON.stringify(data));
+    // console.log('log rawMessage: ', data);
+  });
+
+  // Formatted data that has gone through the beautifier
+  wsClient.on('formattedMessage', (data) => {
+    // console.log('log formattedMessage: ', data);
+
+    /**
+     * Optional: we've included type-guards for many formatted websocket topics.
+     *
+     * These can be used within `if` blocks to narrow down specific event types (even for non-typescript users).
+     */
+    // if (isWsAggTradeFormatted(data)) {
+    //   console.log('log agg trade: ', data);
+    //   return;
+    // }
+
+    // // For one symbol
+    // if (isWsFormattedMarkPriceUpdateEvent(data)) {
+    //   console.log('log mark price: ', data);
+    //   return;
+    // }
+
+    // // for many symbols
+    // if (isWsFormattedMarkPriceUpdateArray(data)) {
+    //   console.log('log mark prices: ', data);
+    //   return;
+    // }
+
+    // if (isWsFormattedKline(data)) {
+    //   console.log('log kline: ', data);
+    //   return;
+    // }
+
+    // if (isWsFormattedTrade(data)) {
+    //   return console.log('log trade: ', data);
+    // }
+
+    // if (isWsFormattedForceOrder(data)) {
+    //   return console.log('log force order: ', data);
+    // }
+
+    // if (isWsFormatted24hrTickerArray(data)) {
+    //   return console.log('log 24hr ticker array: ', data);
+    // }
+
+    // if (isWsFormattedRollingWindowTickerArray(data)) {
+    //   return console.log('log rolling window ticker array: ', data);
+    // }
+
+    // if (isWsFormatted24hrTicker(data)) {
+    //   return console.log('log 24hr ticker: ', data);
+    // }
+
+    if (isWsPartialBookDepthEventFormatted(data)) {
+      return console.log('log partial book depth event: ', data);
+    }
+
+    if (isWsDiffBookDepthEventFormatted(data)) {
+      return console.log('log diff book depthUpdate event: ', data);
+    }
+  });
+
+  wsClient.on('formattedUserDataMessage', (data) => {
+    console.log('log formattedUserDataMessage: ', data);
+  });
+
+  wsClient.on('open', (data) => {
+    console.log('connection opened open:', data.wsKey);
+  });
+
+  // response to command sent via WS stream (e.g LIST_SUBSCRIPTIONS)
+  wsClient.on('response', (data) => {
+    console.log('log response: ', data?.message || JSON.stringify(data));
+  });
+
+  wsClient.on('reconnecting', (data) => {
+    console.log('ws automatically reconnecting.... ', data?.wsKey);
+  });
+
+  wsClient.on('reconnected', (data) => {
+    console.log('ws has reconnected ', data?.wsKey);
+    // No action needed here, unless you need to query the REST API after being reconnected.
+  });
+
+  try {
+    /**
+     * The Websocket Client will automatically manage connectivity and active topics/subscriptions for you.
+     *
+     * Simply call wsClient.subscribe(topic, wsKey) as many times as you want, with or without an array.
+     *
+     * The WsKey is a reference to the connection that this topic should be routed to.
+     * WS_KEY_MAP is a complete enum with all the available WsKey values.
+     *
+     * The following topics are routed to the "market" endpoint for USDM Futures market data, as per the following documentation:
+     * https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Important-WebSocket-Change-Notice#public-high-frequency-public-data
+     */
+
+    // Uses the regular market feeds WS URL dedicated to USDM Futures: wss://fstream.binance.com/market/stream
+    const wsConnectionKey = WS_KEY_MAP.usdmMarket;
+
+    /**
+     * Subscribe to each available type of USDM Derivatives market topic, the new way
+     */
+    await wsClient.subscribe(
+      [
+        // Aggregate Trade Stream
+        // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Aggregate-Trade-Streams
+        // 'btcusdt@aggTrade',
+        // Mark Price Stream
+        // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Mark-Price-Stream
+        // 'btcusdt@markPrice',
+        // 'btcusdt@markPrice@1s',
+        // Mark Price Stream for All market
+        // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Mark-Price-Stream-for-All-market
+        // '!markPrice@arr',
+        // Kline/Candlestick Streams
+        // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Kline-Candlestick-Streams
+        // 'btcusdt@kline_1m',
+        // Continuous Contract Kline/Candlestick Streams
+        // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Continuous-Contract-Kline-Candlestick-Streams
+        // 'btcusdt_perpetual@continuousKline_1m', // DOESNT EXIST AS TYPE GUARD, ONLY IN BEAUTIFIER
+        // Individual Symbol Mini Ticker Stream
+        // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Individual-Symbol-Mini-Ticker-Stream
+        // 'btcusdt@miniTicker', // DOESNT EXIST AS TYPE GUARD, ONLY FOR RAW MESSAGE
+        // All Market Mini Tickers Stream
+        // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/All-Market-Mini-Tickers-Stream
+        // '!miniTicker@arr', // DOESNT EXIST AS TYPE GUARD
+        // Individual Symbol Ticker Streams
+        // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Individual-Symbol-Ticker-Streams
+        // 'btcusdt@ticker',
+        // All Market Tickers Stream
+        // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/All-Market-Tickers-Stream
+        // '!ticker@arr', // DOESNT EXIST AS TYPE GUARD
+        // Liquidation Order Stream
+        // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Liquidation-Order-Streams
+        // 'btcusdt@forceOrder',
+        // Liquidation Order Stream for All market
+        // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/All-Market-Liquidation-Order-Streams
+        // '!forceOrder@arr',
+        // Composite Index Symbol Information Streams
+        // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Composite-Index-Symbol-Information-Streams
+        // 'btcusdt@compositeIndex', // DOESNT EXIST AS TYPE GUARD
+        // Contract Info Stream
+        // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Contract-Info-Stream
+        // '!contractInfo', // DOESNT EXIST AS TYPE GUARD
+        // Multi-Assets Mode Asset Index Stream
+        // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Multi-Assets-Mode-Asset-Index
+        // '!assetIndex@arr', // DOESNT EXIST AS TYPE GUARD
+        // 'btcusdt@assetIndex',
+      ],
+      wsConnectionKey,
+    );
+
+    // /**
+    //  *
+    //  * For those that used the Node.js Binance SDK before the v3 release, you can
+    //  * still subscribe to available market topics the "old" way, for convenience
+    //  * when migrating from the old WebsocketClient to the new multiplex client):
+    //  *
+    //  */
+
+    // wsClient.subscribeAggregateTrades(symbol, 'usdm');
+    // wsClient.subscribeTrades(symbol, 'spot');
+    // wsClient.subscribeTrades(symbol, 'usdm');
+    // wsClient.subscribeTrades(coinMSymbol, 'coinm');
+    // wsClient.subscribeCoinIndexPrice(coinMSymbol2);
+    // wsClient.subscribeAllBookTickers('usdm');
+    // wsClient.subscribeSpotKline(symbol, '1m');
+    // wsClient.subscribeMarkPrice(symbol, 'usdm');
+    // wsClient.subscribeMarkPrice(coinMSymbol, 'coinm');
+    // wsClient.subscribeAllMarketMarkPrice('usdm');
+    // wsClient.subscribeAllMarketMarkPrice('coinm');
+    // wsClient.subscribeKlines(symbol, '1m', 'usdm');
+    // wsClient.subscribeContinuousContractKlines(
+    //   symbol,
+    //   'perpetual',
+    //   '1m',
+    //   'usdm',
+    // );
+    // wsClient.subscribeIndexKlines(coinMSymbol2, '1m');
+    // wsClient.subscribeMarkPriceKlines(coinMSymbol, '1m');
+    // wsClient.subscribeSymbolMini24hrTicker(symbol, 'spot'); // 0116 265 5309, opt 1
+    // wsClient.subscribeSymbolMini24hrTicker(symbol, 'usdm');
+    // wsClient.subscribeSymbolMini24hrTicker(coinMSymbol, 'coinm');
+    // wsClient.subscribeSymbol24hrTicker(symbol, 'spot');
+    // wsClient.subscribeSymbol24hrTicker(symbol, 'usdm');
+    // wsClient.subscribeSymbol24hrTicker(coinMSymbol, 'coinm');
+    // wsClient.subscribeAllMini24hrTickers('spot');
+    // wsClient.subscribeAllMini24hrTickers('usdm');
+    // wsClient.subscribeAllMini24hrTickers('coinm');
+    // wsClient.subscribeAll24hrTickers('spot');
+    // wsClient.subscribeAll24hrTickers('usdm');
+    // wsClient.subscribeAll24hrTickers('coinm');
+    // wsClient.subscribeSymbolLiquidationOrders(symbol, 'usdm');
+    // wsClient.subscribeAllLiquidationOrders('usdm');
+    // wsClient.subscribeAllLiquidationOrders('coinm');
+    // wsClient.subscribeSpotSymbol24hrTicker(symbol);
+    // wsClient.subscribeSpotPartialBookDepth('ETHBTC', 5, 1000);
+    // wsClient.subscribeAllRollingWindowTickers('spot', '1d');
+    // wsClient.subscribeSymbolBookTicker(symbol, 'spot');
+    // wsClient.subscribePartialBookDepths(symbol, 5, 100, 'spot');
+    // wsClient.subscribeDiffBookDepth(symbol, 100, 'spot');
+    // wsClient.subscribeContractInfoStream('usdm');
+    // wsClient.subscribeContractInfoStream('coinm');
+  } catch (e) {
+    console.error('exception on subscribe attempt: ', e);
+  }
+})();

--- a/examples/WebSockets/Public/ws-usdm-market.ts
+++ b/examples/WebSockets/Public/ws-usdm-market.ts
@@ -152,48 +152,61 @@ import {
       [
         // Aggregate Trade Stream
         // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Aggregate-Trade-Streams
-        // 'btcusdt@aggTrade',
+        'btcusdt@aggTrade',
+
         // Mark Price Stream
         // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Mark-Price-Stream
-        // 'btcusdt@markPrice',
-        // 'btcusdt@markPrice@1s',
+        'btcusdt@markPrice',
+        'btcusdt@markPrice@1s',
+
         // Mark Price Stream for All market
         // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Mark-Price-Stream-for-All-market
-        // '!markPrice@arr',
+        '!markPrice@arr',
+
         // Kline/Candlestick Streams
         // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Kline-Candlestick-Streams
-        // 'btcusdt@kline_1m',
+        'btcusdt@kline_1m',
+
         // Continuous Contract Kline/Candlestick Streams
         // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Continuous-Contract-Kline-Candlestick-Streams
-        // 'btcusdt_perpetual@continuousKline_1m', // DOESNT EXIST AS TYPE GUARD, ONLY IN BEAUTIFIER
+        'btcusdt_perpetual@continuousKline_1m', // DOESNT EXIST AS TYPE GUARD, ONLY IN BEAUTIFIER
+
         // Individual Symbol Mini Ticker Stream
         // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Individual-Symbol-Mini-Ticker-Stream
-        // 'btcusdt@miniTicker', // DOESNT EXIST AS TYPE GUARD, ONLY FOR RAW MESSAGE
+        'btcusdt@miniTicker', // DOESNT EXIST AS TYPE GUARD, ONLY FOR RAW MESSAGE
+
         // All Market Mini Tickers Stream
         // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/All-Market-Mini-Tickers-Stream
-        // '!miniTicker@arr', // DOESNT EXIST AS TYPE GUARD
+        '!miniTicker@arr', // DOESNT EXIST AS TYPE GUARD
+
         // Individual Symbol Ticker Streams
         // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Individual-Symbol-Ticker-Streams
-        // 'btcusdt@ticker',
+        'btcusdt@ticker',
+
         // All Market Tickers Stream
         // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/All-Market-Tickers-Stream
-        // '!ticker@arr', // DOESNT EXIST AS TYPE GUARD
+        '!ticker@arr', // DOESNT EXIST AS TYPE GUARD
+
         // Liquidation Order Stream
         // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Liquidation-Order-Streams
-        // 'btcusdt@forceOrder',
+        'btcusdt@forceOrder',
+
         // Liquidation Order Stream for All market
         // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/All-Market-Liquidation-Order-Streams
-        // '!forceOrder@arr',
+        '!forceOrder@arr',
+
         // Composite Index Symbol Information Streams
         // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Composite-Index-Symbol-Information-Streams
-        // 'btcusdt@compositeIndex', // DOESNT EXIST AS TYPE GUARD
+
+        'btcusdt@compositeIndex', // DOESNT EXIST AS TYPE GUARD
         // Contract Info Stream
         // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Contract-Info-Stream
-        // '!contractInfo', // DOESNT EXIST AS TYPE GUARD
+        '!contractInfo', // DOESNT EXIST AS TYPE GUARD
+
         // Multi-Assets Mode Asset Index Stream
         // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Multi-Assets-Mode-Asset-Index
-        // '!assetIndex@arr', // DOESNT EXIST AS TYPE GUARD
-        // 'btcusdt@assetIndex',
+        '!assetIndex@arr', // DOESNT EXIST AS TYPE GUARD
+        'btcusdt@assetIndex',
       ],
       wsConnectionKey,
     );

--- a/examples/WebSockets/Public/ws-usdm-public.ts
+++ b/examples/WebSockets/Public/ws-usdm-public.ts
@@ -153,19 +153,19 @@ import {
       [
         // Individual Symbol Book Ticker Streams
         // https://developers.binance.com/docs/binance-spot-api-docs/web-socket-streams#individual-symbol-book-ticker-streams
-        // 'btcusdt@bookTicker',
+        'btcusdt@bookTicker',
         // All Book Tickers Stream
         // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/All-Book-Tickers-Stream
-        // '!bookTicker', // DOESNT EXIST AS TYPE GUARD
+        '!bookTicker', // DOESNT EXIST AS TYPE GUARD
         // Partial Book Depth Streams
         // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Partial-Book-Depth-Streams
-        // 'btcusdt@depth5',
-        // 'btcusdt@depth10@100ms',
+        'btcusdt@depth5',
+        'btcusdt@depth10@100ms',
         // Diff. Book Depth Stream
         // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Diff-Book-Depth-Streams
-        // 'btcusdt@depth',
-        // 'btcusdt@depth@100ms',
-        // 'btcusdt@depth@500ms',
+        'btcusdt@depth',
+        'btcusdt@depth@100ms',
+        'btcusdt@depth@500ms',
       ],
       wsConnectionKey,
     );

--- a/examples/WebSockets/Public/ws-usdm-public.ts
+++ b/examples/WebSockets/Public/ws-usdm-public.ts
@@ -1,0 +1,227 @@
+import {
+  DefaultLogger,
+  isWsDiffBookDepthEventFormatted,
+  isWsPartialBookDepthEventFormatted,
+  WebsocketClient,
+  WS_KEY_MAP,
+} from '../../../src';
+
+// or, with the npm package
+/*
+import {
+  DefaultLogger,
+  isWsDiffBookDepthEventFormatted,
+  isWsPartialBookDepthEventFormatted,
+  WebsocketClient,
+  WS_KEY_MAP,
+} from 'binance';
+*/
+
+(async () => {
+  // Without typescript:
+  // const logger = {
+  const logger: DefaultLogger = {
+    ...DefaultLogger,
+    trace: (...params) => {
+      // A simple way to suppress heartbeats but receive all other traces
+      // if (params[0].includes('ping') || params[0].includes('pong')) {
+      //   return;
+      // }
+      console.log('\n', new Date(), 'trace ', ...params);
+    },
+  };
+
+  const wsClient = new WebsocketClient(
+    {
+      // Optional: when enabled, the SDK will try to format incoming data into more readable objects.
+      // Beautified data is emitted via the "formattedMessage" event
+      beautify: true,
+    },
+    logger, // Optional: customise logging behaviour by extending or overwriting the default logger implementation
+  );
+
+  // Raw unprocessed incoming data, e.g. if you have the beautifier disabled
+  wsClient.on('message', (data) => {
+    // console.log('raw message received ', JSON.stringify(data, null, 2));
+    console.log('raw message received ', JSON.stringify(data));
+    // console.log('log rawMessage: ', data);
+  });
+
+  // Formatted data that has gone through the beautifier
+  wsClient.on('formattedMessage', (data) => {
+    // console.log('log formattedMessage: ', data);
+
+    /**
+     * Optional: we've included type-guards for many formatted websocket topics.
+     *
+     * These can be used within `if` blocks to narrow down specific event types (even for non-typescript users).
+     */
+    // if (isWsAggTradeFormatted(data)) {
+    //   console.log('log agg trade: ', data);
+    //   return;
+    // }
+
+    // // For one symbol
+    // if (isWsFormattedMarkPriceUpdateEvent(data)) {
+    //   console.log('log mark price: ', data);
+    //   return;
+    // }
+
+    // // for many symbols
+    // if (isWsFormattedMarkPriceUpdateArray(data)) {
+    //   console.log('log mark prices: ', data);
+    //   return;
+    // }
+
+    // if (isWsFormattedKline(data)) {
+    //   console.log('log kline: ', data);
+    //   return;
+    // }
+
+    // if (isWsFormattedTrade(data)) {
+    //   return console.log('log trade: ', data);
+    // }
+
+    // if (isWsFormattedForceOrder(data)) {
+    //   return console.log('log force order: ', data);
+    // }
+
+    // if (isWsFormatted24hrTickerArray(data)) {
+    //   return console.log('log 24hr ticker array: ', data);
+    // }
+
+    // if (isWsFormattedRollingWindowTickerArray(data)) {
+    //   return console.log('log rolling window ticker array: ', data);
+    // }
+
+    // if (isWsFormatted24hrTicker(data)) {
+    //   return console.log('log 24hr ticker: ', data);
+    // }
+
+    if (isWsPartialBookDepthEventFormatted(data)) {
+      return console.log('log partial book depth event: ', data);
+    }
+
+    if (isWsDiffBookDepthEventFormatted(data)) {
+      return console.log('log diff book depthUpdate event: ', data);
+    }
+  });
+
+  wsClient.on('formattedUserDataMessage', (data) => {
+    console.log('log formattedUserDataMessage: ', data);
+  });
+
+  wsClient.on('open', (data) => {
+    console.log('connection opened open:', data.wsKey);
+  });
+
+  // response to command sent via WS stream (e.g LIST_SUBSCRIPTIONS)
+  wsClient.on('response', (data) => {
+    console.log('log response: ', data?.message || JSON.stringify(data));
+  });
+
+  wsClient.on('reconnecting', (data) => {
+    console.log('ws automatically reconnecting.... ', data?.wsKey);
+  });
+
+  wsClient.on('reconnected', (data) => {
+    console.log('ws has reconnected ', data?.wsKey);
+    // No action needed here, unless you need to query the REST API after being reconnected.
+  });
+
+  try {
+    /**
+     * The Websocket Client will automatically manage connectivity and active topics/subscriptions for you.
+     *
+     * Simply call wsClient.subscribe(topic, wsKey) as many times as you want, with or without an array.
+     *
+     * The WsKey is a reference to the connection that this topic should be routed to.
+     * WS_KEY_MAP is a complete enum with all the available WsKey values.
+     *
+     * The following topics are routed to the "market" endpoint for USDM Futures market data, as per the following documentation:
+     * https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Important-WebSocket-Change-Notice#public-high-frequency-public-data
+     */
+
+    // Uses the high-frequency order book & core public feeds WS URL dedicated to USDM Futures:
+    // wss://fstream.binance.com/public/stream
+    const wsConnectionKey = WS_KEY_MAP.usdmPublic;
+
+    /**
+     * Subscribe to each available type of USDM Derivatives market topic, the new way
+     */
+    await wsClient.subscribe(
+      [
+        // Individual Symbol Book Ticker Streams
+        // https://developers.binance.com/docs/binance-spot-api-docs/web-socket-streams#individual-symbol-book-ticker-streams
+        // 'btcusdt@bookTicker',
+        // All Book Tickers Stream
+        // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/All-Book-Tickers-Stream
+        // '!bookTicker', // DOESNT EXIST AS TYPE GUARD
+        // Partial Book Depth Streams
+        // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Partial-Book-Depth-Streams
+        // 'btcusdt@depth5',
+        // 'btcusdt@depth10@100ms',
+        // Diff. Book Depth Stream
+        // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Diff-Book-Depth-Streams
+        // 'btcusdt@depth',
+        // 'btcusdt@depth@100ms',
+        // 'btcusdt@depth@500ms',
+      ],
+      wsConnectionKey,
+    );
+
+    // /**
+    //  *
+    //  * For those that used the Node.js Binance SDK before the v3 release, you can
+    //  * still subscribe to available market topics the "old" way, for convenience
+    //  * when migrating from the old WebsocketClient to the new multiplex client):
+    //  *
+    //  */
+
+    // wsClient.subscribeAggregateTrades(symbol, 'usdm');
+    // wsClient.subscribeTrades(symbol, 'spot');
+    // wsClient.subscribeTrades(symbol, 'usdm');
+    // wsClient.subscribeTrades(coinMSymbol, 'coinm');
+    // wsClient.subscribeCoinIndexPrice(coinMSymbol2);
+    // wsClient.subscribeAllBookTickers('usdm');
+    // wsClient.subscribeSpotKline(symbol, '1m');
+    // wsClient.subscribeMarkPrice(symbol, 'usdm');
+    // wsClient.subscribeMarkPrice(coinMSymbol, 'coinm');
+    // wsClient.subscribeAllMarketMarkPrice('usdm');
+    // wsClient.subscribeAllMarketMarkPrice('coinm');
+    // wsClient.subscribeKlines(symbol, '1m', 'usdm');
+    // wsClient.subscribeContinuousContractKlines(
+    //   symbol,
+    //   'perpetual',
+    //   '1m',
+    //   'usdm',
+    // );
+    // wsClient.subscribeIndexKlines(coinMSymbol2, '1m');
+    // wsClient.subscribeMarkPriceKlines(coinMSymbol, '1m');
+    // wsClient.subscribeSymbolMini24hrTicker(symbol, 'spot'); // 0116 265 5309, opt 1
+    // wsClient.subscribeSymbolMini24hrTicker(symbol, 'usdm');
+    // wsClient.subscribeSymbolMini24hrTicker(coinMSymbol, 'coinm');
+    // wsClient.subscribeSymbol24hrTicker(symbol, 'spot');
+    // wsClient.subscribeSymbol24hrTicker(symbol, 'usdm');
+    // wsClient.subscribeSymbol24hrTicker(coinMSymbol, 'coinm');
+    // wsClient.subscribeAllMini24hrTickers('spot');
+    // wsClient.subscribeAllMini24hrTickers('usdm');
+    // wsClient.subscribeAllMini24hrTickers('coinm');
+    // wsClient.subscribeAll24hrTickers('spot');
+    // wsClient.subscribeAll24hrTickers('usdm');
+    // wsClient.subscribeAll24hrTickers('coinm');
+    // wsClient.subscribeSymbolLiquidationOrders(symbol, 'usdm');
+    // wsClient.subscribeAllLiquidationOrders('usdm');
+    // wsClient.subscribeAllLiquidationOrders('coinm');
+    // wsClient.subscribeSpotSymbol24hrTicker(symbol);
+    // wsClient.subscribeSpotPartialBookDepth('ETHBTC', 5, 1000);
+    // wsClient.subscribeAllRollingWindowTickers('spot', '1d');
+    // wsClient.subscribeSymbolBookTicker(symbol, 'spot');
+    // wsClient.subscribePartialBookDepths(symbol, 5, 100, 'spot');
+    // wsClient.subscribeDiffBookDepth(symbol, 100, 'spot');
+    // wsClient.subscribeContractInfoStream('usdm');
+    // wsClient.subscribeContractInfoStream('coinm');
+  } catch (e) {
+    console.error('exception on subscribe attempt: ', e);
+  }
+})();

--- a/examples/WebSockets/README.md
+++ b/examples/WebSockets/README.md
@@ -85,6 +85,10 @@ wsClient.subscribe(['btcusdt@aggTrade', 'btcusdt@forceOrder'], wsKeyUsdmMarket);
 wsClient.subscribeUsdFuturesUserDataStream();
 ```
 
+#### Legacy `wsClient.subscribe*()` methods
+
+If you're using any of the per-topic convenience methods, such as `wsClient.subscribeAggregateTrades(...)`, no change is required. The SDK will automatically route the topic subscription request to the appropriate WS URL.
+
 ## Further Reading
 
 For detailed examples, refer to the examples in this folder, as well as the following documentation:

--- a/examples/WebSockets/README.md
+++ b/examples/WebSockets/README.md
@@ -1,0 +1,93 @@
+# Binance WebSocket Streams
+
+This Node.js, JavaScript & TypeScript SDK for Binance has complete support for all available WebSocket capabilities of Binance's API offering.
+
+## Capabilities
+
+These WebSocket capabilities are split into two key groups:
+
+1. WebSocket Consumers:
+   - Subscribe to market data & receive realtime updates.
+   - Subscribe to private account data & receive realtime updates (generally called the user data stream).
+2. WebSocket API:
+   - Send requests & commands over a persistent WebSocket (WSAPI) connection. E.g. Submit an order.
+   - Subscribe to private account data & receive realtime updates (generally called the user data stream), over a persistent WebSocket (WSAPI) connection. Note:
+     - This was previously available without the WebSocket API, via a mechanic involving a temporary listenKey.
+     - In recent updates, the WebSocket API supports subscribing to the user data stream (private updates).
+     - In some cases, this is the only way to subsrcibe to the user data stream (e.g. in Spot markets).
+
+## Architecture
+
+### WebsocketClient
+
+This SDK has all WebSocket capabilities integrated in the dedicated class called the `WebsocketClient`. This can be imported from the package directly. This all-in-one class handles all aspects of Binance's WebSocket capabilities, across all subdomains & endpoints. It also includes the raw capabilities to support integration with the WebSocket API. Subscriptions, heartbeats and connection recovery after disconnect - these are all included automatically.
+
+If the answer to any of these is yes, you should be using the WebsocketClient:
+
+- You want to subscribe to & receive realtime updates for public market data.
+- You want raw control over how & where WebSocket API commands are sent.
+
+If you are looking for a more convenient integration with Binance's WebSocket API, you should look at the `WebsocketAPIClient`.
+
+### WebsocketAPIClient
+
+This is a utility class built over the WebsocketClient to especially provide a more convenient way of using Binance's WebSocket API. While WebSockets are asynchronous by design, the WebsocketAPIClient provides a way to send WebSocket API commands and await the result. All commands are wrapped in a promise and internal event tracking ensures promises are resolved or rejected as part of the command life cycle.
+
+This utility class in this SDK allows you to integrate the WebSocket API in the same way that you would integrate a REST API. Make a request and await the result.
+
+As of early 2026, some of the user data streams are also only available via the WebSocket API streams. This has been integrated into the WebsocketAPIClient and is available with a number of user data methods, depending on the product group. Some references:
+
+- Spot: `wsApiClient.subscribeUserDataStream(WS_KEY_MAP.mainWSAPI)`
+- Margin: `wsApiClient.subscribeUserDataStream(WS_KEY_MAP.marginUserData)`
+- USDM Futures: `wsApiClient.subscribeUserDataStream(WS_KEY_MAP.usdmWSAPI)`
+- CoinM Futures: `wsApiClient.subscribeUserDataStream(WS_KEY_MAP.coinmWSAPI)`
+
+## Key Features
+
+### Base URL Split & Migration
+
+On 06/03/2026, Binance announced a routing upgrade to their USDM Futures WebSocket System, titled: "Binance USDⓈ-M Futures WebSocket System Upgrade Notice (2026-03-06)".
+
+#### Key Highlights:
+
+- Introduction of three dedicated WebSocket base URLs:
+  - Public (high-frequency public market data)
+    - wss://fstream.binance.com/public
+  - Market (regular market data)
+    - wss://fstream.binance.com/market
+  - Private (user data streams)
+    - wss://fstream.binance.com/private
+- New endpoints are supported immediately upon this announcement.
+- Legacy WebSocket URLs will be permanently retired on 2026-04-23.
+- Documentation including endpoint & stream mapping: https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Important-WebSocket-Change-Notice#public-high-frequency-public-data
+
+#### Binance JavaScript SDK Support
+
+All three dedicated WebSocket base URLs are supported. Each with their own unique WsKey, used to track each unique connection.
+
+Continue to subscribe to market data as before with the dedicated subscribe method, but ensure to provide the connection key depending on the type of market data you are consuming.
+
+Minimal examples:
+
+```typescript
+// ...
+
+// For public (high-frequency public data)
+const wsKeyUsdmPublic = WS_KEY_MAP.usdmPublic;
+wsClient.subscribe(['btcusdt@bookTicker', 'btcusdt@depth'], wsKeyUsdmPublic);
+
+// For market (regular market data)
+const wsKeyUsdmMarket = WS_KEY_MAP.usdmMarket;
+wsClient.subscribe(['btcusdt@aggTrade', 'btcusdt@forceOrder'], wsKeyUsdmMarket);
+
+// For user data, continue using the subscribe user data stream method as before.
+// The SDK will automatically route to the "private" endpoint for USDM Futures:
+wsClient.subscribeUsdFuturesUserDataStream();
+```
+
+## Further Reading
+
+For detailed examples, refer to the examples in this folder, as well as the following documentation:
+
+- Binance JavaScript SDK QuickStart Guide: https://siebly.io/sdk/binance/javascript
+- Binance JavaScript SDK Readme: https://www.npmjs.com/package/binance

--- a/package-lock.json
+++ b/package-lock.json
@@ -6157,16 +6157,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -6370,27 +6360,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -6465,16 +6434,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/shallow-clone": {
@@ -6827,16 +6786,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz",
+      "integrity": "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {
@@ -11880,15 +11838,6 @@
       "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
       "dev": true
     },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "optional": true,
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -12030,12 +11979,6 @@
         }
       }
     },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "optional": true
-    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -12088,15 +12031,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "devOptional": true
-    },
-    "serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "optional": true,
-      "requires": {
-        "randombytes": "^2.1.0"
-      }
     },
     "shallow-clone": {
       "version": "3.0.1",
@@ -12338,15 +12272,14 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz",
+      "integrity": "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==",
       "optional": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "3.4.4",
+  "version": "3.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "3.4.4",
+      "version": "3.5.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "3.4.4",
+  "version": "3.5.0",
   "description": "Professional Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types/websockets/ws-general.ts
+++ b/src/types/websockets/ws-general.ts
@@ -72,22 +72,34 @@ export type WsPublicSpotV1Topic =
   | 'trade'
   | 'realtimes'
   | 'kline'
-  | 'depth'
   | 'mergedDepth'
   | 'diffDepth';
 
-export type WsPublicSpotV2Topic =
-  | 'depth'
+export type WsPublicSpotV2Topic = 'depth' | 'kline' | 'trade' | 'realtimes';
+
+// https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Important-WebSocket-Change-Notice#public-high-frequency-public-data
+export type WsPublicUSDMTopic = 'bookTicker' | 'depth';
+
+// https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Important-WebSocket-Change-Notice#market-regular-market-data
+export type WsMarketUSDMTopic =
+  | 'aggTrade'
+  | 'markPrice'
   | 'kline'
-  | 'trade'
-  | 'bookTicker'
-  | 'realtimes';
+  | 'continuousKline'
+  | 'miniTicker'
+  | 'ticker'
+  | 'forceOrder'
+  | 'compositeIndex'
+  | 'contractInfo'
+  | 'assetIndex';
 
 export type WsPublicTopics =
   | WsPublicInverseTopic
   | WsPublicUSDTPerpTopic
   | WsPublicSpotV1Topic
   | WsPublicSpotV2Topic
+  | WsMarketUSDMTopic
+  | WsPublicUSDMTopic
   | string;
 
 // Same as inverse futures

--- a/src/util/requestUtils.ts
+++ b/src/util/requestUtils.ts
@@ -259,7 +259,13 @@ export function requiresWSAPINewClientOID(
     case WS_KEY_MAP.mainTestnetUserData:
     case WS_KEY_MAP.marginRiskUserData:
     case WS_KEY_MAP.usdm:
+    case WS_KEY_MAP.usdmMarket:
+    case WS_KEY_MAP.usdmPublic:
+    case WS_KEY_MAP.usdmPrivate:
     case WS_KEY_MAP.usdmTestnet:
+    case WS_KEY_MAP.usdmTestnetMarket:
+    case WS_KEY_MAP.usdmTestnetPublic:
+    case WS_KEY_MAP.usdmTestnetPrivate:
     case WS_KEY_MAP.coinm:
     case WS_KEY_MAP.coinm2:
     case WS_KEY_MAP.coinmTestnet:

--- a/src/util/typeGuards.ts
+++ b/src/util/typeGuards.ts
@@ -84,6 +84,12 @@ export function isWSAPIWsKey(wsKey: WsKey): wsKey is WSAPIWsKey {
     case 'mainTestnetPublic':
     case 'mainTestnetUserData':
     case 'usdm':
+    case 'usdmPublic':
+    case 'usdmMarket':
+    case 'usdmPrivate':
+    case 'usdmTestnetPublic':
+    case 'usdmTestnetMarket':
+    case 'usdmTestnetPrivate':
     case 'usdmTestnet':
     case 'coinm':
     case 'coinmTestnet':

--- a/src/util/websockets/WsStore.types.ts
+++ b/src/util/websockets/WsStore.types.ts
@@ -39,7 +39,6 @@ export interface WsStoredState<TWSTopicSubscribeEvent extends string | object> {
    *
    * This promise will resolve once connected (and will then get removed);
    */
-  // connectionInProgressPromise?: DeferredPromise | undefined;
   deferredPromiseStore: Record<string, DeferredPromise>;
   /**
    * All the topics we are expected to be subscribed to on this connection (and we automatically resubscribe to if the connection drops)

--- a/src/util/websockets/user-data-stream-manager.ts
+++ b/src/util/websockets/user-data-stream-manager.ts
@@ -16,6 +16,7 @@ import {
   MiscUserDataConnectionState,
   safeTerminateWs,
   WS_LOGGER_CATEGORY,
+  WSConnectionCategory,
   WsKey,
   WsTopicRequest,
 } from './websocket-util';
@@ -40,7 +41,7 @@ export interface UserDataStreamManagerConfig {
 
   getWsUrlFn(
     wsKey: WsKey,
-    connectionType: 'market' | 'userData' | 'wsAPI',
+    connectionType: WSConnectionCategory,
   ): Promise<string>;
 
   getRestClientOptionsFn: () => RestClientOptions;
@@ -165,8 +166,8 @@ export class UserDataStreamManager {
 
     // Begin the connection process with the active listen key
     try {
-      const wsBaseUrl = await this.getWsUrlFn(wsKey, 'userData');
-      const wsURL = wsBaseUrl + `/${listenKey}`;
+      const wsBaseUrl = await this.getWsUrlFn(wsKey, 'private');
+      const wsURL = wsBaseUrl + `${listenKey}`;
 
       const throwOnConnectionError = true;
       const connectResult = await this.connectFn(

--- a/src/util/websockets/websocket-util.ts
+++ b/src/util/websockets/websocket-util.ts
@@ -54,9 +54,15 @@ export const WS_KEY_MAP = {
   // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams
   // market data, user data
   usdm: 'usdm',
+  usdmPrivate: 'usdmPrivate', // user data only (for split streams)
+  usdmPublic: 'usdmPublic', // high freq public market data (primarily book and tickers)
+  usdmMarket: 'usdmMarket', // all other market data
 
   // https://developers.binance.com/docs/derivatives/usds-margined-futures/general-info
   usdmTestnet: 'usdmTestnet',
+  usdmTestnetPrivate: 'usdmTestnetPrivate', // user data only (for split streams)
+  usdmTestnetPublic: 'usdmTestnetPublic', // high freq public market data (primarily book and tickers)
+  usdmTestnetMarket: 'usdmTestnetMarket', // all other market data
 
   // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-api-general-info
   // ONLY WS API | NO USER DATA
@@ -67,8 +73,15 @@ export const WS_KEY_MAP = {
   // market data, user data
   coinm: 'coinm',
   coinm2: 'coinm2',
+  // coinmPrivate: 'coinmPrivate', // user data only (for split streams)
+  // coinmPublic: 'coinmPublic', // high freq public market data (primarily book and tickers)
+  // coinmMarket: 'coinmMarket', // all other market data
+
   // https://developers.binance.com/docs/derivatives/coin-margined-futures/general-info
   coinmTestnet: 'coinmTestnet',
+  // coinmTestnetPrivate: 'coinmTestnetPrivate', // user data only (for split streams)
+  // coinmTestnetPublic: 'coinmTestnetPublic', // high freq public market data (primarily book and tickers)
+  // coinmTestnetMarket: 'coinmTestnetMarket', // all other market data
 
   // https://developers.binance.com/docs/derivatives/coin-margined-futures/websocket-api-general-info
   // ONLY WS API | NO USER DATA
@@ -156,9 +169,15 @@ export const WS_KEY_URL_MAP: Record<WsKey, string> = {
   // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams
   // market data, user data
   usdm: 'wss://fstream.binance.com',
+  usdmPublic: 'wss://fstream.binance.com',
+  usdmMarket: 'wss://fstream.binance.com',
+  usdmPrivate: 'wss://fstream.binance.com',
 
   // https://developers.binance.com/docs/derivatives/usds-margined-futures/general-info
   usdmTestnet: 'wss://stream.binancefuture.com',
+  usdmTestnetPublic: 'wss://stream.binancefuture.com',
+  usdmTestnetMarket: 'wss://stream.binancefuture.com',
+  usdmTestnetPrivate: 'wss://stream.binancefuture.com',
 
   // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-api-general-info
   // ONLY WS API
@@ -170,8 +189,15 @@ export const WS_KEY_URL_MAP: Record<WsKey, string> = {
   // market data, user data
   coinm: 'wss://dstream.binance.com',
   coinm2: 'wss://dstream-auth.binance.com', // Warning, coinm2 requires a listenkey
+  // coinmPublic: 'wss://dstream.binance.com',
+  // coinmMarket: 'wss://dstream.binance.com',
+  // coinmPrivate: 'wss://dstream.binance.com',
+
   // https://developers.binance.com/docs/derivatives/coin-margined-futures/general-info
   coinmTestnet: 'wss://dstream.binancefuture.com',
+  // coinmTestnetPublic: 'wss://dstream.binancefuture.com',
+  // coinmTestnetMarket: 'wss://dstream.binancefuture.com',
+  // coinmTestnetPrivate: 'wss://dstream.binancefuture.com',
 
   // https://developers.binance.com/docs/derivatives/coin-margined-futures/websocket-api-general-info
   // ONLY WS API | NO USER DATA
@@ -211,14 +237,30 @@ export const WS_KEY_MM_URL_MAP: Record<WsKey, string | undefined> = {
 
   // USDM Futures MM endpoints
   usdm: 'wss://fstream-mm.binance.com',
+  usdmMarket: 'wss://fstream-mm.binance.com',
+  usdmPrivate: 'wss://fstream-mm.binance.com',
+  usdmPublic: 'wss://fstream-mm.binance.com',
+
   usdmTestnet: undefined, // No MM endpoint for testnet
+  usdmTestnetPublic: undefined,
+  usdmTestnetMarket: undefined,
+  usdmTestnetPrivate: undefined,
+
   usdmWSAPI: 'wss://ws-fapi-mm.binance.com',
   usdmWSAPITestnet: undefined, // No MM endpoint for testnet
 
   // COINM Futures MM endpoints
   coinm: 'wss://dstream-mm.binance.com',
   coinm2: undefined, // No MM endpoint for coinm2
+  // coinmPublic: 'wss://dstream-mm.binance.com',
+  // coinmMarket: 'wss://dstream-mm.binance.com',
+  // coinmPrivate: 'wss://dstream-mm.binance.com',
+
   coinmTestnet: undefined, // No MM endpoint for testnet
+  // coinmTestnetPublic: undefined,
+  // coinmTestnetMarket: undefined,
+  // coinmTestnetPrivate: undefined,
+
   coinmWSAPI: 'wss://ws-dapi-mm.binance.com',
   coinmWSAPITestnet: undefined, // No MM endpoint for testnet
 
@@ -251,14 +293,26 @@ export const WS_KEY_DEMO_URL_MAP: Record<WsKey, string | undefined> = {
 
   // Demo Trading - USDM Futures
   usdm: 'wss://fstream.binancefuture.com',
+  usdmPublic: 'wss://fstream.binancefuture.com',
+  usdmMarket: 'wss://fstream.binancefuture.com',
+  usdmPrivate: 'wss://fstream.binancefuture.com',
   usdmTestnet: undefined, // No demo for testnet
+  usdmTestnetMarket: undefined,
+  usdmTestnetPrivate: undefined,
+  usdmTestnetPublic: undefined,
   usdmWSAPI: 'wss://testnet.binancefuture.com',
   usdmWSAPITestnet: undefined, // No demo for testnet
 
   // Demo Trading - COINM Futures
   coinm: 'wss://dstream.binancefuture.com',
+  // coinmPublic: 'wss://dstream.binancefuture.com',
+  // coinmMarket: 'wss://dstream.binancefuture.com',
+  // coinmPrivate: 'wss://dstream.binancefuture.com',
   coinm2: undefined, // No demo for coinm2
   coinmTestnet: undefined, // No demo for testnet
+  // coinmTestnetPublic: undefined,
+  // coinmTestnetMarket: undefined,
+  // coinmTestnetPrivate: undefined,
   coinmWSAPI: 'wss://testnet.binancefuture.com',
   coinmWSAPITestnet: undefined, // No demo for testnet
 
@@ -271,9 +325,19 @@ export const WS_KEY_DEMO_URL_MAP: Record<WsKey, string | undefined> = {
   alpha: undefined,
 };
 
+/**
+ * For some products, topics are broken down into 3 endpoint/connection categories:
+ *  https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Important-WebSocket-Change-Notice#public--market-combined-subscriptions
+ *
+ * - Public (high frequency market data, e.g. book updates)
+ * - Market (general market data)
+ * - Private (account data, user data stream)
+ */
+export type WSConnectionCategory = 'public' | 'market' | 'private';
+
 export function getWsURLSuffix(
   wsKey: WsKey,
-  connectionType: 'market' | 'userData',
+  connectionType: WSConnectionCategory,
 ): string {
   switch (wsKey) {
     case 'main':
@@ -283,9 +347,10 @@ export function getWsURLSuffix(
     case 'mainTestnetPublic':
     case 'mainTestnetUserData': {
       switch (connectionType) {
+        case 'public':
         case 'market':
           return '/stream';
-        case 'userData':
+        case 'private':
           return '/ws';
         default: {
           throw neverGuard(
@@ -301,12 +366,16 @@ export function getWsURLSuffix(
     case 'marginUserData': {
       return '/ws-api/v3';
     }
+    // USDM Futures
     case 'usdm':
     case 'usdmTestnet': {
       switch (connectionType) {
+        // Legacy market data endpoints subscribe via /stream.
+        // In future, routing should automatically direct topics to usdmPublic or usdmMarket, depending on the topic
+        case 'public':
         case 'market':
           return '/stream';
-        case 'userData':
+        case 'private':
           return '/ws';
         default: {
           throw neverGuard(
@@ -316,6 +385,18 @@ export function getWsURLSuffix(
         }
       }
     }
+    case 'usdmPublic':
+    case 'usdmTestnetPublic':
+      return '/public/stream';
+
+    case 'usdmMarket':
+    case 'usdmTestnetMarket':
+      return '/market/stream';
+
+    case 'usdmPrivate':
+    case 'usdmTestnetPrivate':
+      return '/private/stream?listenKey='; // listen key will be suffixed to this
+
     case 'usdmWSAPI':
     case 'usdmWSAPITestnet': {
       return '/ws-fapi/v1';
@@ -324,14 +405,16 @@ export function getWsURLSuffix(
     case 'coinmWSAPITestnet': {
       return '/ws-dapi/v1';
     }
+    // CoinM Futures & European Options
     case 'coinm':
     case 'coinmTestnet':
     case 'eoptions':
       switch (connectionType) {
+        case 'public':
         case 'market':
-          return '/market/stream';
-        case 'userData':
-          return '/private/ws';
+          return '/stream';
+        case 'private':
+          return '/ws/'; // listen key will be suffixed to this, both coinm & eoptions
         default: {
           throw neverGuard(
             connectionType,
@@ -339,6 +422,15 @@ export function getWsURLSuffix(
           );
         }
       }
+    // case 'coinmPublic':
+    // case 'coinmTestnetPublic':
+    //   return '/public/stream';
+    // case 'coinmMarket':
+    // case 'coinmTestnetMarket':
+    //   return '/market/stream';
+    // case 'coinmPrivate':
+    // case 'coinmTestnetPrivate':
+    //   return '/private/stream';
     case 'coinm2':
       return '/stream&listenKey=';
     case 'portfolioMarginUserData':
@@ -352,6 +444,63 @@ export function getWsURLSuffix(
       throw neverGuard(wsKey, `Unhandled WsKey "${wsKey}"`);
     }
   }
+}
+
+/**
+ * Follows API spec to route topics to specific WS Endpoints:
+ * https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Important-WebSocket-Change-Notice#public--market-combined-subscriptions
+ */
+export function getWSConnectionCategoryForTopic(
+  wsTopic: WsTopic,
+): WSConnectionCategory {
+  switch (wsTopic) {
+    case 'diffDepth':
+    case 'mergedDepth':
+    case 'orderBookL2_200':
+    case 'orderBookL2_25':
+    case 'realtimes': // are these remnants from upgrade?
+    case 'bookTicker':
+    case 'depth': {
+      // Public (high-frequency public data)
+      return 'public';
+    }
+    case 'insurance':
+    case 'klineV2':
+    case 'aggTrade':
+    case 'markPrice':
+    case 'kline':
+    case 'continuousKline':
+    case 'miniTicker':
+    case 'ticker':
+    case 'forceOrder':
+    case 'compositeIndex':
+    case 'contractInfo':
+    case 'assetIndex':
+    case 'ticketInfo':
+    case 'instrument_info': {
+      return 'market';
+    }
+    case 'outboundAccountInfo':
+    case 'order':
+    case 'stop_order':
+    case 'position':
+    case 'trade':
+    case 'wallet':
+    case 'execution':
+    case 'executionReport': {
+      return 'private';
+    }
+    default: {
+      return 'market';
+      // const err = neverGuard(
+      //   wsTopic,
+      //   `Unhandled WsTopic "${wsTopic}" - cannot resolve connection category. Defaulting to 'market'`,
+      // );
+      // console.warn(new Date(), err);
+    }
+  }
+
+  return 'market';
 }
 
 export const WS_AUTH_ON_CONNECT_KEYS: WsKey[] = [];
@@ -398,7 +547,11 @@ export function getTestnetWsKey(wsKey: WsKey): WsKey {
     case WS_KEY_MAP.usdmTestnet:
     case WS_KEY_MAP.mainWSAPITestnet:
     case WS_KEY_MAP.usdmWSAPITestnet:
-    case WS_KEY_MAP.coinmWSAPITestnet: {
+    case WS_KEY_MAP.coinmWSAPITestnet:
+    // case WS_KEY_MAP.coinmTestnetPrivate: // case WS_KEY_MAP.coinmTestnetMarket: // case WS_KEY_MAP.coinmTestnetPublic:
+    case WS_KEY_MAP.usdmTestnetMarket:
+    case WS_KEY_MAP.usdmTestnetPublic:
+    case WS_KEY_MAP.usdmTestnetPrivate: {
       return wsKey;
     }
 
@@ -419,6 +572,12 @@ export function getTestnetWsKey(wsKey: WsKey): WsKey {
     case WS_KEY_MAP.usdmWSAPI: {
       return WS_KEY_MAP.usdmWSAPITestnet;
     }
+    case WS_KEY_MAP.usdmMarket:
+      return WS_KEY_MAP.usdmTestnetMarket;
+    case WS_KEY_MAP.usdmPublic:
+      return WS_KEY_MAP.usdmTestnetPublic;
+    case WS_KEY_MAP.usdmPrivate:
+      return WS_KEY_MAP.usdmTestnetPrivate;
 
     case WS_KEY_MAP.coinm:
     case WS_KEY_MAP.coinm2: {
@@ -427,6 +586,13 @@ export function getTestnetWsKey(wsKey: WsKey): WsKey {
     case WS_KEY_MAP.coinmWSAPI: {
       return WS_KEY_MAP.coinmWSAPITestnet;
     }
+
+    // case WS_KEY_MAP.coinmMarket:
+    //   return WS_KEY_MAP.coinmTestnetMarket;
+    // case WS_KEY_MAP.coinmPublic:
+    //   return WS_KEY_MAP.coinmTestnetPublic;
+    // case WS_KEY_MAP.coinmPrivate:
+    //   return WS_KEY_MAP.coinmTestnetPrivate;
 
     case WS_KEY_MAP.marginRiskUserData:
     case WS_KEY_MAP.marginUserData:
@@ -664,16 +830,28 @@ export function resolveUserDataMarketForWsKey(wsKey: WsKey): WsMarket {
     case 'mainWSAPITestnet':
       return 'spotTestnet';
     case 'usdm':
+    case 'usdmMarket':
+    case 'usdmPrivate':
+    case 'usdmPublic':
     case 'usdmWSAPI':
       return 'usdm';
     case 'usdmTestnet':
+    case 'usdmTestnetMarket':
+    case 'usdmTestnetPrivate':
+    case 'usdmTestnetPublic':
     case 'usdmWSAPITestnet':
       return 'usdmTestnet';
     case 'coinm':
     case 'coinm2':
+    // case 'coinmMarket':
+    // case 'coinmPrivate':
+    // case 'coinmPublic':
     case 'coinmWSAPI':
       return 'coinm';
     case 'coinmTestnet':
+    // case 'coinmTestnetMarket':
+    // case 'coinmTestnetPrivate':
+    // case 'coinmTestnetPublic':
     case 'coinmWSAPITestnet':
       return 'coinmTestnet';
     case 'eoptions':
@@ -697,21 +875,52 @@ export function resolveUserDataMarketForWsKey(wsKey: WsKey): WsMarket {
 /**
  * Used by the legacy subscribe* utility methods to determine which wsKey to route the subscription to.
  */
-export function resolveWsKeyForLegacyMarket(
+export function getWsKeyForProductGroup(
   market: 'spot' | 'usdm' | 'coinm',
+  topic: WsTopic,
 ): WsKey {
+  const wsConnectionCategory = getWSConnectionCategoryForTopic(topic);
+
   switch (market) {
     case 'spot': {
       return 'main';
     }
     case 'coinm': {
       return 'coinm';
+      // switch (wsConnectionCategory) {
+      //   case 'market':
+      //     return 'coinmMarket';
+      //   case 'private':
+      //     return 'coinmPrivate';
+      //   case 'public':
+      //     return 'coinmPublic';
+      //   default: {
+      //     throw neverGuard(
+      //       wsConnectionCategory,
+      //       `getWsKeyForProductGroup(${market}, ${topic}): Unhandled wsConnectionCategory "${wsConnectionCategory}"`,
+      //     );
+      //   }
+      // }
     }
     case 'usdm': {
-      return 'usdm';
+      switch (wsConnectionCategory) {
+        case 'market':
+          return 'usdmMarket';
+        case 'private':
+          return 'usdmPrivate';
+        case 'public':
+          return 'usdmPublic';
+        default: {
+          throw neverGuard(
+            wsConnectionCategory,
+            `getWsKeyForProductGroup(${market}, ${topic}): Unhandled wsConnectionCategory "${wsConnectionCategory}"`,
+          );
+        }
+      }
     }
   }
 }
+
 export function parseRawWsMessageLegacy(
   event: any,
   options: WSClientConfigurableOptions,

--- a/src/util/websockets/websocket-util.ts
+++ b/src/util/websockets/websocket-util.ts
@@ -386,6 +386,10 @@ export function isPrivateWsTopic(topic: string): boolean {
   return PRIVATE_TOPICS.includes(topic);
 }
 
+export function getTestnetWsKey(wsKey: WSAPIWsKeyMain): WSAPIWsKeyMain;
+export function getTestnetWsKey(wsKey: WSAPIWsKeyFutures): WSAPIWsKeyFutures;
+export function getTestnetWsKey(wsKey: WSAPIWsKey): WSAPIWsKey;
+export function getTestnetWsKey(wsKey: WsKey): WsKey;
 export function getTestnetWsKey(wsKey: WsKey): WsKey {
   switch (wsKey) {
     case WS_KEY_MAP.mainTestnetPublic:

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -43,6 +43,7 @@ import {
   getPromiseRefForWSAPIRequest,
   getRealWsKeyFromDerivedWsKey,
   getTestnetWsKey,
+  getWsKeyForProductGroup,
   getWsUrl,
   getWsURLSuffix,
   isPrivateWsTopic,
@@ -52,10 +53,10 @@ import {
   parseEventTypeFromMessage,
   parseRawWsMessage,
   resolveUserDataMarketForWsKey,
-  resolveWsKeyForLegacyMarket,
   WS_AUTH_ON_CONNECT_KEYS,
   WS_KEY_MAP,
   WSAPIWsKey,
+  WSConnectionCategory,
   WsKey,
   WsTopicRequest,
 } from './util/websockets/websocket-util';
@@ -140,7 +141,7 @@ export class WebsocketClient extends BaseWebsocketClient<
       ) => {
         return this.respawnUserDataStream(wsKey, market, context);
       },
-      getWsUrlFn: (wsKey: WsKey, connectionType: 'market' | 'userData') => {
+      getWsUrlFn: (wsKey: WsKey, connectionType: WSConnectionCategory) => {
         return this.getWsUrl(wsKey, connectionType);
       },
       getRestClientOptionsFn: () => this.getRestClientOptions(),
@@ -447,7 +448,7 @@ export class WebsocketClient extends BaseWebsocketClient<
    */
   async getWsUrl(
     wsKey: WsKey,
-    connectionType: 'market' | 'userData' = 'market',
+    connectionType: 'public' | 'market' | 'private' = 'market',
   ): Promise<string> {
     const wsBaseURL =
       getWsUrl(wsKey, this.options, this.logger) +
@@ -1436,12 +1437,15 @@ export class WebsocketClient extends BaseWebsocketClient<
    * Note: the wsKey parameter is optional, but can be used to connect to other environments for this product group.
    */
   public async subscribeUsdFuturesUserDataStream(
-    wsKey: WsKey = 'usdm', // usdm | usdmTestnet
+    wsKey: WsKey = WS_KEY_MAP.usdmPrivate, // usdm | usdmPrivate | usdmTestnet
     forceNewConnection?: boolean,
     miscState?: MiscUserDataConnectionState,
   ): Promise<WSConnectedResult | undefined> {
     try {
-      const isTestnet = wsKey === WS_KEY_MAP.usdmTestnet;
+      const isTestnet =
+        wsKey === WS_KEY_MAP.usdmTestnet ||
+        wsKey === WS_KEY_MAP.usdmTestnetPrivate;
+
       const restClient = this.restClientCache.getUSDMRestClient(
         this.getRestClientOptions(),
         this.options.requestOptions,
@@ -1474,7 +1478,7 @@ export class WebsocketClient extends BaseWebsocketClient<
   }
 
   public unsubscribeUsdFuturesUserDataStream(
-    wsKey: WsKey = 'usdm',
+    wsKey: WsKey = WS_KEY_MAP.usdmPrivate,
   ): Promise<void> {
     return this.closeUserDataStream(wsKey, 'usdm');
   }
@@ -1915,11 +1919,12 @@ export class WebsocketClient extends BaseWebsocketClient<
   public subscribeAggregateTrades(
     symbol: string,
     market: 'spot' | 'usdm' | 'coinm',
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const lowerCaseSymbol = symbol.toLowerCase();
     const streamName = 'aggTrade';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     return this.subscribe(`${lowerCaseSymbol}@${streamName}`, wsKey);
   }
 
@@ -1930,11 +1935,12 @@ export class WebsocketClient extends BaseWebsocketClient<
   public subscribeTrades(
     symbol: string,
     market: 'spot' | 'usdm' | 'coinm',
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const lowerCaseSymbol = symbol.toLowerCase();
     const streamName = 'trade';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     return this.subscribe(`${lowerCaseSymbol}@${streamName}`, wsKey);
   }
 
@@ -1944,13 +1950,14 @@ export class WebsocketClient extends BaseWebsocketClient<
   public subscribeCoinIndexPrice(
     symbol: string,
     updateSpeedMs: 1000 | 3000 = 3000,
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const lowerCaseSymbol = symbol.toLowerCase();
     const streamName = 'indexPrice';
     const speedSuffix = updateSpeedMs === 1000 ? '@1s' : '';
     const market: WsMarket = 'coinm';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     return this.subscribe(
       `${lowerCaseSymbol}@${streamName}${speedSuffix}`,
       wsKey,
@@ -1964,12 +1971,13 @@ export class WebsocketClient extends BaseWebsocketClient<
     symbol: string,
     market: 'usdm' | 'coinm',
     updateSpeedMs: 1000 | 3000 = 3000,
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const lowerCaseSymbol = symbol.toLowerCase();
     const streamName = 'markPrice';
     const speedSuffix = updateSpeedMs === 1000 ? '@1s' : '';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     return this.subscribe(
       `${lowerCaseSymbol}@${streamName}${speedSuffix}`,
       wsKey,
@@ -1982,11 +1990,12 @@ export class WebsocketClient extends BaseWebsocketClient<
   public subscribeAllMarketMarkPrice(
     market: 'usdm' | 'coinm',
     updateSpeedMs: 1000 | 3000 = 3000,
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const streamName = '!markPrice@arr';
     const speedSuffix = updateSpeedMs === 1000 ? '@1s' : '';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     return this.subscribe(`${streamName}${speedSuffix}`, wsKey);
   }
 
@@ -1997,11 +2006,12 @@ export class WebsocketClient extends BaseWebsocketClient<
     symbol: string,
     interval: KlineInterval,
     market: 'spot' | 'usdm' | 'coinm',
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const lowerCaseSymbol = symbol.toLowerCase();
     const streamName = 'kline';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     return this.subscribe(
       `${lowerCaseSymbol}@${streamName}_${interval}`,
       wsKey,
@@ -2016,11 +2026,12 @@ export class WebsocketClient extends BaseWebsocketClient<
     contractType: 'perpetual' | 'current_quarter' | 'next_quarter',
     interval: KlineInterval,
     market: 'usdm' | 'coinm',
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const lowerCaseSymbol = symbol.toLowerCase();
     const streamName = 'continuousKline';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     return this.subscribe(
       `${lowerCaseSymbol}_${contractType}@${streamName}_${interval}`,
       wsKey,
@@ -2033,12 +2044,13 @@ export class WebsocketClient extends BaseWebsocketClient<
   public subscribeIndexKlines(
     symbol: string,
     interval: KlineInterval,
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const lowerCaseSymbol = symbol.toLowerCase();
     const streamName = 'indexPriceKline';
     const market: WsMarket = 'coinm';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     return this.subscribe(
       `${lowerCaseSymbol}@${streamName}_${interval}`,
       wsKey,
@@ -2051,12 +2063,13 @@ export class WebsocketClient extends BaseWebsocketClient<
   public subscribeMarkPriceKlines(
     symbol: string,
     interval: KlineInterval,
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const lowerCaseSymbol = symbol.toLowerCase();
     const streamName = 'markPriceKline';
     const market: WsMarket = 'coinm';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     return this.subscribe(
       `${lowerCaseSymbol}@${streamName}_${interval}`,
       wsKey,
@@ -2069,11 +2082,12 @@ export class WebsocketClient extends BaseWebsocketClient<
   public subscribeSymbolMini24hrTicker(
     symbol: string,
     market: 'spot' | 'usdm' | 'coinm',
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const lowerCaseSymbol = symbol.toLowerCase();
     const streamName = 'miniTicker';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     return this.subscribe(`${lowerCaseSymbol}@${streamName}`, wsKey);
   }
 
@@ -2082,10 +2096,11 @@ export class WebsocketClient extends BaseWebsocketClient<
    */
   public subscribeAllMini24hrTickers(
     market: 'spot' | 'usdm' | 'coinm',
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const streamName = 'miniTicker';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     return this.subscribe(`!${streamName}@arr`, wsKey);
   }
 
@@ -2095,11 +2110,12 @@ export class WebsocketClient extends BaseWebsocketClient<
   public subscribeSymbol24hrTicker(
     symbol: string,
     market: 'spot' | 'usdm' | 'coinm',
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const lowerCaseSymbol = symbol.toLowerCase();
     const streamName = 'ticker';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     return this.subscribe(`${lowerCaseSymbol}@${streamName}`, wsKey);
   }
 
@@ -2166,10 +2182,11 @@ export class WebsocketClient extends BaseWebsocketClient<
    */
   public subscribeAll24hrTickers(
     market: 'spot' | 'usdm' | 'coinm',
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const streamName = 'ticker';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     return this.subscribe(`!${streamName}@arr`, wsKey);
   }
 
@@ -2185,10 +2202,11 @@ export class WebsocketClient extends BaseWebsocketClient<
   public subscribeAllRollingWindowTickers(
     market: 'spot',
     windowSize: '1h' | '4h' | '1d',
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const streamName = 'ticker';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     return this.subscribe(`!${streamName}_${windowSize}@arr`, wsKey);
   }
 
@@ -2198,21 +2216,25 @@ export class WebsocketClient extends BaseWebsocketClient<
   public subscribeSymbolBookTicker(
     symbol: string,
     market: 'spot' | 'usdm' | 'coinm',
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const lowerCaseSymbol = symbol.toLowerCase();
     const streamName = 'bookTicker';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     return this.subscribe(`${lowerCaseSymbol}@${streamName}`, wsKey);
   }
 
   /**
    * Subscribe to best bid/ask for all symbols in spot markets.
    */
-  public subscribeAllBookTickers(market: 'usdm' | 'coinm'): Promise<unknown> {
+  public subscribeAllBookTickers(
+    market: 'usdm' | 'coinm',
+    wsKeyOverride?: WsKey,
+  ): Promise<unknown> {
     const streamName = 'bookTicker';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     return this.subscribe(`!${streamName}`, wsKey);
   }
 
@@ -2222,11 +2244,12 @@ export class WebsocketClient extends BaseWebsocketClient<
   public subscribeSymbolLiquidationOrders(
     symbol: string,
     market: 'usdm' | 'coinm',
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const lowerCaseSymbol = symbol.toLowerCase();
     const streamName = 'forceOrder';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     return this.subscribe(`${lowerCaseSymbol}@${streamName}`, wsKey);
   }
 
@@ -2235,10 +2258,11 @@ export class WebsocketClient extends BaseWebsocketClient<
    */
   public subscribeAllLiquidationOrders(
     market: 'usdm' | 'coinm',
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const streamName = 'forceOrder@arr';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     return this.subscribe(`!${streamName}`, wsKey);
   }
 
@@ -2254,11 +2278,12 @@ export class WebsocketClient extends BaseWebsocketClient<
     levels: 5 | 10 | 20,
     updateMs: 100 | 250 | 500 | 1000,
     market: 'spot' | 'usdm' | 'coinm',
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const lowerCaseSymbol = symbol.toLowerCase();
     const streamName = 'depth';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     const updateMsSuffx = typeof updateMs === 'number' ? `@${updateMs}ms` : '';
     return this.subscribe(
       `${lowerCaseSymbol}@${streamName}${levels}${updateMsSuffx}`,
@@ -2278,11 +2303,12 @@ export class WebsocketClient extends BaseWebsocketClient<
     symbol: string,
     updateMs: 100 | 250 | 500 | 1000 = 100,
     market: 'spot' | 'usdm' | 'coinm',
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const lowerCaseSymbol = symbol.toLowerCase();
     const streamName = 'depth';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     const updateMsSuffx = typeof updateMs === 'number' ? `@${updateMs}ms` : '';
     return this.subscribe(
       `${lowerCaseSymbol}@${streamName}${updateMsSuffx}`,
@@ -2295,10 +2321,11 @@ export class WebsocketClient extends BaseWebsocketClient<
    */
   public subscribeContractInfoStream(
     market: 'usdm' | 'coinm',
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
     const streamName = '!contractInfo';
 
-    const wsKey = resolveWsKeyForLegacyMarket(market);
+    const wsKey = wsKeyOverride || getWsKeyForProductGroup(market, streamName);
     return this.subscribe(`${streamName}`, wsKey);
   }
 
@@ -2311,15 +2338,21 @@ export class WebsocketClient extends BaseWebsocketClient<
   /**
    * Subscribe to aggregate trades for a symbol in spot markets.
    */
-  public subscribeSpotAggregateTrades(symbol: string): Promise<unknown> {
-    return this.subscribeAggregateTrades(symbol, 'spot');
+  public subscribeSpotAggregateTrades(
+    symbol: string,
+    wsKeyOverride?: WsKey,
+  ): Promise<unknown> {
+    return this.subscribeAggregateTrades(symbol, 'spot', wsKeyOverride);
   }
 
   /**
    * Subscribe to trades for a symbol in spot markets.
    */
-  public subscribeSpotTrades(symbol: string): Promise<unknown> {
-    return this.subscribeTrades(symbol, 'spot');
+  public subscribeSpotTrades(
+    symbol: string,
+    wsKeyOverride?: WsKey,
+  ): Promise<unknown> {
+    return this.subscribeTrades(symbol, 'spot', wsKeyOverride);
   }
 
   /**
@@ -2328,43 +2361,55 @@ export class WebsocketClient extends BaseWebsocketClient<
   public subscribeSpotKline(
     symbol: string,
     interval: KlineInterval,
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
-    return this.subscribeKlines(symbol, interval, 'spot');
+    return this.subscribeKlines(symbol, interval, 'spot', wsKeyOverride);
   }
 
   /**
    * Subscribe to mini 24hr ticker for a symbol in spot markets.
    */
-  public subscribeSpotSymbolMini24hrTicker(symbol: string): Promise<unknown> {
-    return this.subscribeSymbolMini24hrTicker(symbol, 'spot');
+  public subscribeSpotSymbolMini24hrTicker(
+    symbol: string,
+    wsKeyOverride?: WsKey,
+  ): Promise<unknown> {
+    return this.subscribeSymbolMini24hrTicker(symbol, 'spot', wsKeyOverride);
   }
 
   /**
    * Subscribe to mini 24hr mini ticker in spot markets.
    */
-  public subscribeSpotAllMini24hrTickers(): Promise<unknown> {
-    return this.subscribeAllMini24hrTickers('spot');
+  public subscribeSpotAllMini24hrTickers(
+    wsKeyOverride?: WsKey,
+  ): Promise<unknown> {
+    return this.subscribeAllMini24hrTickers('spot', wsKeyOverride);
   }
 
   /**
    * Subscribe to 24hr ticker for a symbol in spot markets.
    */
-  public subscribeSpotSymbol24hrTicker(symbol: string): Promise<unknown> {
-    return this.subscribeSymbol24hrTicker(symbol, 'spot');
+  public subscribeSpotSymbol24hrTicker(
+    symbol: string,
+    wsKeyOverride?: WsKey,
+  ): Promise<unknown> {
+    return this.subscribeSymbol24hrTicker(symbol, 'spot', wsKeyOverride);
   }
 
   /**
    * Subscribe to 24hr ticker in spot markets.
    */
-  public subscribeSpotAll24hrTickers(): Promise<unknown> {
-    return this.subscribeAll24hrTickers('spot');
+  public subscribeSpotAll24hrTickers(wsKeyOverride?: WsKey): Promise<unknown> {
+    return this.subscribeAll24hrTickers('spot', wsKeyOverride);
   }
 
   /**
    * Subscribe to best bid/ask for symbol in spot markets.
    */
-  public subscribeSpotSymbolBookTicker(symbol: string): Promise<unknown> {
-    return this.subscribeSymbolBookTicker(symbol, 'spot');
+  public subscribeSpotSymbolBookTicker(
+    symbol: string,
+    wsKeyOverride?: WsKey,
+  ): Promise<unknown> {
+    return this.subscribeSymbolBookTicker(symbol, 'spot', wsKeyOverride);
   }
 
   /**
@@ -2374,8 +2419,15 @@ export class WebsocketClient extends BaseWebsocketClient<
     symbol: string,
     levels: 5 | 10 | 20,
     updateMs: 1000 | 100 = 1000,
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
-    return this.subscribePartialBookDepths(symbol, levels, updateMs, 'spot');
+    return this.subscribePartialBookDepths(
+      symbol,
+      levels,
+      updateMs,
+      'spot',
+      wsKeyOverride,
+    );
   }
 
   /**
@@ -2384,7 +2436,8 @@ export class WebsocketClient extends BaseWebsocketClient<
   public subscribeSpotDiffBookDepth(
     symbol: string,
     updateMs: 1000 | 100 = 1000,
+    wsKeyOverride?: WsKey,
   ): Promise<unknown> {
-    return this.subscribeDiffBookDepth(symbol, updateMs, 'spot');
+    return this.subscribeDiffBookDepth(symbol, updateMs, 'spot', wsKeyOverride);
   }
 }


### PR DESCRIPTION
## Summary
- Bump dependencies after audit.
- Readme updates.
- Add more WebSocket documentation for more detailed guidance.
- No breaking changes expected, but USDM Futures WebSocket users may need to migrate in future when Binance deprecates the previous WS endpoint.
- Add complete support for new USDM Futures Base URL Split & Migration, with examples:
  - **Action required**: if you're using the wsClient.subscribe() methods, you **must** provide the correct WsKey. Refer to these examples for guidance:
    - USDM Public topics: https://github.com/tiagosiebler/binance/blob/master/examples/WebSockets/Public/ws-usdm-public.ts#L145-L152
    - USDM Market topics: https://github.com/tiagosiebler/binance/blob/master/examples/WebSockets/Public/ws-usdm-market.ts#L145-L151 
    - USDM ListenKey User Data: https://github.com/tiagosiebler/binance/blob/master/examples/WebSockets/Private(userdata)/ws-userdata-listenkey.ts#L182-L186
    - USDM WS API User Data (recommended): https://github.com/tiagosiebler/binance/blob/master/examples/WebSockets/Private(userdata)/ws-userdata-wsapi.ts#L185

### Base URL Split & Migration

On 06/03/2026, Binance announced a routing upgrade to their USDM Futures WebSocket System, titled: "Binance USDⓈ-M Futures WebSocket System Upgrade Notice (2026-03-06)".

#### Key Highlights:

- Introduction of three dedicated WebSocket base URLs:
  - Public (high-frequency public market data)
    - wss://fstream.binance.com/public
  - Market (regular market data)
    - wss://fstream.binance.com/market
  - Private (user data streams)
    - wss://fstream.binance.com/private
- New endpoints are supported immediately upon this announcement.
- Legacy WebSocket URLs will be permanently retired on 2026-04-23.
- Documentation including endpoint & stream mapping: https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Important-WebSocket-Change-Notice#public-high-frequency-public-data

#### Binance JavaScript SDK Support

All three dedicated WebSocket base URLs are supported. Each with their own unique WsKey, used to track each unique connection.

Continue to subscribe to market data as before with the dedicated subscribe method, but ensure to provide the connection key depending on the type of market data you are consuming.

Minimal examples:

```typescript
// ...

// For public (high-frequency public data)
const wsKeyUsdmPublic = WS_KEY_MAP.usdmPublic;
wsClient.subscribe(['btcusdt@bookTicker', 'btcusdt@depth'], wsKeyUsdmPublic);

// For market (regular market data)
const wsKeyUsdmMarket = WS_KEY_MAP.usdmMarket;
wsClient.subscribe(['btcusdt@aggTrade', 'btcusdt@forceOrder'], wsKeyUsdmMarket);

// For user data, continue using the subscribe user data stream method as before.
// The SDK will automatically route to the "private" endpoint for USDM Futures:
wsClient.subscribeUsdFuturesUserDataStream();
```

#### Legacy `wsClient.subscribe*()` methods

If you're using any of the per-topic convenience methods, such as `wsClient.subscribeAggregateTrades(...)`, no change is required. The SDK will automatically route the topic subscription request to the appropriate WS URL.

## Further Reading

For detailed examples, refer to the examples in this folder, as well as the following documentation:

- Binance JavaScript SDK QuickStart Guide: https://siebly.io/sdk/binance/javascript
- Binance JavaScript SDK Tutorial: https://siebly.io/sdk/binance/javascript/tutorial
- Binance JavaScript SDK Readme: https://www.npmjs.com/package/binance


<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

## PR Checklist

As part of the PR, make sure you have:
- [x] No breaking changes / documented all breaking changes clearly.
- [ ] Updated & checked that all tests pass.
- [x] Increased the version number in the package.json <!-- Only if your changes need to be published to npm -->
- [x] Checked `npm install` runs without issue.
- [x] Included the package-lock.json, if it changed after npm install <!-- The version number should update, if you also updated the package.json version number -->
- [x] Checked `npm run build` runs without issue.
- [ ] Updated the endpoint map (optional, if you know how).
- [ ] Run llms.txt generator (optional, if you know how).
