### PR TITLE
feat(v3.5.8): auto resolve usdm wsKey when subscribing to market data, update bracket order example to use passive limit order for TP

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -90,6 +90,6 @@ High level summary for some of the available examples, but check the folder for 
 
 #### REST USDM Examples
 
-- `rest-future-bracket-order.ts` Creates an entry order plus TP/SL Algo Service orders.
+- `rest-future-bracket-order.ts` Creates an entry order plus a passive reduce-only TP limit order and an SL Algo Service order.
 - `rest-usdm-order.ts` Creates a single entry order using `submitNewOrder`.
 - `rest-usdm-order-sl.ts` Modifies a Hedge Mode LONG stop-loss order using Algo Service orders.

--- a/examples/Rest/Futures/rest-future-bracket-order.ts
+++ b/examples/Rest/Futures/rest-future-bracket-order.ts
@@ -1,5 +1,6 @@
 import {
   FuturesNewAlgoOrderParams,
+  NewFuturesOrderParams,
   USDMClient,
 } from '../../../src/index';
 
@@ -19,34 +20,33 @@ const client = new USDMClient({
 
     const assetPrices = await client.getMarkPrice({ symbol });
     const markPrice = Number(assetPrices.markPrice);
-    const stopLossPrice = ((markPrice * 99.9) / 100).toFixed(2);
-    const takeProfitPrice = ((markPrice * 100.1) / 100).toFixed(2);
+    const stopLossPrice = Number(((markPrice * 99.9) / 100).toFixed(2));
+    const takeProfitPrice = Number(((markPrice * 100.1) / 100).toFixed(2));
 
-    const entryOrder = {
+    const entryOrder: NewFuturesOrderParams = {
       positionSide: 'BOTH',
       quantity,
       reduceOnly: 'false',
       side: 'BUY',
       symbol,
       type: 'MARKET',
-    } as const;
+    };
 
-    const takeProfitOrder: FuturesNewAlgoOrderParams = {
-      algoType: 'CONDITIONAL',
+    const takeProfitOrder: NewFuturesOrderParams = {
       positionSide: 'BOTH',
-      priceProtect: 'TRUE',
+      price: takeProfitPrice,
+      quantity,
+      reduceOnly: 'true',
       side: 'SELL',
-      triggerPrice: takeProfitPrice,
       symbol,
-      type: 'TAKE_PROFIT_MARKET',
-      workingType: 'MARK_PRICE',
-      closePosition: 'true',
+      timeInForce: 'GTX',
+      type: 'LIMIT',
     };
 
     const stopLossOrder: FuturesNewAlgoOrderParams = {
       algoType: 'CONDITIONAL',
       positionSide: 'BOTH',
-      priceProtect: 'TRUE',
+      priceProtect: 'true',
       side: 'SELL',
       triggerPrice: stopLossPrice,
       symbol,
@@ -56,11 +56,10 @@ const client = new USDMClient({
     };
 
     const openedOrder = await client.submitNewOrder(entryOrder);
-    const takeProfitAlgoOrder =
-      await client.submitNewAlgoOrder(takeProfitOrder);
+    const takeProfitLimitOrder = await client.submitNewOrder(takeProfitOrder);
     const stopLossAlgoOrder = await client.submitNewAlgoOrder(stopLossOrder);
 
-    console.log({ openedOrder, takeProfitAlgoOrder, stopLossAlgoOrder });
+    console.log({ openedOrder, takeProfitLimitOrder, stopLossAlgoOrder });
   } catch (e) {
     console.error(e);
   }

--- a/llms.txt
+++ b/llms.txt
@@ -268,14 +268,18 @@ For a complete example, refer to the [rest-private-rsa.ts](./rest-private-rsa.ts
 ================
 File: examples/REST/Futures/rest-future-bracket-order.ts
 ================
-import { NewFuturesOrderParams, USDMClient } from '../../../src/index';
+import {
+  FuturesNewAlgoOrderParams,
+  NewFuturesOrderParams,
+  USDMClient,
+} from '../../../src/index';
 ⋮----
 // TODO: check balance and do other validations
 ⋮----
 // create three orders
-// 1. entry order (GTC),
-// 2. take profit order (GTE_GTC),
-// 3. stop loss order (GTE_GTC)
+// 1. entry order,
+// 2. passive reduce-only take profit limit order,
+// 3. stop loss Algo Service order
 
 ================
 File: examples/REST/Futures/rest-usdm-demo.ts
@@ -913,7 +917,7 @@ High level summary for some of the available examples, but check the folder for 
 
 #### REST USDM Examples
 
-- `rest-future-bracket-order.ts` Creates three order, entry, TP, SL and submit them all at once using `submitMultipleOrders`
+- `rest-future-bracket-order.ts` Creates an entry order plus a passive reduce-only TP limit order and an SL Algo Service order.
 - `rest-usdm-order.ts` Creates single entry, using `submitNewOrder`
 - `rest-usdm-order-sl.ts` Modify current Stop Loss order(HedgeMode only)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "3.5.7",
+      "version": "3.5.8",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "description": "Professional Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/util/websockets/websocket-util.ts
+++ b/src/util/websockets/websocket-util.ts
@@ -53,6 +53,15 @@ export const WS_KEY_MAP = {
 
   // https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams
   // market data, user data
+  /**
+   * USD-M Futures product-group alias.
+   *
+   * For raw subscribe/unsubscribe calls, this is auto-routed to the required
+   * split USD-M market data key (`usdmPublic` or `usdmMarket`) per topic.
+   *
+   * For direct endpoint control, use `usdmPublic`, `usdmMarket`, or
+   * `usdmPrivate`.
+   */
   usdm: 'usdm',
   usdmPrivate: 'usdmPrivate', // user data only (for split streams)
   usdmPublic: 'usdmPublic', // high freq public market data (primarily book and tickers)
@@ -115,7 +124,13 @@ export const WS_KEYS_SPOT = [
 
 export const WS_KEYS_FUTURES = [
   WS_KEY_MAP.usdm,
+  WS_KEY_MAP.usdmPrivate,
+  WS_KEY_MAP.usdmPublic,
+  WS_KEY_MAP.usdmMarket,
   WS_KEY_MAP.usdmTestnet,
+  WS_KEY_MAP.usdmTestnetPrivate,
+  WS_KEY_MAP.usdmTestnetPublic,
+  WS_KEY_MAP.usdmTestnetMarket,
   WS_KEY_MAP.usdmWSAPI,
   WS_KEY_MAP.usdmWSAPITestnet,
   WS_KEY_MAP.coinm,
@@ -736,6 +751,55 @@ export function getNormalisedTopicRequests(
 }
 
 /**
+ * These topics resolve to the public (high-frequency public data) WS endpoint for USDM futures:
+ * https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Important-WebSocket-Change-Notice#public-high-frequency-public-data
+ *
+ * All other public topics revert to the market endpoint.
+ */
+const USDM_PUBLIC_MARKET_DATA_STREAMS = ['bookTicker', 'depth'];
+
+/**
+ * USD-M Futures retired the legacy combined market data endpoint on 2026-04-23.
+ * Keep the legacy `usdm` wsKey convenient by routing raw market data streams to
+ * Binance's split public/market stream keys.
+ */
+export function getUsdmMarketDataWsKeyForTopic(
+  wsKey: WsKey,
+  topic: string,
+): WsKey {
+  if (wsKey !== WS_KEY_MAP.usdm && wsKey !== WS_KEY_MAP.usdmTestnet) {
+    return wsKey;
+  }
+
+  const streamName = extractStreamNameFromWsTopic(topic);
+  const isPublicStream = USDM_PUBLIC_MARKET_DATA_STREAMS.includes(streamName);
+
+  if (wsKey === WS_KEY_MAP.usdmTestnet) {
+    return isPublicStream
+      ? WS_KEY_MAP.usdmTestnetPublic
+      : WS_KEY_MAP.usdmTestnetMarket;
+  }
+
+  return isPublicStream ? WS_KEY_MAP.usdmPublic : WS_KEY_MAP.usdmMarket;
+}
+
+function extractStreamNameFromWsTopic(topic: string): string {
+  if (topic.startsWith('!')) {
+    return topic.slice(1).split('@')[0].split('_')[0];
+  }
+
+  const firstStreamSegment = topic.includes('@')
+    ? topic.slice(topic.indexOf('@') + 1).split('@')[0]
+    : topic;
+
+  if (firstStreamSegment.startsWith('depth')) {
+    return 'depth';
+  }
+
+  return firstStreamSegment.split('_')[0];
+}
+
+/**
  * Groups topics in request into per-wsKey groups
  * @param normalisedTopicRequests
  * @param wsKey
@@ -753,7 +817,10 @@ export function getTopicsPerWSKey(
 
   // Sort into per wsKey arrays, in case topics are mixed together for different wsKeys
   for (const topicRequest of normalisedTopicRequests) {
-    const derivedWsKey = wsKey;
+    const derivedWsKey = getUsdmMarketDataWsKeyForTopic(
+      wsKey,
+      topicRequest.topic,
+    );
 
     if (
       !perWsKeyTopics[derivedWsKey] ||

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -43,6 +43,7 @@ import {
   getPromiseRefForWSAPIRequest,
   getRealWsKeyFromDerivedWsKey,
   getTestnetWsKey,
+  getTopicsPerWSKey,
   getWsKeyForProductGroup,
   getWsUrl,
   getWsURLSuffix,
@@ -63,6 +64,8 @@ import {
 import { WSConnectedResult } from './util/websockets/WsStore.types';
 
 const WS_LOGGER_CATEGORY = { category: 'binance-ws' };
+
+type TopicRequestsPerWsKeyEntry = [WsKey, WsTopicRequest<string>[]];
 
 export interface WSAPIRequestFlags {
   /** If true, will skip auth requirement for WS API connection */
@@ -186,7 +189,8 @@ export class WebsocketClient extends BaseWebsocketClient<
   public connectPublic(): Promise<WSConnectedResult | undefined>[] {
     return [
       this.connect(WS_KEY_MAP.main),
-      this.connect(WS_KEY_MAP.usdm),
+      this.connect(WS_KEY_MAP.usdmPublic),
+      this.connect(WS_KEY_MAP.usdmMarket),
       this.connect(WS_KEY_MAP.coinm),
       this.connect(WS_KEY_MAP.eoptions),
       this.connect(WS_KEY_MAP.alpha),
@@ -236,7 +240,21 @@ export class WebsocketClient extends BaseWebsocketClient<
     const topicRequests = Array.isArray(requests) ? requests : [requests];
     const normalisedTopicRequests = getNormalisedTopicRequests(topicRequests);
 
-    return this.subscribeTopicsForWsKey(normalisedTopicRequests, wsKey);
+    const topicRequestsPerWsKey = getTopicsPerWSKey(
+      normalisedTopicRequests,
+      wsKey,
+    );
+
+    const topicRequestEntries = Object.entries(
+      topicRequestsPerWsKey,
+    ) as TopicRequestsPerWsKeyEntry[];
+
+    const subscribePromises = topicRequestEntries.map(
+      ([resolvedWsKey, resolvedTopicRequests]) =>
+        this.subscribeTopicsForWsKey(resolvedTopicRequests, resolvedWsKey),
+    );
+
+    return Promise.all(subscribePromises);
   }
 
   /**
@@ -254,7 +272,20 @@ export class WebsocketClient extends BaseWebsocketClient<
     const topicRequests = Array.isArray(requests) ? requests : [requests];
     const normalisedTopicRequests = getNormalisedTopicRequests(topicRequests);
 
-    return this.unsubscribeTopicsForWsKey(normalisedTopicRequests, wsKey);
+    const topicRequestsPerWsKey = getTopicsPerWSKey(
+      normalisedTopicRequests,
+      wsKey,
+    );
+    const topicRequestEntries = Object.entries(
+      topicRequestsPerWsKey,
+    ) as TopicRequestsPerWsKeyEntry[];
+
+    const unsubscribePromises = topicRequestEntries.map(
+      ([resolvedWsKey, resolvedTopicRequests]) =>
+        this.unsubscribeTopicsForWsKey(resolvedTopicRequests, resolvedWsKey),
+    );
+
+    return Promise.all(unsubscribePromises);
   }
 
   /**

--- a/test/websockets/usdmWsRouting.test.ts
+++ b/test/websockets/usdmWsRouting.test.ts
@@ -1,0 +1,147 @@
+import { WebsocketClient } from '../../src/websocket-client';
+import {
+  getTopicsPerWSKey,
+  getUsdmMarketDataWsKeyForTopic,
+  WS_KEY_MAP,
+  WsTopicRequest,
+} from '../../src/util/websockets/websocket-util';
+
+describe('USD-M websocket routing', () => {
+  it('resolves legacy usdm market data topics to split wsKeys', () => {
+    expect(
+      getUsdmMarketDataWsKeyForTopic(
+        WS_KEY_MAP.usdm,
+        'btcusdt@bookTicker',
+      ),
+    ).toBe(WS_KEY_MAP.usdmPublic);
+    expect(
+      getUsdmMarketDataWsKeyForTopic(
+        WS_KEY_MAP.usdm,
+        'btcusdt@depth10@100ms',
+      ),
+    ).toBe(WS_KEY_MAP.usdmPublic);
+    expect(
+      getUsdmMarketDataWsKeyForTopic(
+        WS_KEY_MAP.usdm,
+        'btcusdt@aggTrade',
+      ),
+    ).toBe(WS_KEY_MAP.usdmMarket);
+    expect(
+      getUsdmMarketDataWsKeyForTopic(WS_KEY_MAP.usdm, 'btcusdt@kline_1m'),
+    ).toBe(WS_KEY_MAP.usdmMarket);
+    expect(
+      getUsdmMarketDataWsKeyForTopic(WS_KEY_MAP.usdm, '!forceOrder@arr'),
+    ).toBe(WS_KEY_MAP.usdmMarket);
+    expect(
+      getUsdmMarketDataWsKeyForTopic(WS_KEY_MAP.usdm, 'btcusdt@trade'),
+    ).toBe(WS_KEY_MAP.usdmMarket);
+  });
+
+  it('resolves legacy usdm testnet market data topics to split testnet wsKeys', () => {
+    expect(
+      getUsdmMarketDataWsKeyForTopic(
+        WS_KEY_MAP.usdmTestnet,
+        'btcusdt@depth@100ms',
+      ),
+    ).toBe(WS_KEY_MAP.usdmTestnetPublic);
+    expect(
+      getUsdmMarketDataWsKeyForTopic(
+        WS_KEY_MAP.usdmTestnet,
+        '!miniTicker@arr',
+      ),
+    ).toBe(WS_KEY_MAP.usdmTestnetMarket);
+  });
+
+  it('does not reroute explicit split wsKeys', () => {
+    expect(
+      getUsdmMarketDataWsKeyForTopic(
+        WS_KEY_MAP.usdmPublic,
+        'btcusdt@aggTrade',
+      ),
+    ).toBe(WS_KEY_MAP.usdmPublic);
+    expect(
+      getUsdmMarketDataWsKeyForTopic(
+        WS_KEY_MAP.usdmMarket,
+        'btcusdt@depth',
+      ),
+    ).toBe(WS_KEY_MAP.usdmMarket);
+  });
+
+  it('groups mixed legacy usdm topics by resolved split wsKey', () => {
+    const topics: WsTopicRequest<string>[] = [
+      { topic: 'btcusdt@bookTicker' },
+      { topic: 'ethusdt@depth5@100ms' },
+      { topic: 'btcusdt@aggTrade' },
+      { topic: '!miniTicker@arr' },
+    ];
+
+    const topicsPerWsKey = getTopicsPerWSKey(topics, WS_KEY_MAP.usdm);
+
+    expect(
+      topicsPerWsKey[WS_KEY_MAP.usdmPublic]?.map((topic) => topic.topic),
+    ).toEqual(['btcusdt@bookTicker', 'ethusdt@depth5@100ms']);
+    expect(
+      topicsPerWsKey[WS_KEY_MAP.usdmMarket]?.map((topic) => topic.topic),
+    ).toEqual(['btcusdt@aggTrade', '!miniTicker@arr']);
+  });
+
+  it('subscribes once per resolved split wsKey for legacy usdm topics', async () => {
+    const wsClient = new WebsocketClient();
+    const connectSpy = jest
+      .spyOn(wsClient, 'connect')
+      .mockResolvedValue(undefined);
+
+    await wsClient.subscribe(
+      [
+        'btcusdt@bookTicker',
+        'ethusdt@depth5@100ms',
+        'btcusdt@aggTrade',
+        'btcusdt@kline_1m',
+      ],
+      WS_KEY_MAP.usdm,
+    );
+
+    expect(connectSpy).toHaveBeenCalledTimes(2);
+    expect(connectSpy).toHaveBeenCalledWith(WS_KEY_MAP.usdmPublic);
+    expect(connectSpy).toHaveBeenCalledWith(WS_KEY_MAP.usdmMarket);
+
+    const publicTopics = [
+      ...wsClient.getWsStore().getTopics(WS_KEY_MAP.usdmPublic),
+    ].map((topic) => topic.topic);
+    const marketTopics = [
+      ...wsClient.getWsStore().getTopics(WS_KEY_MAP.usdmMarket),
+    ].map((topic) => topic.topic);
+
+    expect(publicTopics).toEqual([
+      'btcusdt@bookTicker',
+      'ethusdt@depth5@100ms',
+    ]);
+    expect(marketTopics).toEqual(['btcusdt@aggTrade', 'btcusdt@kline_1m']);
+  });
+
+  it('unsubscribes from the resolved split wsKeys for legacy usdm topics', async () => {
+    const wsClient = new WebsocketClient();
+    jest.spyOn(wsClient, 'connect').mockResolvedValue(undefined);
+
+    const topics = ['btcusdt@bookTicker', 'btcusdt@aggTrade'];
+
+    await wsClient.subscribe(topics, WS_KEY_MAP.usdm);
+    await wsClient.unsubscribe(topics, WS_KEY_MAP.usdm);
+
+    expect(wsClient.getWsStore().getTopics(WS_KEY_MAP.usdmPublic).size).toBe(0);
+    expect(wsClient.getWsStore().getTopics(WS_KEY_MAP.usdmMarket).size).toBe(0);
+  });
+
+  it('connectPublic opens split usdm market data connections', async () => {
+    const wsClient = new WebsocketClient();
+    const connectSpy = jest
+      .spyOn(wsClient, 'connect')
+      .mockResolvedValue(undefined);
+
+    await Promise.all(wsClient.connectPublic());
+
+    expect(connectSpy).toHaveBeenCalledWith(WS_KEY_MAP.usdmPublic);
+    expect(connectSpy).toHaveBeenCalledWith(WS_KEY_MAP.usdmMarket);
+    expect(connectSpy).not.toHaveBeenCalledWith(WS_KEY_MAP.usdm);
+  });
+});


### PR DESCRIPTION
## Summary
- Update bracket order example to use limit order for TP. More likely to see a fill if there's a flash move past the TP order.
- Update subscribe/unsubscribe WebsocketClient methods to automatically resolve the wsKey for usdm futures, when subscribing to market data (see #653 for more details).
<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

## PR Checklist

As part of the PR, make sure you have:
- [ ] No breaking changes / documented all breaking changes clearly.
- [ ] Updated & checked that all tests pass.
- [ ] Increased the version number in the package.json <!-- Only if your changes need to be published to npm -->
- [ ] Checked `npm install` runs without issue.
- [ ] Included the package-lock.json, if it changed after npm install <!-- The version number should update, if you also updated the package.json version number -->
- [ ] Checked `npm run build` runs without issue.
- [ ] Updated the endpoint map (optional, if you know how).
- [ ] Run llms.txt generator (optional, if you know how).
