### PR TITLE
Fix: rename activationPrice to correct activatePrice in WSAPINewFutur…

### DIFF
--- a/src/types/websockets/ws-api-requests.ts
+++ b/src/types/websockets/ws-api-requests.ts
@@ -691,7 +691,7 @@ export interface WSAPINewFuturesAlgoOrderRequest<numberType = numberInString> {
   newClientOrderId?: string;
   stopPrice?: numberInString;
   closePosition?: BooleanString;
-  activationPrice?: numberInString;
+  activatePrice?: numberInString;
   callbackRate?: numberInString;
   workingType?: WorkingType;
   priceProtect?: BooleanStringCapitalised;


### PR DESCRIPTION
…esAlgoOrderRequest


Fix incorrect parameter name in WSAPINewFuturesAlgoOrderRequest.

According to Binance documentation, the correct parameter name is activatePrice, not activationPrice. 
https://developers.binance.com/docs/derivatives/usds-margined-futures/trade/websocket-api/New-Algo-Order

## Summary
<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

## PR Checklist

As part of the PR, make sure you have:
- [ ] No breaking changes / documented all breaking changes clearly.
- [ ] Updated & checked that all tests pass.
- [ ] Increased the version number in the package.json <!-- Only if your changes need to be published to npm -->
- [ ] Checked `npm install` runs without issue.
- [ ] Included the package-lock.json, if it changed after npm install <!-- The version number should update, if you also updated the package.json version number -->
- [ ] Checked `npm run build` runs without issue.
- [ ] Updated the endpoint map (optional, if you know how).
- [ ] Run llms.txt generator (optional, if you know how).
