### PR TITLE
fix(v3.5.1): handle suffix when adding listenKey to WebSocket URL

### DIFF
--- a/examples/WebSockets/Private(userdata)/ws-userdata-listenkey.ts
+++ b/examples/WebSockets/Private(userdata)/ws-userdata-listenkey.ts
@@ -157,23 +157,14 @@ import {
    */
 
   /**
-   * Example 1: Spot, by default, routes to the "main" wss domain "wss://stream.binance.com:9443".
-   * No parameters needed, just call the subscribe function.
-   *
-   * Note: the listen key workflow is deprecated for "spot" markets. Use the
+   * Note: for spot markets, the listen key workflow is deprecated. Use the
    * WebSocket API `userDataStream.subscribe` workflow instead (only available
    * in spot right now). See `subscribeUserDataStream()` in the WebsocketAPIClient.
    */
-  // wsClient.subscribeSpotUserDataStream();
-
-  // // Example 2: Optional: subscribe to spot via other wss domains
-  // wsClient.subscribeSpotUserDataStream('main2'); // routed to "wss://stream.binance.com:443"
-
-  // // Example 3: cross margin
-  // wsClient.subscribeCrossMarginUserDataStream();
-
-  // // Example 4: isolated margin
-  // wsClient.subscribeIsolatedMarginUserDataStream('BTCUSDC');
+  // Deprecated, see above: wsClient.subscribeSpotUserDataStream();
+  // Deprecated, see above: wsClient.subscribeSpotUserDataStream('main2');
+  // Deprecated, see above: wsClient.subscribeCrossMarginUserDataStream();
+  // Deprecated, see above: wsClient.subscribeIsolatedMarginUserDataStream('BTCUSDC');
 
   /**
    * Futures
@@ -202,14 +193,6 @@ import {
     try {
       // console.log('killing all connections');
       // wsClient.closeAll();
-      // Example 1:
-      wsClient.unsubscribeSpotUserDataStream();
-      // Example 2: use the wsKey to route to another domain
-      wsClient.unsubscribeSpotUserDataStream('main2');
-      // Example 3: cross margin
-      wsClient.unsubscribeCrossMarginUserDataStream();
-      // Example 4: isolated margin
-      wsClient.unsubscribeIsolatedMarginUserDataStream('BTCUSDC');
       // Example 5: usdm futures
       wsClient.unsubscribeUsdFuturesUserDataStream();
       // Example 6: coinm futures

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",
@@ -4016,9 +4016,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -10354,9 +10354,9 @@
       }
     },
     "flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true
     },
     "follow-redirects": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Professional Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/util/websockets/user-data-stream-manager.ts
+++ b/src/util/websockets/user-data-stream-manager.ts
@@ -166,7 +166,11 @@ export class UserDataStreamManager {
 
     // Begin the connection process with the active listen key
     try {
-      const wsBaseUrl = await this.getWsUrlFn(wsKey, 'private');
+      let wsBaseUrl = await this.getWsUrlFn(wsKey, 'private');
+      if (!wsBaseUrl.endsWith('/') && !wsBaseUrl.endsWith('=')) {
+        wsBaseUrl += '/';
+      }
+
       const wsURL = wsBaseUrl + `${listenKey}`;
 
       const throwOnConnectionError = true;

--- a/src/util/websockets/websocket-util.ts
+++ b/src/util/websockets/websocket-util.ts
@@ -351,7 +351,7 @@ export function getWsURLSuffix(
         case 'market':
           return '/stream';
         case 'private':
-          return '/ws';
+          return '/ws/'; // /ws/listenKeyHere
         default: {
           throw neverGuard(
             connectionType,
@@ -376,7 +376,8 @@ export function getWsURLSuffix(
         case 'market':
           return '/stream';
         case 'private':
-          return '/ws';
+          // listen key will be suffixed to this
+          return '/ws/'; // /ws/listenKeyHere
         default: {
           throw neverGuard(
             connectionType,
@@ -395,7 +396,8 @@ export function getWsURLSuffix(
 
     case 'usdmPrivate':
     case 'usdmTestnetPrivate':
-      return '/private/stream?listenKey='; // listen key will be suffixed to this
+      // listen key will be suffixed to this
+      return '/private/stream?listenKey=';
 
     case 'usdmWSAPI':
     case 'usdmWSAPITestnet': {
@@ -414,7 +416,8 @@ export function getWsURLSuffix(
         case 'market':
           return '/stream';
         case 'private':
-          return '/ws/'; // listen key will be suffixed to this, both coinm & eoptions
+          // listen key will be suffixed to this, both coinm & eoptions
+          return '/ws/'; // /ws/listenKeyHere
         default: {
           throw neverGuard(
             connectionType,
@@ -434,10 +437,14 @@ export function getWsURLSuffix(
     case 'coinm2':
       return '/stream&listenKey=';
     case 'portfolioMarginUserData':
-      return '/pm/ws'; // pm/ws/listenKeyHere
+      // listen key will be suffixed to this
+      return '/pm/ws/'; // pm/ws/listenKeyHere
+
     case 'portfolioMarginProUserData':
-      return '/pm-classic/ws';
+      // listen key will be suffixed to this
+      return '/pm-classic/ws/'; // pm-classic/ws/listenKeyHere
     case 'alpha':
+      // https://developers.binance.com/docs/alpha/market-data/websocket-market-data
       // wss://nbstream.binance.com/w3w/wsa/stream
       return '/w3w/wsa/stream';
     default: {


### PR DESCRIPTION
## Summary
- The previous PR introduced an issue where portfolio margin listenKey connection URLs were incorrectly prepared.
- This ensures the URL is correctly structured. Added a guard to prevent this from happening again in future.
- Bump audit dependency.
<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

## PR Checklist

As part of the PR, make sure you have:
- [ ] No breaking changes / documented all breaking changes clearly.
- [ ] Updated & checked that all tests pass.
- [ ] Increased the version number in the package.json <!-- Only if your changes need to be published to npm -->
- [ ] Checked `npm install` runs without issue.
- [ ] Included the package-lock.json, if it changed after npm install <!-- The version number should update, if you also updated the package.json version number -->
- [ ] Checked `npm run build` runs without issue.
- [ ] Updated the endpoint map (optional, if you know how).
- [ ] Run llms.txt generator (optional, if you know how).
