### PR TITLE
Fix: sort request parameters alphabetically before signing

### DIFF
--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -496,11 +496,11 @@ export class WebsocketClient extends BaseWebsocketClient<
       const encodeValues = true;
       const filterUndefinedParams = true;
 
-      const semiFinalRequestParams = {
+      const semiFinalRequestParams = Object.fromEntries(Object.entries({
         apiKey: this.options.api_key,
         ...otherParams,
-      };
-
+      }).sort(([a], [b]) => a.localeCompare(b)));
+      
       const serialisedParams = serialiseParams(
         semiFinalRequestParams,
         strictParamValidation,


### PR DESCRIPTION
added alphabetical sorting of request parameters before signing. This change also affects other WebSocket API requests

## Summary
Fix for #659

## Additional Information


## PR Checklist

As part of the PR, make sure you have:
- [ ] No breaking changes / documented all breaking changes clearly.
- [ ] Updated & checked that all tests pass.
- [ ] Increased the version number in the package.json <!-- Only if your changes need to be published to npm -->
- [ ] Checked `npm install` runs without issue.
- [ ] Included the package-lock.json, if it changed after npm install <!-- The version number should update, if you also updated the package.json version number -->
- [ ] Checked `npm run build` runs without issue.
- [ ] Updated the endpoint map (optional, if you know how).
- [ ] Run llms.txt generator (optional, if you know how).
