### PR TITLE
feat(v3.5.9): add support for historical block trades and margin liquidation loan features, update documentation and examples

### DIFF
--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -52,516 +52,523 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [testConnectivity()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L765) |  | GET | `api/v3/ping` |
-| [getExchangeInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L769) |  | GET | `api/v3/exchangeInfo` |
-| [getOrderBook()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L789) |  | GET | `api/v3/depth` |
-| [getRecentTrades()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L793) |  | GET | `api/v3/trades` |
-| [getHistoricalTrades()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L797) |  | GET | `api/v3/historicalTrades` |
-| [getAggregateTrades()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L801) |  | GET | `api/v3/aggTrades` |
-| [getKlines()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L807) |  | GET | `api/v3/klines` |
-| [getUIKlines()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L811) |  | GET | `api/v3/uiKlines` |
-| [getAvgPrice()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L815) |  | GET | `api/v3/avgPrice` |
-| [getExecutionRules()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L819) |  | GET | `api/v3/executionRules?symbols=` |
-| [getReferencePrice()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L834) |  | GET | `api/v3/referencePrice` |
-| [getReferencePriceCalculation()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L840) |  | GET | `api/v3/referencePrice/calculation` |
-| [get24hrChangeStatistics()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L847) |  | GET | `api/v3/ticker/24hr?symbols=` |
-| [getTradingDayTicker()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L877) |  | GET | `api/v3/ticker/tradingDay?symbols=` |
-| [getSymbolPriceTicker()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L892) |  | GET | `api/v3/ticker/price?symbols=` |
-| [getSymbolOrderBookTicker()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L909) |  | GET | `api/v3/ticker/bookTicker?symbols=` |
-| [getRollingWindowTicker()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L926) |  | GET | `api/v3/ticker?symbols=` |
-| [submitNewOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L948) | :closed_lock_with_key:  | POST | `api/v3/order` |
-| [testNewOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L956) | :closed_lock_with_key:  | POST | `api/v3/order/test` |
-| [getOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L964) | :closed_lock_with_key:  | GET | `api/v3/order` |
-| [cancelOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L968) | :closed_lock_with_key:  | DELETE | `api/v3/order` |
-| [cancelAllSymbolOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L972) | :closed_lock_with_key:  | DELETE | `api/v3/openOrders` |
-| [replaceOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L978) | :closed_lock_with_key:  | POST | `api/v3/order/cancelReplace` |
-| [amendOrderKeepPriority()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L992) | :closed_lock_with_key:  | PUT | `fapi/v1/order/amend/keepPriority` |
-| [getOpenOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L999) | :closed_lock_with_key:  | GET | `api/v3/openOrders` |
-| [getAllOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1003) | :closed_lock_with_key:  | GET | `api/v3/allOrders` |
-| [submitNewOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1010) | :closed_lock_with_key:  | POST | `api/v3/order/oco` |
-| [submitNewOrderList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1017) | :closed_lock_with_key:  | POST | `api/v3/orderList/oco` |
-| [submitNewOrderListOTO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1026) | :closed_lock_with_key:  | POST | `api/v3/orderList/oto` |
-| [submitNewOrderListOTOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1035) | :closed_lock_with_key:  | POST | `api/v3/orderList/otoco` |
-| [submitNewOrderListOPO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1045) | :closed_lock_with_key:  | POST | `api/v3/orderList/opo` |
-| [submitNewOrderListOPOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1054) | :closed_lock_with_key:  | POST | `api/v3/orderList/opoco` |
-| [cancelOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1064) | :closed_lock_with_key:  | DELETE | `api/v3/orderList` |
-| [getOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1069) | :closed_lock_with_key:  | GET | `api/v3/orderList` |
-| [getAllOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1073) | :closed_lock_with_key:  | GET | `api/v3/allOrderList` |
-| [getAllOpenOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1080) | :closed_lock_with_key:  | GET | `api/v3/openOrderList` |
-| [submitNewSOROrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1087) | :closed_lock_with_key:  | POST | `api/v3/sor/order` |
-| [testNewSOROrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1098) | :closed_lock_with_key:  | POST | `api/v3/sor/order/test` |
-| [getAccountInformation()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1114) | :closed_lock_with_key:  | GET | `api/v3/account` |
-| [getAccountTradeList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1120) | :closed_lock_with_key:  | GET | `api/v3/myTrades` |
-| [getOrderRateLimit()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1126) | :closed_lock_with_key:  | GET | `api/v3/rateLimit/order` |
-| [getPreventedMatches()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1130) | :closed_lock_with_key:  | GET | `api/v3/myPreventedMatches` |
-| [getAllocations()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1136) | :closed_lock_with_key:  | GET | `api/v3/myAllocations` |
-| [getCommissionRates()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1140) | :closed_lock_with_key:  | GET | `api/v3/account/commission` |
-| [getCrossMarginCollateralRatio()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1150) | :closed_lock_with_key:  | GET | `sapi/v1/margin/crossMarginCollateralRatio` |
-| [getAllCrossMarginPairs()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1159) |  | GET | `sapi/v1/margin/allPairs` |
-| [getIsolatedMarginAllSymbols()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1163) | :closed_lock_with_key:  | GET | `sapi/v1/margin/isolated/allPairs` |
-| [getAllMarginAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1169) |  | GET | `sapi/v1/margin/allAssets` |
-| [getMarginDelistSchedule()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1173) | :closed_lock_with_key:  | GET | `sapi/v1/margin/delist-schedule` |
-| [getIsolatedMarginTierData()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1177) | :closed_lock_with_key:  | GET | `sapi/v1/margin/isolatedMarginTier` |
-| [queryMarginPriceIndex()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1183) |  | GET | `sapi/v1/margin/priceIndex` |
-| [getMarginAvailableInventory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1189) | :closed_lock_with_key:  | GET | `sapi/v1/margin/available-inventory` |
-| [getLeverageBracket()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1195) | :closed_lock_with_key:  | GET | `sapi/v1/margin/leverageBracket` |
-| [getNextHourlyInterestRate()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1205) | :closed_lock_with_key:  | GET | `sapi/v1/margin/next-hourly-interest-rate` |
-| [getMarginInterestHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1211) | :closed_lock_with_key:  | GET | `sapi/v1/margin/interestHistory` |
-| [submitMarginAccountBorrowRepay()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1218) | :closed_lock_with_key:  | POST | `sapi/v1/margin/borrow-repay` |
-| [getMarginAccountBorrowRepayRecords()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1224) | :closed_lock_with_key:  | GET | `sapi/v1/margin/borrow-repay` |
-| [getMarginInterestRateHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1230) | :closed_lock_with_key:  | GET | `sapi/v1/margin/interestRateHistory` |
-| [queryMaxBorrow()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1236) | :closed_lock_with_key:  | GET | `sapi/v1/margin/maxBorrowable` |
-| [getMarginForceLiquidationRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1248) | :closed_lock_with_key:  | GET | `sapi/v1/margin/forceLiquidationRec` |
-| [getSmallLiabilityExchangeCoins()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1257) | :closed_lock_with_key:  | GET | `sapi/v1/margin/exchange-small-liability` |
-| [getSmallLiabilityExchangeHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1261) | :closed_lock_with_key:  | GET | `sapi/v1/margin/exchange-small-liability-history` |
-| [marginAccountCancelOpenOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1273) | :closed_lock_with_key:  | DELETE | `sapi/v1/margin/openOrders` |
-| [marginAccountCancelOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1279) | :closed_lock_with_key:  | DELETE | `sapi/v1/margin/orderList` |
-| [marginAccountCancelOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1284) | :closed_lock_with_key:  | DELETE | `sapi/v1/margin/order` |
-| [marginAccountNewOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1290) | :closed_lock_with_key:  | POST | `sapi/v1/margin/order/oco` |
-| [marginAccountNewOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1297) | :closed_lock_with_key:  | POST | `sapi/v1/margin/order` |
-| [getMarginOrderCountUsage()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1305) | :closed_lock_with_key:  | GET | `sapi/v1/margin/rateLimit/order` |
-| [queryMarginAccountAllOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1311) | :closed_lock_with_key:  | GET | `sapi/v1/margin/allOrderList` |
-| [queryMarginAccountAllOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1317) | :closed_lock_with_key:  | GET | `sapi/v1/margin/allOrders` |
-| [queryMarginAccountOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1323) | :closed_lock_with_key:  | GET | `sapi/v1/margin/orderList` |
-| [queryMarginAccountOpenOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1327) | :closed_lock_with_key:  | GET | `sapi/v1/margin/openOrderList` |
-| [queryMarginAccountOpenOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1334) | :closed_lock_with_key:  | GET | `sapi/v1/margin/openOrders` |
-| [queryMarginAccountOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1338) | :closed_lock_with_key:  | GET | `sapi/v1/margin/order` |
-| [queryMarginAccountTradeList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1342) | :closed_lock_with_key:  | GET | `sapi/v1/margin/myTrades` |
-| [submitSmallLiabilityExchange()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1348) | :closed_lock_with_key:  | POST | `sapi/v1/margin/exchange-small-liability` |
-| [submitManualLiquidation()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1355) | :closed_lock_with_key:  | POST | `sapi/v1/margin/manual-liquidation` |
-| [submitMarginOTOOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1364) | :closed_lock_with_key:  | POST | `sapi/v1/margin/order/oto` |
-| [submitMarginOTOCOOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1376) | :closed_lock_with_key:  | POST | `sapi/v1/margin/order/otoco` |
-| [createMarginSpecialLowLatencyKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1389) | :closed_lock_with_key:  | POST | `sapi/v1/margin/apiKey` |
-| [deleteMarginSpecialLowLatencyKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1395) | :closed_lock_with_key:  | DELETE | `sapi/v1/margin/apiKey` |
-| [updateMarginIPForSpecialLowLatencyKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1403) | :closed_lock_with_key:  | PUT | `sapi/v1/margin/apiKey/ip` |
-| [getMarginSpecialLowLatencyKeys()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1414) | :closed_lock_with_key:  | GET | `sapi/v1/margin/api-key-list` |
-| [getMarginSpecialLowLatencyKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1423) | :closed_lock_with_key:  | GET | `sapi/v1/margin/apiKey` |
-| [getCrossMarginTransferHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1436) | :closed_lock_with_key:  | GET | `sapi/v1/margin/transfer` |
-| [queryMaxTransferOutAmount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1442) | :closed_lock_with_key:  | GET | `sapi/v1/margin/maxTransferable` |
-| [updateCrossMarginMaxLeverage()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1454) | :closed_lock_with_key:  | POST | `sapi/v1/margin/max-leverage` |
-| [disableIsolatedMarginAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1460) | :closed_lock_with_key:  | DELETE | `sapi/v1/margin/isolated/account` |
-| [enableIsolatedMarginAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1467) | :closed_lock_with_key:  | POST | `sapi/v1/margin/isolated/account` |
-| [getBNBBurn()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1474) | :closed_lock_with_key:  | GET | `sapi/v1/bnbBurn` |
-| [getMarginSummary()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1478) | :closed_lock_with_key:  | GET | `sapi/v1/margin/tradeCoeff` |
-| [queryCrossMarginAccountDetails()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1482) | :closed_lock_with_key:  | GET | `sapi/v1/margin/account` |
-| [getCrossMarginFeeData()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1486) | :closed_lock_with_key:  | GET | `sapi/v1/margin/crossMarginData` |
-| [getIsolatedMarginAccountLimit()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1492) | :closed_lock_with_key:  | GET | `sapi/v1/margin/isolated/accountLimit` |
-| [getIsolatedMarginAccountInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1499) | :closed_lock_with_key:  | GET | `sapi/v1/margin/isolated/account` |
-| [getIsolatedMarginFeeData()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1505) | :closed_lock_with_key:  | GET | `sapi/v1/margin/isolatedMarginData` |
-| [toggleBNBBurn()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1511) | :closed_lock_with_key:  | POST | `sapi/v1/bnbBurn` |
-| [getMarginCapitalFlow()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1519) | :closed_lock_with_key:  | GET | `sapi/v1/margin/capital-flow` |
-| [queryLoanRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1528) | :closed_lock_with_key:  | GET | `sapi/v1/margin/loan` |
-| [queryRepayRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1537) | :closed_lock_with_key:  | GET | `sapi/v1/margin/repay` |
-| [isolatedMarginAccountTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1546) | :closed_lock_with_key:  | POST | `sapi/v1/margin/isolated/transfer` |
-| [getBalances()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1558) | :closed_lock_with_key:  | GET | `sapi/v1/capital/config/getall` |
-| [withdraw()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1562) | :closed_lock_with_key:  | POST | `sapi/v1/capital/withdraw/apply` |
-| [getWithdrawHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1566) | :closed_lock_with_key:  | GET | `sapi/v1/capital/withdraw/history` |
-| [getWithdrawAddresses()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1572) | :closed_lock_with_key:  | GET | `sapi/v1/capital/withdraw/address/list` |
-| [getWithdrawQuota()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1576) | :closed_lock_with_key:  | GET | `sapi/v1/capital/withdraw/quota` |
-| [getDepositHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1583) | :closed_lock_with_key:  | GET | `sapi/v1/capital/deposit/hisrec` |
-| [getDepositAddress()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1587) | :closed_lock_with_key:  | GET | `sapi/v1/capital/deposit/address` |
-| [getDepositAddresses()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1593) | :closed_lock_with_key:  | GET | `sapi/v1/capital/deposit/address/list` |
-| [submitDepositCredit()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1599) | :closed_lock_with_key:  | POST | `sapi/v1/capital/deposit/credit-apply` |
-| [getAutoConvertStablecoins()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1608) | :closed_lock_with_key:  | GET | `sapi/v1/capital/contract/convertible-coins` |
-| [setConvertibleCoins()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1615) | :closed_lock_with_key:  | POST | `sapi/v1/capital/contract/convertible-coins` |
-| [getAssetDetail()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1628) | :closed_lock_with_key:  | GET | `sapi/v1/asset/assetDetail` |
-| [getWalletBalances()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1634) | :closed_lock_with_key:  | GET | `sapi/v1/asset/wallet/balance` |
-| [getUserAsset()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1640) | :closed_lock_with_key:  | POST | `sapi/v3/asset/getUserAsset` |
-| [submitUniversalTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1644) | :closed_lock_with_key:  | POST | `sapi/v1/asset/transfer` |
-| [getUniversalTransferHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1650) | :closed_lock_with_key:  | GET | `sapi/v1/asset/transfer` |
-| [getDust()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1656) | :closed_lock_with_key:  | POST | `sapi/v1/asset/dust-btc` |
-| [convertDustToBnb()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1660) | :closed_lock_with_key:  | POST | `sapi/v1/asset/dust` |
-| [getDustLog()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1664) | :closed_lock_with_key:  | GET | `sapi/v1/asset/dribblet` |
-| [getAssetDividendRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1668) | :closed_lock_with_key:  | GET | `sapi/v1/asset/assetDividend` |
-| [getTradeFee()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1672) | :closed_lock_with_key:  | GET | `sapi/v1/asset/tradeFee` |
-| [getFundingAsset()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1676) | :closed_lock_with_key:  | POST | `sapi/v1/asset/get-funding-asset` |
-| [getCloudMiningHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1680) | :closed_lock_with_key:  | GET | `sapi/v1/asset/ledger-transfer/cloud-mining/queryByPage` |
-| [getDelegationHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1690) | :closed_lock_with_key:  | GET | `sapi/v1/asset/custody/transfer-history` |
-| [submitNewFutureAccountTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1720) | :closed_lock_with_key:  | POST | `sapi/v1/futures/transfer` |
-| [getFutureAccountTransferHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1730) | :closed_lock_with_key:  | GET | `sapi/v1/futures/transfer` |
-| [getCrossCollateralBorrowHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1739) | :closed_lock_with_key:  | GET | `sapi/v1/futures/loan/borrow/history` |
-| [getCrossCollateralRepaymentHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1746) | :closed_lock_with_key:  | GET | `sapi/v1/futures/loan/repay/history` |
-| [getCrossCollateralWalletV2()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1753) | :closed_lock_with_key:  | GET | `sapi/v2/futures/loan/wallet` |
-| [getAdjustCrossCollateralLTVHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1760) | :closed_lock_with_key:  | GET | `sapi/v1/futures/loan/adjustCollateral/history` |
-| [getCrossCollateralLiquidationHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1772) | :closed_lock_with_key:  | GET | `sapi/v1/futures/loan/liquidationHistory` |
-| [getCrossCollateralInterestHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1781) | :closed_lock_with_key:  | GET | `sapi/v1/futures/loan/interestHistory` |
-| [getAccountInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1793) | :closed_lock_with_key:  | GET | `sapi/v1/account/info` |
-| [getDailyAccountSnapshot()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1797) | :closed_lock_with_key:  | GET | `sapi/v1/accountSnapshot` |
-| [disableFastWithdrawSwitch()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1803) | :closed_lock_with_key:  | POST | `sapi/v1/account/disableFastWithdrawSwitch` |
-| [enableFastWithdrawSwitch()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1807) | :closed_lock_with_key:  | POST | `sapi/v1/account/enableFastWithdrawSwitch` |
-| [getAccountStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1811) | :closed_lock_with_key:  | GET | `sapi/v1/account/status` |
-| [getApiTradingStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1815) | :closed_lock_with_key:  | GET | `sapi/v1/account/apiTradingStatus` |
-| [getApiKeyPermissions()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1819) | :closed_lock_with_key:  | GET | `sapi/v1/account/apiRestrictions` |
-| [withdrawTravelRule()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1835) | :closed_lock_with_key:  | POST | `sapi/v1/localentity/withdraw/apply` |
-| [getTravelRuleWithdrawHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1846) | :closed_lock_with_key:  | GET | `sapi/v1/localentity/withdraw/history` |
-| [getTravelRuleWithdrawHistoryV2()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1855) | :closed_lock_with_key:  | GET | `sapi/v2/localentity/withdraw/history` |
-| [submitTravelRuleDepositQuestionnaire()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1867) | :closed_lock_with_key:  | PUT | `sapi/v1/localentity/deposit/provide-info` |
-| [getTravelRuleDepositHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1876) | :closed_lock_with_key:  | GET | `sapi/v1/localentity/deposit/history` |
-| [getOnboardedVASPList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1887) | :closed_lock_with_key:  | GET | `sapi/v1/localentity/vasp` |
-| [getSystemStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1897) |  | GET | `sapi/v1/system/status` |
-| [getDelistSchedule()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1901) | :closed_lock_with_key:  | GET | `sapi/v1/spot/delist-schedule` |
-| [createVirtualSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1911) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/virtualSubAccount` |
-| [getSubAccountList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1917) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/list` |
-| [subAccountEnableFutures()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1923) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/futures/enable` |
-| [subAccountEnableMargin()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1931) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/margin/enable` |
-| [enableOptionsForSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1935) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/eoptions/enable` |
-| [subAccountEnableLeverageToken()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1945) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/blvt/enable` |
-| [getSubAccountStatusOnMarginOrFutures()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1951) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/status` |
-| [getSubAccountFuturesPositionRisk()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1957) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/futures/positionRisk` |
-| [getSubAccountFuturesPositionRiskV2()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1965) | :closed_lock_with_key:  | GET | `sapi/v2/sub-account/futures/positionRisk` |
-| [getSubAccountTransactionStatistics()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1971) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/transaction-statistics` |
-| [getSubAccountIPRestriction()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1986) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/subAccountApi/ipRestriction` |
-| [subAccountDeleteIPList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1995) | :closed_lock_with_key:  | DELETE | `sapi/v1/sub-account/subAccountApi/ipRestriction/ipList` |
-| [subAccountAddIPRestriction()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2004) | :closed_lock_with_key:  | POST | `sapi/v2/sub-account/subAccountApi/ipRestriction` |
-| [subAccountAddIPList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2017) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/subAccountApi/ipRestriction/ipList` |
-| [subAccountEnableOrDisableIPRestriction()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2030) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/subAccountApi/ipRestriction` |
-| [subAccountFuturesTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2045) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/futures/transfer` |
-| [getSubAccountFuturesAccountDetail()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2051) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/futures/account` |
-| [getSubAccountDetailOnFuturesAccountV2()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2057) | :closed_lock_with_key:  | GET | `sapi/v2/sub-account/futures/account` |
-| [getSubAccountDetailOnMarginAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2063) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/margin/account` |
-| [getSubAccountDepositAddress()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2069) | :closed_lock_with_key:  | GET | `sapi/v1/capital/deposit/subAddress` |
-| [getSubAccountDepositHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2075) | :closed_lock_with_key:  | GET | `sapi/v1/capital/deposit/subHisrec` |
-| [getSubAccountFuturesAccountSummary()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2081) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/futures/accountSummary` |
-| [getSubAccountSummaryOnFuturesAccountV2()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2085) | :closed_lock_with_key:  | GET | `sapi/v2/sub-account/futures/accountSummary` |
-| [getSubAccountsSummaryOfMarginAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2094) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/margin/accountSummary` |
-| [subAccountMarginTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2098) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/margin/transfer` |
-| [getSubAccountAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2104) | :closed_lock_with_key:  | GET | `sapi/v3/sub-account/assets` |
-| [getSubAccountAssetsMaster()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2110) | :closed_lock_with_key:  | GET | `sapi/v4/sub-account/assets` |
-| [getSubAccountFuturesAssetTransferHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2116) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/futures/internalTransfer` |
-| [getSubAccountSpotAssetTransferHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2125) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/sub/transfer/history` |
-| [getSubAccountSpotAssetsSummary()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2131) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/spotSummary` |
-| [getSubAccountUniversalTransferHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2137) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/universalTransfer` |
-| [subAccountFuturesAssetTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2143) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/futures/internalTransfer` |
-| [subAccountTransferHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2152) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/transfer/subUserHistory` |
-| [subAccountTransferToMaster()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2161) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/transfer/subToMaster` |
-| [subAccountTransferToSameMaster()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2167) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/transfer/subToSub` |
-| [subAccountUniversalTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2173) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/universalTransfer` |
-| [subAccountMovePosition()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2179) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/futures/move-position` |
-| [getSubAccountFuturesPositionMoveHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2188) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/futures/move-position` |
-| [depositAssetsIntoManagedSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2203) | :closed_lock_with_key:  | POST | `sapi/v1/managed-subaccount/deposit` |
-| [getManagedSubAccountDepositAddress()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2209) | :closed_lock_with_key:  | GET | `sapi/v1/managed-subaccount/deposit/address` |
-| [withdrawAssetsFromManagedSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2218) | :closed_lock_with_key:  | POST | `sapi/v1/managed-subaccount/withdraw` |
-| [getManagedSubAccountTransfersParent()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2224) | :closed_lock_with_key:  | GET | `sapi/v1/managed-subaccount/queryTransLogForTradeParent` |
-| [getManagedSubAccountTransferLog()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2236) | :closed_lock_with_key:  | GET | `sapi/v1/managed-subaccount/query-trans-log` |
-| [getManagedSubAccountTransfersInvestor()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2248) | :closed_lock_with_key:  | GET | `sapi/v1/managed-subaccount/queryTransLogForInvestor` |
-| [getManagedSubAccounts()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2260) | :closed_lock_with_key:  | GET | `sapi/v1/managed-subaccount/info` |
-| [getManagedSubAccountSnapshot()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2267) | :closed_lock_with_key:  | GET | `sapi/v1/managed-subaccount/accountSnapshot` |
-| [getManagedSubAccountAssetDetails()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2276) | :closed_lock_with_key:  | GET | `sapi/v1/managed-subaccount/asset` |
-| [getManagedSubAccountMarginAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2282) | :closed_lock_with_key:  | GET | `sapi/v1/managed-subaccount/marginAsset` |
-| [getManagedSubAccountFuturesAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2289) | :closed_lock_with_key:  | GET | `sapi/v1/managed-subaccount/fetch-future-asset` |
-| [getAutoInvestAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2305) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/all/asset` |
-| [getAutoInvestSourceAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2312) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/source-asset/list` |
-| [getAutoInvestTargetAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2321) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/target-asset/list` |
-| [getAutoInvestTargetAssetsROI()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2330) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/target-asset/roi/list` |
-| [getAutoInvestIndex()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2339) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/index/info` |
-| [getAutoInvestPlans()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2345) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/plan/list` |
-| [submitAutoInvestOneTimeTransaction()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2363) | :closed_lock_with_key:  | POST | `sapi/v1/lending/auto-invest/one-off` |
-| [updateAutoInvestPlanStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2379) | :closed_lock_with_key:  | POST | `sapi/v1/lending/auto-invest/plan/edit-status` |
-| [updateAutoInvestmentPlan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2388) | :closed_lock_with_key:  | POST | `sapi/v1/lending/auto-invest/plan/edit` |
-| [submitAutoInvestRedemption()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2405) | :closed_lock_with_key:  | POST | `sapi/v1/lending/auto-invest/redeem` |
-| [getAutoInvestSubscriptionTransactions()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2413) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/history/list` |
-| [getOneTimeTransactionStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2419) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/one-off/status` |
-| [submitAutoInvestmentPlan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2428) | :closed_lock_with_key:  | POST | `sapi/v1/lending/auto-invest/plan/add` |
-| [getAutoInvestRedemptionHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2443) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/redeem/history` |
-| [getAutoInvestPlan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2452) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/plan/id` |
-| [getAutoInvestUserIndex()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2456) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/index/user-summary` |
-| [getAutoInvestRebalanceHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2465) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/rebalance/history` |
-| [getConvertPairs()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2480) | :closed_lock_with_key:  | GET | `sapi/v1/convert/exchangeInfo` |
-| [getConvertAssetInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2484) | :closed_lock_with_key:  | GET | `sapi/v1/convert/assetInfo` |
-| [convertQuoteRequest()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2494) | :closed_lock_with_key:  | POST | `sapi/v1/convert/getQuote` |
-| [acceptQuoteRequest()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2498) | :closed_lock_with_key:  | POST | `sapi/v1/convert/acceptQuote` |
-| [getConvertTradeHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2502) | :closed_lock_with_key:  | GET | `sapi/v1/convert/tradeFlow` |
-| [getOrderStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2506) | :closed_lock_with_key:  | GET | `sapi/v1/convert/orderStatus` |
-| [submitConvertLimitOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2510) | :closed_lock_with_key:  | POST | `sapi/v1/convert/limit/placeOrder` |
-| [cancelConvertLimitOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2514) | :closed_lock_with_key:  | POST | `sapi/v1/convert/limit/cancelOrder` |
-| [getConvertLimitOpenOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2518) | :closed_lock_with_key:  | GET | `sapi/v1/convert/limit/queryOpenOrders` |
-| [getEthStakingAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2533) | :closed_lock_with_key:  | GET | `sapi/v1/eth-staking/account` |
-| [getEthStakingAccountV2()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2537) | :closed_lock_with_key:  | GET | `sapi/v2/eth-staking/account` |
-| [getEthStakingQuota()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2541) | :closed_lock_with_key:  | GET | `sapi/v1/eth-staking/eth/quota` |
-| [subscribeEthStakingV1()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2554) | :closed_lock_with_key:  | POST | `sapi/v1/eth-staking/eth/stake` |
-| [subscribeEthStakingV2()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2560) | :closed_lock_with_key:  | POST | `sapi/v2/eth-staking/eth/stake` |
-| [redeemEth()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2566) | :closed_lock_with_key:  | POST | `sapi/v1/eth-staking/eth/redeem` |
-| [wrapBeth()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2570) | :closed_lock_with_key:  | POST | `sapi/v1/eth-staking/wbeth/wrap` |
-| [getEthStakingHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2580) | :closed_lock_with_key:  | GET | `sapi/v1/eth-staking/eth/history/stakingHistory` |
-| [getEthRedemptionHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2590) | :closed_lock_with_key:  | GET | `sapi/v1/eth-staking/eth/history/redemptionHistory` |
-| [getBethRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2600) | :closed_lock_with_key:  | GET | `sapi/v1/eth-staking/eth/history/rewardsHistory` |
-| [getWbethRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2610) | :closed_lock_with_key:  | GET | `sapi/v1/eth-staking/eth/history/wbethRewardsHistory` |
-| [getEthRateHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2619) | :closed_lock_with_key:  | GET | `sapi/v1/eth-staking/eth/history/rateHistory` |
-| [getBethWrapHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2629) | :closed_lock_with_key:  | GET | `sapi/v1/eth-staking/wbeth/history/wrapHistory` |
-| [getBethUnwrapHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2639) | :closed_lock_with_key:  | GET | `sapi/v1/eth-staking/wbeth/history/unwrapHistory` |
-| [getBfusdAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2655) | :closed_lock_with_key:  | GET | `sapi/v1/bfusd/account` |
-| [getBfusdQuota()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2659) | :closed_lock_with_key:  | GET | `sapi/v1/bfusd/quota` |
-| [subscribeBfusd()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2663) | :closed_lock_with_key:  | POST | `sapi/v1/bfusd/subscribe` |
-| [redeemBfusd()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2669) | :closed_lock_with_key:  | POST | `sapi/v1/bfusd/redeem` |
-| [getBfusdSubscriptionHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2673) | :closed_lock_with_key:  | GET | `sapi/v1/bfusd/history/subscriptionHistory` |
-| [getBfusdRedemptionHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2679) | :closed_lock_with_key:  | GET | `sapi/v1/bfusd/history/redemptionHistory` |
-| [getBfusdRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2685) | :closed_lock_with_key:  | GET | `sapi/v1/bfusd/history/rewardsHistory` |
-| [getBfusdRateHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2691) | :closed_lock_with_key:  | GET | `sapi/v1/bfusd/history/rateHistory` |
-| [getRwusdAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2703) | :closed_lock_with_key:  | GET | `sapi/v1/rwusd/account` |
-| [getRwusdQuota()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2707) | :closed_lock_with_key:  | GET | `sapi/v1/rwusd/quota` |
-| [subscribeRwusd()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2711) | :closed_lock_with_key:  | POST | `sapi/v1/rwusd/subscribe` |
-| [redeemRwusd()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2717) | :closed_lock_with_key:  | POST | `sapi/v1/rwusd/redeem` |
-| [getRwusdSubscriptionHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2721) | :closed_lock_with_key:  | GET | `sapi/v1/rwusd/history/subscriptionHistory` |
-| [getRwusdRedemptionHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2727) | :closed_lock_with_key:  | GET | `sapi/v1/rwusd/history/redemptionHistory` |
-| [getRwusdRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2733) | :closed_lock_with_key:  | GET | `sapi/v1/rwusd/history/rewardsHistory` |
-| [getRwusdRateHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2739) | :closed_lock_with_key:  | GET | `sapi/v1/rwusd/history/rateHistory` |
-| [getStakingProducts()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2748) | :closed_lock_with_key:  | GET | `sapi/v1/staking/productList` |
-| [getStakingProductPosition()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2759) | :closed_lock_with_key:  | GET | `sapi/v1/staking/position` |
-| [getStakingHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2771) | :closed_lock_with_key:  | GET | `sapi/v1/staking/stakingRecord` |
-| [getPersonalLeftQuotaOfStakingProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2778) | :closed_lock_with_key:  | GET | `sapi/v1/staking/personalLeftQuota` |
-| [getSolStakingAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2791) | :closed_lock_with_key:  | GET | `sapi/v1/sol-staking/account` |
-| [getSolStakingQuota()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2795) | :closed_lock_with_key:  | GET | `sapi/v1/sol-staking/sol/quota` |
-| [subscribeSolStaking()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2805) | :closed_lock_with_key:  | POST | `sapi/v1/sol-staking/sol/stake` |
-| [redeemSol()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2811) | :closed_lock_with_key:  | POST | `sapi/v1/sol-staking/sol/redeem` |
-| [claimSolBoostRewards()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2815) | :closed_lock_with_key:  | POST | `sapi/v1/sol-staking/sol/claim` |
-| [getSolStakingHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2827) | :closed_lock_with_key:  | GET | `sapi/v1/sol-staking/sol/history/stakingHistory` |
-| [getSolRedemptionHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2837) | :closed_lock_with_key:  | GET | `sapi/v1/sol-staking/sol/history/redemptionHistory` |
-| [getBnsolRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2847) | :closed_lock_with_key:  | GET | `sapi/v1/sol-staking/sol/history/bnsolRewardsHistory` |
-| [getBnsolRateHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2858) | :closed_lock_with_key:  | GET | `sapi/v1/sol-staking/sol/history/rateHistory` |
-| [getSolBoostRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2868) | :closed_lock_with_key:  | GET | `sapi/v1/sol-staking/sol/history/boostRewardsHistory` |
-| [getSolUnclaimedRewards()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2878) | :closed_lock_with_key:  | GET | `sapi/v1/sol-staking/sol/history/unclaimedRewards` |
-| [getOnchainYieldsLockedProducts()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2893) | :closed_lock_with_key:  | GET | `sapi/v1/onchain-yields/locked/list` |
-| [getOnchainYieldsLockedPersonalLeftQuota()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2899) | :closed_lock_with_key:  | GET | `sapi/v1/onchain-yields/locked/personalLeftQuota` |
-| [getOnchainYieldsLockedPosition()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2908) | :closed_lock_with_key:  | GET | `sapi/v1/onchain-yields/locked/position` |
-| [getOnchainYieldsAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2914) | :closed_lock_with_key:  | GET | `sapi/v1/onchain-yields/account` |
-| [getOnchainYieldsLockedSubscriptionPreview()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2924) | :closed_lock_with_key:  | GET | `sapi/v1/onchain-yields/locked/subscriptionPreview` |
-| [subscribeOnchainYieldsLockedProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2933) | :closed_lock_with_key:  | POST | `sapi/v1/onchain-yields/locked/subscribe` |
-| [setOnchainYieldsLockedAutoSubscribe()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2939) | :closed_lock_with_key:  | POST | `sapi/v1/onchain-yields/locked/setAutoSubscribe` |
-| [setOnchainYieldsLockedRedeemOption()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2948) | :closed_lock_with_key:  | POST | `sapi/v1/onchain-yields/locked/setRedeemOption` |
-| [redeemOnchainYieldsLockedProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2957) | :closed_lock_with_key:  | POST | `sapi/v1/onchain-yields/locked/redeem` |
-| [getOnchainYieldsLockedSubscriptionRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2969) | :closed_lock_with_key:  | GET | `sapi/v1/onchain-yields/locked/history/subscriptionRecord` |
-| [getOnchainYieldsLockedRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2978) | :closed_lock_with_key:  | GET | `sapi/v1/onchain-yields/locked/history/rewardsRecord` |
-| [getOnchainYieldsLockedRedemptionRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2987) | :closed_lock_with_key:  | GET | `sapi/v1/onchain-yields/locked/history/redemptionRecord` |
-| [getSoftStakingProductList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3002) | :closed_lock_with_key:  | GET | `sapi/v1/soft-staking/list` |
-| [setSoftStaking()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3008) | :closed_lock_with_key:  | GET | `sapi/v1/soft-staking/set` |
-| [getSoftStakingRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3014) | :closed_lock_with_key:  | GET | `sapi/v1/soft-staking/history/rewardsRecord` |
-| [getFuturesLeadTraderStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3029) | :closed_lock_with_key:  | GET | `sapi/v1/copyTrading/futures/userStatus` |
-| [getFuturesLeadTradingSymbolWhitelist()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3033) | :closed_lock_with_key:  | GET | `sapi/v1/copyTrading/futures/leadSymbol` |
-| [getMiningAlgos()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3045) |  | GET | `sapi/v1/mining/pub/algoList` |
-| [getMiningCoins()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3049) |  | GET | `sapi/v1/mining/pub/coinList` |
-| [getHashrateResales()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3053) | :closed_lock_with_key:  | GET | `sapi/v1/mining/hash-transfer/config/details/list` |
-| [getMiners()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3062) | :closed_lock_with_key:  | GET | `sapi/v1/mining/worker/list` |
-| [getMinerDetails()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3066) | :closed_lock_with_key:  | GET | `sapi/v1/mining/worker/detail` |
-| [getExtraBonuses()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3072) | :closed_lock_with_key:  | GET | `sapi/v1/mining/payment/other` |
-| [getMiningEarnings()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3078) | :closed_lock_with_key:  | GET | `sapi/v1/mining/payment/list` |
-| [cancelHashrateResaleConfig()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3084) | :closed_lock_with_key:  | POST | `sapi/v1/mining/hash-transfer/config/cancel` |
-| [getHashrateResale()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3093) | :closed_lock_with_key:  | GET | `sapi/v1/mining/hash-transfer/profit/details` |
-| [getMiningAccountEarnings()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3102) | :closed_lock_with_key:  | GET | `sapi/v1/mining/payment/uid` |
-| [getMiningStatistics()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3108) | :closed_lock_with_key:  | GET | `sapi/v1/mining/statistics/user/status` |
-| [submitHashrateResale()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3114) | :closed_lock_with_key:  | POST | `sapi/v1/mining/hash-transfer/config` |
-| [getMiningAccounts()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3118) | :closed_lock_with_key:  | GET | `sapi/v1/mining/statistics/user/list` |
-| [submitVpNewOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3130) | :closed_lock_with_key:  | POST | `sapi/v1/algo/futures/newOrderVp` |
-| [submitTwapNewOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3137) | :closed_lock_with_key:  | POST | `sapi/v1/algo/futures/newOrderTwap` |
-| [cancelAlgoOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3144) | :closed_lock_with_key:  | DELETE | `sapi/v1/algo/futures/order` |
-| [getAlgoSubOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3150) | :closed_lock_with_key:  | GET | `sapi/v1/algo/futures/subOrders` |
-| [getAlgoOpenOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3156) | :closed_lock_with_key:  | GET | `sapi/v1/algo/futures/openOrders` |
-| [getAlgoHistoricalOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3163) | :closed_lock_with_key:  | GET | `sapi/v1/algo/futures/historicalOrders` |
-| [submitSpotAlgoTwapOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3176) | :closed_lock_with_key:  | POST | `sapi/v1/algo/spot/newOrderTwap` |
-| [cancelSpotAlgoOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3183) | :closed_lock_with_key:  | DELETE | `sapi/v1/algo/spot/order` |
-| [getSpotAlgoSubOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3189) | :closed_lock_with_key:  | GET | `sapi/v1/algo/spot/subOrders` |
-| [getSpotAlgoOpenOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3195) | :closed_lock_with_key:  | GET | `sapi/v1/algo/spot/openOrders` |
-| [getSpotAlgoHistoricalOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3202) | :closed_lock_with_key:  | GET | `sapi/v1/algo/spot/historicalOrders` |
-| [getCryptoLoanFlexibleCollateralAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3217) | :closed_lock_with_key:  | GET | `sapi/v2/loan/flexible/collateral/data` |
-| [getCryptoLoanFlexibleAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3226) | :closed_lock_with_key:  | GET | `sapi/v2/loan/flexible/loanable/data` |
-| [borrowCryptoLoanFlexible()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3239) | :closed_lock_with_key:  | POST | `sapi/v2/loan/flexible/borrow` |
-| [repayCryptoLoanFlexible()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3245) | :closed_lock_with_key:  | POST | `sapi/v2/loan/flexible/repay` |
-| [repayCryptoLoanFlexibleWithCollateral()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3251) | :closed_lock_with_key:  | POST | `sapi/v2/loan/flexible/repay/collateral` |
-| [adjustCryptoLoanFlexibleLTV()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3257) | :closed_lock_with_key:  | POST | `sapi/v2/loan/flexible/adjust/ltv` |
-| [getCryptoLoanFlexibleLTVAdjustmentHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3269) | :closed_lock_with_key:  | GET | `sapi/v2/loan/flexible/ltv/adjustment/history` |
-| [getFlexibleLoanCollateralRepayRate()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3281) | :closed_lock_with_key:  | GET | `sapi/v2/loan/flexible/repay/rate` |
-| [getLoanFlexibleBorrowHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3292) | :closed_lock_with_key:  | GET | `sapi/v2/loan/flexible/borrow/history` |
-| [getCryptoLoanFlexibleOngoingOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3301) | :closed_lock_with_key:  | GET | `sapi/v2/loan/flexible/ongoing/orders` |
-| [getFlexibleLoanLiquidationHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3310) | :closed_lock_with_key:  | GET | `sapi/v2/loan/flexible/liquidation/history` |
-| [getLoanFlexibleRepaymentHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3319) | :closed_lock_with_key:  | GET | `sapi/v2/loan/flexible/repay/history` |
-| [getCryptoLoanLoanableAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3337) | :closed_lock_with_key:  | GET | `sapi/v1/loan/loanable/data` |
-| [getCryptoLoanCollateralRepayRate()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3344) | :closed_lock_with_key:  | GET | `sapi/v1/loan/repay/collateral/rate` |
-| [getCryptoLoanCollateralAssetsData()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3353) | :closed_lock_with_key:  | GET | `sapi/v1/loan/collateral/data` |
-| [getCryptoLoansIncomeHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3362) | :closed_lock_with_key:  | GET | `sapi/v1/loan/income` |
-| [borrowCryptoLoan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3377) | :closed_lock_with_key:  | POST | `sapi/v1/loan/borrow` |
-| [repayCryptoLoan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3386) | :closed_lock_with_key:  | POST | `sapi/v1/loan/repay` |
-| [adjustCryptoLoanLTV()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3395) | :closed_lock_with_key:  | POST | `sapi/v1/loan/adjust/ltv` |
-| [customizeCryptoLoanMarginCall()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3404) | :closed_lock_with_key:  | POST | `sapi/v1/loan/customize/margin_call` |
-| [getCryptoLoanOngoingOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3420) | :closed_lock_with_key:  | GET | `sapi/v1/loan/ongoing/orders` |
-| [getCryptoLoanBorrowHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3427) | :closed_lock_with_key:  | GET | `sapi/v1/loan/borrow/history` |
-| [getCryptoLoanLTVAdjustmentHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3434) | :closed_lock_with_key:  | GET | `sapi/v1/loan/ltv/adjustment/history` |
-| [getCryptoLoanRepaymentHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3443) | :closed_lock_with_key:  | GET | `sapi/v1/loan/repay/history` |
-| [getSimpleEarnAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3455) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/account` |
-| [getFlexibleSavingProducts()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3459) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/flexible/list` |
-| [getSimpleEarnLockedProductList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3466) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/locked/list` |
-| [getFlexibleProductPosition()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3475) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/flexible/position` |
-| [getLockedProductPosition()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3484) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/locked/position` |
-| [getFlexiblePersonalLeftQuota()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3493) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/flexible/personalLeftQuota` |
-| [getLockedPersonalLeftQuota()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3502) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/locked/personalLeftQuota` |
-| [purchaseFlexibleProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3517) | :closed_lock_with_key:  | POST | `sapi/v1/simple-earn/flexible/subscribe` |
-| [subscribeSimpleEarnLockedProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3523) | :closed_lock_with_key:  | POST | `sapi/v1/simple-earn/locked/subscribe` |
-| [redeemFlexibleProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3529) | :closed_lock_with_key:  | POST | `sapi/v1/simple-earn/flexible/redeem` |
-| [redeemLockedProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3535) | :closed_lock_with_key:  | POST | `sapi/v1/simple-earn/locked/redeem` |
-| [setFlexibleAutoSubscribe()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3541) | :closed_lock_with_key:  | POST | `sapi/v1/simple-earn/flexible/setAutoSubscribe` |
-| [setLockedAutoSubscribe()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3550) | :closed_lock_with_key:  | POST | `sapi/v1/simple-earn/locked/setAutoSubscribe` |
-| [getFlexibleSubscriptionPreview()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3559) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/flexible/subscriptionPreview` |
-| [getLockedSubscriptionPreview()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3568) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/locked/subscriptionPreview` |
-| [setLockedProductRedeemOption()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3577) | :closed_lock_with_key:  | POST | `sapi/v1/simple-earn/locked/setRedeemOption` |
-| [getFlexibleSubscriptionRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3595) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/flexible/history/subscriptionRecord` |
-| [getLockedSubscriptionRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3607) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/locked/history/subscriptionRecord` |
-| [getFlexibleRedemptionRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3619) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/flexible/history/redemptionRecord` |
-| [getLockedRedemptionRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3631) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/locked/history/redemptionRecord` |
-| [getFlexibleRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3641) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/flexible/history/rewardsRecord` |
-| [getLockedRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3651) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/locked/history/rewardsRecord` |
-| [getCollateralRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3661) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/flexible/history/collateralRecord` |
-| [getRateHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3671) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/flexible/history/rateHistory` |
-| [getVipBorrowInterestRate()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3687) | :closed_lock_with_key:  | GET | `sapi/v1/loan/vip/request/interestRate` |
-| [getVipLoanInterestRateHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3693) | :closed_lock_with_key:  | GET | `sapi/v1/loan/vip/interestRateHistory` |
-| [getVipLoanableAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3702) | :closed_lock_with_key:  | GET | `sapi/v1/loan/vip/loanable/data` |
-| [getVipCollateralAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3709) | :closed_lock_with_key:  | GET | `sapi/v1/loan/vip/collateral/data` |
-| [getVipLoanOpenOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3722) | :closed_lock_with_key:  | GET | `sapi/v1/loan/vip/ongoing/orders` |
-| [getVipLoanRepaymentHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3729) | :closed_lock_with_key:  | GET | `sapi/v1/loan/vip/repay/history` |
-| [checkVipCollateralAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3738) | :closed_lock_with_key:  | GET | `sapi/v1/loan/vip/collateral/account` |
-| [getVipApplicationStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3745) | :closed_lock_with_key:  | GET | `sapi/v1/loan/vip/request/data` |
-| [renewVipLoan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3758) | :closed_lock_with_key:  | POST | `sapi/v1/loan/vip/renew` |
-| [repayVipLoan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3762) | :closed_lock_with_key:  | POST | `sapi/v1/loan/vip/repay` |
-| [borrowVipLoan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3766) | :closed_lock_with_key:  | POST | `sapi/v1/loan/vip/borrow` |
-| [getDualInvestmentProducts()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3776) | :closed_lock_with_key:  | GET | `sapi/v1/dci/product/list` |
-| [subscribeDualInvestmentProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3791) | :closed_lock_with_key:  | POST | `sapi/v1/dci/product/subscribe` |
-| [getDualInvestmentPositions()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3797) | :closed_lock_with_key:  | GET | `sapi/v1/dci/product/positions` |
-| [getDualInvestmentAccounts()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3806) | :closed_lock_with_key:  | GET | `sapi/v1/dci/product/accounts` |
-| [getVipLoanAccruedInterest()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3810) | :closed_lock_with_key:  | GET | `sapi/v1/loan/vip/accruedInterest` |
-| [updateAutoCompoundStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3817) | :closed_lock_with_key:  | POST | `sapi/v1/dci/product/auto_compound/edit-status` |
-| [createGiftCard()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3832) | :closed_lock_with_key:  | POST | `sapi/v1/giftcard/createCode` |
-| [createDualTokenGiftCard()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3836) | :closed_lock_with_key:  | POST | `sapi/v1/giftcard/buyCode` |
-| [redeemGiftCard()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3840) | :closed_lock_with_key:  | POST | `sapi/v1/giftcard/redeemCode` |
-| [verifyGiftCard()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3844) | :closed_lock_with_key:  | GET | `sapi/v1/giftcard/verify` |
-| [getTokenLimit()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3848) | :closed_lock_with_key:  | GET | `sapi/v1/giftcard/buyCode/token-limit` |
-| [getRsaPublicKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3852) | :closed_lock_with_key:  | GET | `sapi/v1/giftcard/cryptography/rsa-public-key` |
-| [getNftTransactionHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3862) | :closed_lock_with_key:  | GET | `sapi/v1/nft/history/transactions` |
-| [getNftDepositHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3869) | :closed_lock_with_key:  | GET | `sapi/v1/nft/history/deposit` |
-| [getNftWithdrawHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3876) | :closed_lock_with_key:  | GET | `sapi/v1/nft/history/withdraw` |
-| [getNftAsset()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3883) | :closed_lock_with_key:  | GET | `sapi/v1/nft/user/getAsset` |
-| [getC2CTradeHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3896) | :closed_lock_with_key:  | GET | `sapi/v1/c2c/orderMatch/listUserOrderHistory` |
-| [getFiatOrderHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3911) | :closed_lock_with_key:  | GET | `sapi/v1/fiat/orders` |
-| [getFiatPaymentsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3917) | :closed_lock_with_key:  | GET | `sapi/v1/fiat/payments` |
-| [fiatWithdraw()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3923) | :closed_lock_with_key:  | POST | `/sapi/v2/fiat/withdraw` |
-| [fiatDeposit()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3927) | :closed_lock_with_key:  | POST | `sapi/v1/fiat/deposit` |
-| [getFiatOrderDetail()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3931) | :closed_lock_with_key:  | GET | `sapi/v1/fiat/get-order-detail` |
-| [getSpotRebateHistoryRecords()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3943) | :closed_lock_with_key:  | GET | `sapi/v1/rebate/taxQuery` |
-| [getPortfolioMarginIndexPrice()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3956) |  | GET | `sapi/v1/portfolio/asset-index-price` |
-| [getPortfolioMarginAssetLeverage()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3962) | :closed_lock_with_key:  | GET | `sapi/v1/portfolio/margin-asset-leverage` |
-| [getPortfolioMarginProCollateralRate()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3968) |  | GET | `sapi/v1/portfolio/collateralRate` |
-| [getPortfolioMarginProTieredCollateralRate()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3974) |  | GET | `sapi/v2/portfolio/collateralRate` |
-| [getPortfolioMarginProAccountInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3985) | :closed_lock_with_key:  | GET | `sapi/v1/portfolio/account` |
-| [setPortfolioMarginMarginCallLevel()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3989) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/margin-call-level` |
-| [getPortfolioMarginMarginCallLevel()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3995) | :closed_lock_with_key:  | GET | `sapi/v1/portfolio/margin-call-level` |
-| [deletePortfolioMarginMarginCallLevel()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3999) | :closed_lock_with_key:  | DELETE | `sapi/v1/portfolio/margin-call-level` |
-| [bnbTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4003) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/bnb-transfer` |
-| [submitPortfolioMarginProFullTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4009) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/auto-collection` |
-| [submitPortfolioMarginProSpecificTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4015) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/asset-collection` |
-| [repayPortfolioMarginProBankruptcyLoan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4021) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/repay` |
-| [getPortfolioMarginProBankruptcyLoanAmount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4029) | :closed_lock_with_key:  | GET | `sapi/v1/portfolio/pmLoan` |
-| [repayFuturesNegativeBalance()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4033) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/repay-futures-negative-balance` |
-| [updateAutoRepayFuturesStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4039) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/repay-futures-switch` |
-| [getAutoRepayFuturesStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4045) | :closed_lock_with_key:  | GET | `sapi/v1/portfolio/repay-futures-switch` |
-| [getPortfolioMarginProInterestHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4051) | :closed_lock_with_key:  | GET | `sapi/v1/portfolio/interest-history` |
-| [getPortfolioMarginProSpanAccountInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4057) | :closed_lock_with_key:  | GET | `sapi/v2/portfolio/account` |
-| [getPortfolioMarginProAccountBalance()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4061) | :closed_lock_with_key:  | GET | `sapi/v1/portfolio/balance` |
-| [mintPortfolioMarginBFUSD()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4071) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/mint` |
-| [redeemPortfolioMarginBFUSD()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4081) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/redeem` |
-| [getPortfolioMarginBankruptcyLoanRepayHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4089) | :closed_lock_with_key:  | GET | `sapi/v1/portfolio/pmLoan-history` |
-| [transferLDUSDTPortfolioMargin()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4104) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/earn-asset-transfer` |
-| [getTransferableEarnAssetBalanceForPortfolioMargin()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4117) | :closed_lock_with_key:  | GET | `sapi/v1/portfolio/earn-asset-balance` |
-| [getFuturesTickLevelOrderbookDataLink()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4134) | :closed_lock_with_key:  | GET | `sapi/v1/futures/histDataLink` |
-| [getBlvtInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4148) |  | GET | `sapi/v1/blvt/tokenInfo` |
-| [subscribeBlvt()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4152) | :closed_lock_with_key:  | POST | `sapi/v1/blvt/subscribe` |
-| [getBlvtSubscriptionRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4156) | :closed_lock_with_key:  | GET | `sapi/v1/blvt/subscribe/record` |
-| [redeemBlvt()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4162) | :closed_lock_with_key:  | POST | `sapi/v1/blvt/redeem` |
-| [getBlvtRedemptionRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4166) | :closed_lock_with_key:  | GET | `sapi/v1/blvt/redeem/record` |
-| [getBlvtUserLimitInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4172) | :closed_lock_with_key:  | GET | `sapi/v1/blvt/userLimit` |
-| [getPayTransactions()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4183) | :closed_lock_with_key:  | GET | `sapi/v1/pay/transactions` |
-| [getInstLoanRiskUnit()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4193) | :closed_lock_with_key:  | GET | `sapi/v1/margin/loan-group/ltv-details` |
-| [closeInstLoanRiskUnit()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4199) | :closed_lock_with_key:  | DELETE | `sapi/v1/margin/loan-group` |
-| [addInstLoanCollateralAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4203) | :closed_lock_with_key:  | POST | `sapi/v1/margin/loan-group/edit-member` |
-| [getActiveInstLoanRiskUnits()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4209) | :closed_lock_with_key:  | GET | `sapi/v1/margin/loan-groups/activated` |
-| [getClosedInstLoanRiskUnits()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4213) | :closed_lock_with_key:  | GET | `sapi/v1/margin/loan-groups/closed` |
-| [getInstLoanForceLiquidationRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4225) | :closed_lock_with_key:  | GET | `sapi/v1/margin/loan-group/force-liquidation` |
-| [transferInstLoanRiskUnit()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4239) | :closed_lock_with_key:  | POST | `sapi/v1/margin/loan-group/transfer-out` |
-| [borrowInstitutionalLoan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4251) | :closed_lock_with_key:  | POST | `sapi/v1/margin/loan-group/borrow` |
-| [getInstLoanInterestHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4257) | :closed_lock_with_key:  | GET | `sapi/v1/margin/loan-group/interest-history` |
-| [repayInstitutionalLoan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4266) | :closed_lock_with_key:  | POST | `sapi/v1/margin/loan-group/repay` |
-| [getInstLoanBorrowRepayRecords()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4272) | :closed_lock_with_key:  | GET | `sapi/v1/margin/loan-group/borrow-repay` |
-| [getMarginInterestRebateBalance()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4278) | :closed_lock_with_key:  | GET | `sapi/v1/margin/loan-group/interest-rebate-balance` |
-| [getMarginInterestRebateBalanceRecords()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4282) | :closed_lock_with_key:  | GET | `sapi/v1/margin/loan-group/interest-rebate-balance/records` |
-| [getAlphaTokenList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4297) |  | GET | `bapi/defi/v1/public/wallet-direct/buw/wallet/cex/alpha/all/token/list` |
-| [getAlphaExchangeInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4304) |  | GET | `bapi/defi/v1/public/alpha-trade/get-exchange-info` |
-| [getAlphaAggTrades()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4311) |  | GET | `bapi/defi/v1/public/alpha-trade/agg-trades` |
-| [getAlphaKlines()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4319) |  | GET | `bapi/defi/v1/public/alpha-trade/klines` |
-| [getAlphaTicker()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4327) |  | GET | `bapi/defi/v1/public/alpha-trade/ticker` |
-| [getAlphaFullDepth()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4335) |  | GET | `bapi/defi/v1/public/alpha-trade/fullDepth` |
-| [createBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4351) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccount` |
-| [getBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4357) | :closed_lock_with_key:  | GET | `sapi/v1/broker/subAccount` |
-| [enableMarginBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4363) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccount/futures` |
-| [createApiKeyBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4369) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccountApi` |
-| [changePermissionApiKeyBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4375) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccountApi/permission` |
-| [changeComissionBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4381) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccountApi/permission` |
-| [enableUniversalTransferApiKeyBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4387) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccountApi/permission/universalTransfer` |
-| [updateIpRestrictionForSubAccountApiKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4396) | :closed_lock_with_key:  | POST | `sapi/v2/broker/subAccountApi/ipRestriction` |
-| [deleteIPRestrictionForSubAccountApiKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4410) | :closed_lock_with_key:  | DELETE | `sapi/v1/broker/subAccountApi/ipRestriction/ipList` |
-| [deleteApiKeyBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4426) | :closed_lock_with_key:  | DELETE | `sapi/v1/broker/subAccountApi` |
-| [getSubAccountBrokerIpRestriction()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4432) | :closed_lock_with_key:  | GET | `sapi/v1/broker/subAccountApi/ipRestriction` |
-| [getApiKeyBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4448) | :closed_lock_with_key:  | GET | `sapi/v1/broker/subAccountApi` |
-| [getBrokerInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4454) | :closed_lock_with_key:  | GET | `sapi/v1/broker/info` |
-| [updateSubAccountBNBBurn()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4458) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccount/bnbBurn/spot` |
-| [updateSubAccountMarginInterestBNBBurn()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4468) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccount/bnbBurn/marginInterest` |
-| [getSubAccountBNBBurnStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4481) | :closed_lock_with_key:  | GET | `sapi/v1/broker/subAccount/bnbBurn/status` |
-| [deleteBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4497) | :closed_lock_with_key:  | DELETE | `/sapi/v1/broker/subAccount` |
-| [transferBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4507) | :closed_lock_with_key:  | POST | `sapi/v1/broker/transfer` |
-| [getBrokerSubAccountHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4513) | :closed_lock_with_key:  | GET | `sapi/v1/broker/transfer` |
-| [submitBrokerSubFuturesTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4519) | :closed_lock_with_key:  | POST | `sapi/v1/broker/transfer/futures` |
-| [getSubAccountFuturesTransferHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4534) | :closed_lock_with_key:  | GET | `sapi/v1/broker/transfer/futures` |
-| [getBrokerSubDepositHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4546) | :closed_lock_with_key:  | GET | `sapi/v1/broker/subAccount/depositHist` |
-| [getBrokerSubAccountSpotAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4552) | :closed_lock_with_key:  | GET | `sapi/v1/broker/subAccount/spotSummary` |
-| [getSubAccountMarginAssetInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4561) | :closed_lock_with_key:  | GET | `sapi/v1/broker/subAccount/marginSummary` |
-| [querySubAccountFuturesAssetInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4570) | :closed_lock_with_key:  | GET | `sapi/v3/broker/subAccount/futuresSummary` |
-| [universalTransferBroker()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4579) | :closed_lock_with_key:  | POST | `sapi/v1/broker/universalTransfer` |
-| [getUniversalTransferBroker()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4586) | :closed_lock_with_key:  | GET | `sapi/v1/broker/universalTransfer` |
-| [updateBrokerSubAccountCommission()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4598) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccountApi/commission` |
-| [updateBrokerSubAccountFuturesCommission()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4604) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccountApi/commission/futures` |
-| [getBrokerSubAccountFuturesCommission()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4613) | :closed_lock_with_key:  | GET | `sapi/v1/broker/subAccountApi/commission/futures` |
-| [updateBrokerSubAccountCoinFuturesCommission()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4622) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccountApi/commission/coinFutures` |
-| [getBrokerSubAccountCoinFuturesCommission()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4631) | :closed_lock_with_key:  | GET | `sapi/v1/broker/subAccountApi/commission/coinFutures` |
-| [getBrokerSpotCommissionRebate()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4640) | :closed_lock_with_key:  | GET | `sapi/v1/broker/rebate/recentRecord` |
-| [getBrokerFuturesCommissionRebate()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4646) | :closed_lock_with_key:  | GET | `sapi/v1/broker/rebate/futures/recentRecord` |
-| [getBrokerIfNewSpotUser()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4683) | :closed_lock_with_key:  | GET | `sapi/v1/apiReferral/ifNewUser` |
-| [getBrokerSubAccountDepositHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4694) | :closed_lock_with_key:  | GET | `sapi/v1/bv1/apiReferral/ifNewUser` |
-| [enableFuturesBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4713) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccount` |
-| [enableMarginApiKeyBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4723) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccount/margin` |
-| [getSpotUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4764) |  | POST | `api/v3/userDataStream` |
-| [keepAliveSpotUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4768) |  | PUT | `api/v3/userDataStream?listenKey=${listenKey}` |
-| [closeSpotUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4772) |  | DELETE | `api/v3/userDataStream?listenKey=${listenKey}` |
-| [getMarginUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4779) |  | POST | `sapi/v1/userDataStream` |
-| [keepAliveMarginUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4783) |  | PUT | `sapi/v1/userDataStream?listenKey=${listenKey}` |
-| [closeMarginUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4787) |  | DELETE | `sapi/v1/userDataStream?listenKey=${listenKey}` |
-| [getIsolatedMarginUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4792) |  | POST | `sapi/v1/userDataStream/isolated?${serialiseParams(params` |
-| [keepAliveIsolatedMarginUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4800) |  | PUT | `sapi/v1/userDataStream/isolated?${serialiseParams(params` |
-| [closeIsolatedMarginUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4809) |  | DELETE | `sapi/v1/userDataStream/isolated?${serialiseParams(params` |
-| [getMarginRiskUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4821) |  | POST | `sapi/v1/margin/listen-key` |
-| [keepAliveMarginRiskUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4825) |  | PUT | `sapi/v1/margin/listen-key?listenKey=${listenKey}` |
-| [closeMarginRiskUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4829) |  | DELETE | `sapi/v1/margin/listen-key` |
-| [getMarginListenToken()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4837) | :closed_lock_with_key:  | POST | `sapi/v1/userListenToken` |
-| [getBSwapLiquidity()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4859) | :closed_lock_with_key:  | GET | `sapi/v1/bswap/liquidity` |
-| [addBSwapLiquidity()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4866) | :closed_lock_with_key:  | POST | `sapi/v1/bswap/liquidityAdd` |
-| [removeBSwapLiquidity()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4875) | :closed_lock_with_key:  | POST | `sapi/v1/bswap/liquidityRemove` |
-| [getBSwapOperations()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4884) | :closed_lock_with_key:  | GET | `sapi/v1/bswap/liquidityOps` |
-| [getLeftDailyPurchaseQuotaFlexibleProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4899) | :closed_lock_with_key:  | GET | `sapi/v1/lending/daily/userLeftQuota` |
-| [getLeftDailyRedemptionQuotaFlexibleProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4908) | :closed_lock_with_key:  | GET | `sapi/v1/lending/daily/userRedemptionQuota` |
-| [purchaseFixedAndActivityProject()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4922) | :closed_lock_with_key:  | POST | `sapi/v1/lending/customizedFixed/purchase` |
-| [getFixedAndActivityProjects()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4932) | :closed_lock_with_key:  | GET | `sapi/v1/lending/project/list` |
-| [getFixedAndActivityProductPosition()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4941) | :closed_lock_with_key:  | GET | `sapi/v1/lending/project/position/list` |
-| [getLendingAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4950) | :closed_lock_with_key:  | GET | `sapi/v1/lending/union/account` |
-| [getPurchaseRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4957) | :closed_lock_with_key:  | GET | `sapi/v1/lending/union/purchaseRecord` |
-| [getRedemptionRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4964) | :closed_lock_with_key:  | GET | `sapi/v1/lending/union/redemptionRecord` |
-| [getInterestHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4971) | :closed_lock_with_key:  | GET | `sapi/v1/lending/union/interestHistory` |
-| [changeFixedAndActivityPositionToDailyPosition()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4978) | :closed_lock_with_key:  | POST | `sapi/v1/lending/positionChanged` |
-| [enableConvertSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4995) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccount/convert` |
-| [convertBUSD()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L5003) | :closed_lock_with_key:  | POST | `sapi/v1/asset/convert-transfer` |
-| [getConvertBUSDHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L5010) | :closed_lock_with_key:  | GET | `sapi/v1/asset/convert-transfer/queryByPage` |
+| [testConnectivity()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L775) |  | GET | `api/v3/ping` |
+| [getExchangeInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L779) |  | GET | `api/v3/exchangeInfo` |
+| [getOrderBook()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L799) |  | GET | `api/v3/depth` |
+| [getRecentTrades()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L803) |  | GET | `api/v3/trades` |
+| [getHistoricalTrades()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L807) |  | GET | `api/v3/historicalTrades` |
+| [getHistoricalBlockTrades()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L811) |  | GET | `api/v3/historicalBlockTrades` |
+| [getAggregateTrades()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L817) |  | GET | `api/v3/aggTrades` |
+| [getKlines()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L823) |  | GET | `api/v3/klines` |
+| [getUIKlines()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L827) |  | GET | `api/v3/uiKlines` |
+| [getAvgPrice()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L831) |  | GET | `api/v3/avgPrice` |
+| [getExecutionRules()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L835) |  | GET | `api/v3/executionRules?symbols=` |
+| [getReferencePrice()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L850) |  | GET | `api/v3/referencePrice` |
+| [getReferencePriceCalculation()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L856) |  | GET | `api/v3/referencePrice/calculation` |
+| [get24hrChangeStatistics()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L863) |  | GET | `api/v3/ticker/24hr?symbols=` |
+| [getTradingDayTicker()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L893) |  | GET | `api/v3/ticker/tradingDay?symbols=` |
+| [getSymbolPriceTicker()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L908) |  | GET | `api/v3/ticker/price?symbols=` |
+| [getSymbolOrderBookTicker()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L925) |  | GET | `api/v3/ticker/bookTicker?symbols=` |
+| [getRollingWindowTicker()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L942) |  | GET | `api/v3/ticker?symbols=` |
+| [submitNewOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L964) | :closed_lock_with_key:  | POST | `api/v3/order` |
+| [testNewOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L972) | :closed_lock_with_key:  | POST | `api/v3/order/test` |
+| [getOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L980) | :closed_lock_with_key:  | GET | `api/v3/order` |
+| [cancelOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L984) | :closed_lock_with_key:  | DELETE | `api/v3/order` |
+| [cancelAllSymbolOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L988) | :closed_lock_with_key:  | DELETE | `api/v3/openOrders` |
+| [replaceOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L994) | :closed_lock_with_key:  | POST | `api/v3/order/cancelReplace` |
+| [amendOrderKeepPriority()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1008) | :closed_lock_with_key:  | PUT | `fapi/v1/order/amend/keepPriority` |
+| [getOpenOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1015) | :closed_lock_with_key:  | GET | `api/v3/openOrders` |
+| [getAllOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1019) | :closed_lock_with_key:  | GET | `api/v3/allOrders` |
+| [submitNewOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1026) | :closed_lock_with_key:  | POST | `api/v3/order/oco` |
+| [submitNewOrderList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1033) | :closed_lock_with_key:  | POST | `api/v3/orderList/oco` |
+| [submitNewOrderListOTO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1042) | :closed_lock_with_key:  | POST | `api/v3/orderList/oto` |
+| [submitNewOrderListOTOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1051) | :closed_lock_with_key:  | POST | `api/v3/orderList/otoco` |
+| [submitNewOrderListOPO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1061) | :closed_lock_with_key:  | POST | `api/v3/orderList/opo` |
+| [submitNewOrderListOPOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1070) | :closed_lock_with_key:  | POST | `api/v3/orderList/opoco` |
+| [cancelOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1080) | :closed_lock_with_key:  | DELETE | `api/v3/orderList` |
+| [getOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1085) | :closed_lock_with_key:  | GET | `api/v3/orderList` |
+| [getAllOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1089) | :closed_lock_with_key:  | GET | `api/v3/allOrderList` |
+| [getAllOpenOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1096) | :closed_lock_with_key:  | GET | `api/v3/openOrderList` |
+| [submitNewSOROrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1103) | :closed_lock_with_key:  | POST | `api/v3/sor/order` |
+| [testNewSOROrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1114) | :closed_lock_with_key:  | POST | `api/v3/sor/order/test` |
+| [getAccountInformation()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1130) | :closed_lock_with_key:  | GET | `api/v3/account` |
+| [getAccountTradeList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1136) | :closed_lock_with_key:  | GET | `api/v3/myTrades` |
+| [getOrderRateLimit()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1142) | :closed_lock_with_key:  | GET | `api/v3/rateLimit/order` |
+| [getPreventedMatches()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1146) | :closed_lock_with_key:  | GET | `api/v3/myPreventedMatches` |
+| [getAllocations()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1152) | :closed_lock_with_key:  | GET | `api/v3/myAllocations` |
+| [getCommissionRates()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1156) | :closed_lock_with_key:  | GET | `api/v3/account/commission` |
+| [getCrossMarginCollateralRatio()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1166) | :closed_lock_with_key:  | GET | `sapi/v1/margin/crossMarginCollateralRatio` |
+| [getAllCrossMarginPairs()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1175) |  | GET | `sapi/v1/margin/allPairs` |
+| [getIsolatedMarginAllSymbols()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1179) | :closed_lock_with_key:  | GET | `sapi/v1/margin/isolated/allPairs` |
+| [getAllMarginAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1185) |  | GET | `sapi/v1/margin/allAssets` |
+| [getMarginDelistSchedule()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1189) | :closed_lock_with_key:  | GET | `sapi/v1/margin/delist-schedule` |
+| [getIsolatedMarginTierData()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1193) | :closed_lock_with_key:  | GET | `sapi/v1/margin/isolatedMarginTier` |
+| [queryMarginPriceIndex()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1199) |  | GET | `sapi/v1/margin/priceIndex` |
+| [getMarginAvailableInventory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1205) | :closed_lock_with_key:  | GET | `sapi/v1/margin/available-inventory` |
+| [getLeverageBracket()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1211) | :closed_lock_with_key:  | GET | `sapi/v1/margin/leverageBracket` |
+| [getNextHourlyInterestRate()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1221) | :closed_lock_with_key:  | GET | `sapi/v1/margin/next-hourly-interest-rate` |
+| [getMarginInterestHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1227) | :closed_lock_with_key:  | GET | `sapi/v1/margin/interestHistory` |
+| [submitMarginAccountBorrowRepay()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1234) | :closed_lock_with_key:  | POST | `sapi/v1/margin/borrow-repay` |
+| [getMarginAccountBorrowRepayRecords()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1240) | :closed_lock_with_key:  | GET | `sapi/v1/margin/borrow-repay` |
+| [getMarginInterestRateHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1246) | :closed_lock_with_key:  | GET | `sapi/v1/margin/interestRateHistory` |
+| [queryMaxBorrow()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1252) | :closed_lock_with_key:  | GET | `sapi/v1/margin/maxBorrowable` |
+| [getMarginForceLiquidationRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1264) | :closed_lock_with_key:  | GET | `sapi/v1/margin/forceLiquidationRec` |
+| [getSmallLiabilityExchangeCoins()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1273) | :closed_lock_with_key:  | GET | `sapi/v1/margin/exchange-small-liability` |
+| [getSmallLiabilityExchangeHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1277) | :closed_lock_with_key:  | GET | `sapi/v1/margin/exchange-small-liability-history` |
+| [marginAccountCancelOpenOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1289) | :closed_lock_with_key:  | DELETE | `sapi/v1/margin/openOrders` |
+| [marginAccountCancelOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1295) | :closed_lock_with_key:  | DELETE | `sapi/v1/margin/orderList` |
+| [marginAccountCancelOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1300) | :closed_lock_with_key:  | DELETE | `sapi/v1/margin/order` |
+| [marginAccountNewOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1306) | :closed_lock_with_key:  | POST | `sapi/v1/margin/order/oco` |
+| [marginAccountNewOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1313) | :closed_lock_with_key:  | POST | `sapi/v1/margin/order` |
+| [getMarginOrderCountUsage()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1321) | :closed_lock_with_key:  | GET | `sapi/v1/margin/rateLimit/order` |
+| [queryMarginAccountAllOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1327) | :closed_lock_with_key:  | GET | `sapi/v1/margin/allOrderList` |
+| [queryMarginAccountAllOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1333) | :closed_lock_with_key:  | GET | `sapi/v1/margin/allOrders` |
+| [queryMarginAccountOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1339) | :closed_lock_with_key:  | GET | `sapi/v1/margin/orderList` |
+| [queryMarginAccountOpenOCO()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1343) | :closed_lock_with_key:  | GET | `sapi/v1/margin/openOrderList` |
+| [queryMarginAccountOpenOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1350) | :closed_lock_with_key:  | GET | `sapi/v1/margin/openOrders` |
+| [queryMarginAccountOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1354) | :closed_lock_with_key:  | GET | `sapi/v1/margin/order` |
+| [queryMarginAccountTradeList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1358) | :closed_lock_with_key:  | GET | `sapi/v1/margin/myTrades` |
+| [submitSmallLiabilityExchange()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1364) | :closed_lock_with_key:  | POST | `sapi/v1/margin/exchange-small-liability` |
+| [submitManualLiquidation()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1371) | :closed_lock_with_key:  | POST | `sapi/v1/margin/manual-liquidation` |
+| [submitMarginOTOOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1380) | :closed_lock_with_key:  | POST | `sapi/v1/margin/order/oto` |
+| [submitMarginOTOCOOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1392) | :closed_lock_with_key:  | POST | `sapi/v1/margin/order/otoco` |
+| [createMarginSpecialLowLatencyKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1405) | :closed_lock_with_key:  | POST | `sapi/v1/margin/apiKey` |
+| [deleteMarginSpecialLowLatencyKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1411) | :closed_lock_with_key:  | DELETE | `sapi/v1/margin/apiKey` |
+| [updateMarginIPForSpecialLowLatencyKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1419) | :closed_lock_with_key:  | PUT | `sapi/v1/margin/apiKey/ip` |
+| [getMarginSpecialLowLatencyKeys()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1430) | :closed_lock_with_key:  | GET | `sapi/v1/margin/api-key-list` |
+| [getMarginSpecialLowLatencyKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1439) | :closed_lock_with_key:  | GET | `sapi/v1/margin/apiKey` |
+| [getMarginLiquidationLoan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1449) | :closed_lock_with_key:  | GET | `sapi/v1/margin/liquidation-loan` |
+| [repayMarginLiquidationLoan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1456) | :closed_lock_with_key:  | POST | `sapi/v1/margin/liquidation-loan/repay` |
+| [getMarginLiquidationLoanRepayHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1465) | :closed_lock_with_key:  | GET | `sapi/v1/margin/liquidation-loan/repay-history` |
+| [exitMarginSpecialKeyMode()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1477) | :closed_lock_with_key:  | POST | `sapi/v1/margin/exit-special-key-mode` |
+| [getCrossMarginTransferHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1487) | :closed_lock_with_key:  | GET | `sapi/v1/margin/transfer` |
+| [queryMaxTransferOutAmount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1493) | :closed_lock_with_key:  | GET | `sapi/v1/margin/maxTransferable` |
+| [updateCrossMarginMaxLeverage()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1505) | :closed_lock_with_key:  | POST | `sapi/v1/margin/max-leverage` |
+| [disableIsolatedMarginAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1511) | :closed_lock_with_key:  | DELETE | `sapi/v1/margin/isolated/account` |
+| [enableIsolatedMarginAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1518) | :closed_lock_with_key:  | POST | `sapi/v1/margin/isolated/account` |
+| [getBNBBurn()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1525) | :closed_lock_with_key:  | GET | `sapi/v1/bnbBurn` |
+| [getMarginSummary()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1529) | :closed_lock_with_key:  | GET | `sapi/v1/margin/tradeCoeff` |
+| [queryCrossMarginAccountDetails()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1533) | :closed_lock_with_key:  | GET | `sapi/v1/margin/account` |
+| [getCrossMarginFeeData()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1537) | :closed_lock_with_key:  | GET | `sapi/v1/margin/crossMarginData` |
+| [getIsolatedMarginAccountLimit()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1543) | :closed_lock_with_key:  | GET | `sapi/v1/margin/isolated/accountLimit` |
+| [getIsolatedMarginAccountInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1550) | :closed_lock_with_key:  | GET | `sapi/v1/margin/isolated/account` |
+| [getIsolatedMarginFeeData()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1556) | :closed_lock_with_key:  | GET | `sapi/v1/margin/isolatedMarginData` |
+| [toggleBNBBurn()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1562) | :closed_lock_with_key:  | POST | `sapi/v1/bnbBurn` |
+| [getMarginCapitalFlow()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1570) | :closed_lock_with_key:  | GET | `sapi/v1/margin/capital-flow` |
+| [queryLoanRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1579) | :closed_lock_with_key:  | GET | `sapi/v1/margin/loan` |
+| [queryRepayRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1588) | :closed_lock_with_key:  | GET | `sapi/v1/margin/repay` |
+| [isolatedMarginAccountTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1597) | :closed_lock_with_key:  | POST | `sapi/v1/margin/isolated/transfer` |
+| [getBalances()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1609) | :closed_lock_with_key:  | GET | `sapi/v1/capital/config/getall` |
+| [withdraw()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1613) | :closed_lock_with_key:  | POST | `sapi/v1/capital/withdraw/apply` |
+| [getWithdrawHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1617) | :closed_lock_with_key:  | GET | `sapi/v1/capital/withdraw/history` |
+| [getWithdrawAddresses()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1623) | :closed_lock_with_key:  | GET | `sapi/v1/capital/withdraw/address/list` |
+| [getWithdrawQuota()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1627) | :closed_lock_with_key:  | GET | `sapi/v1/capital/withdraw/quota` |
+| [getDepositHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1634) | :closed_lock_with_key:  | GET | `sapi/v1/capital/deposit/hisrec` |
+| [getDepositAddress()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1638) | :closed_lock_with_key:  | GET | `sapi/v1/capital/deposit/address` |
+| [getDepositAddresses()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1644) | :closed_lock_with_key:  | GET | `sapi/v1/capital/deposit/address/list` |
+| [submitDepositCredit()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1650) | :closed_lock_with_key:  | POST | `sapi/v1/capital/deposit/credit-apply` |
+| [getAutoConvertStablecoins()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1659) | :closed_lock_with_key:  | GET | `sapi/v1/capital/contract/convertible-coins` |
+| [setConvertibleCoins()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1666) | :closed_lock_with_key:  | POST | `sapi/v1/capital/contract/convertible-coins` |
+| [getAssetDetail()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1679) | :closed_lock_with_key:  | GET | `sapi/v1/asset/assetDetail` |
+| [getWalletBalances()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1685) | :closed_lock_with_key:  | GET | `sapi/v1/asset/wallet/balance` |
+| [getUserAsset()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1691) | :closed_lock_with_key:  | POST | `sapi/v3/asset/getUserAsset` |
+| [submitUniversalTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1695) | :closed_lock_with_key:  | POST | `sapi/v1/asset/transfer` |
+| [getUniversalTransferHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1701) | :closed_lock_with_key:  | GET | `sapi/v1/asset/transfer` |
+| [getDust()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1707) | :closed_lock_with_key:  | POST | `sapi/v1/asset/dust-btc` |
+| [convertDustToBnb()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1711) | :closed_lock_with_key:  | POST | `sapi/v1/asset/dust` |
+| [convertDustAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1718) | :closed_lock_with_key:  | POST | `sapi/v1/asset/dust-convert/convert` |
+| [queryDustConvertibleAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1725) | :closed_lock_with_key:  | POST | `sapi/v1/asset/dust-convert/query-convertible-assets` |
+| [getDustLog()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1734) | :closed_lock_with_key:  | GET | `sapi/v1/asset/dribblet` |
+| [getAssetDividendRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1738) | :closed_lock_with_key:  | GET | `sapi/v1/asset/assetDividend` |
+| [getTradeFee()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1742) | :closed_lock_with_key:  | GET | `sapi/v1/asset/tradeFee` |
+| [getFundingAsset()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1746) | :closed_lock_with_key:  | POST | `sapi/v1/asset/get-funding-asset` |
+| [getCloudMiningHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1750) | :closed_lock_with_key:  | GET | `sapi/v1/asset/ledger-transfer/cloud-mining/queryByPage` |
+| [getDelegationHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1760) | :closed_lock_with_key:  | GET | `sapi/v1/asset/custody/transfer-history` |
+| [submitNewFutureAccountTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1790) | :closed_lock_with_key:  | POST | `sapi/v1/futures/transfer` |
+| [getFutureAccountTransferHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1800) | :closed_lock_with_key:  | GET | `sapi/v1/futures/transfer` |
+| [getCrossCollateralBorrowHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1809) | :closed_lock_with_key:  | GET | `sapi/v1/futures/loan/borrow/history` |
+| [getCrossCollateralRepaymentHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1816) | :closed_lock_with_key:  | GET | `sapi/v1/futures/loan/repay/history` |
+| [getCrossCollateralWalletV2()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1823) | :closed_lock_with_key:  | GET | `sapi/v2/futures/loan/wallet` |
+| [getAdjustCrossCollateralLTVHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1830) | :closed_lock_with_key:  | GET | `sapi/v1/futures/loan/adjustCollateral/history` |
+| [getCrossCollateralLiquidationHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1842) | :closed_lock_with_key:  | GET | `sapi/v1/futures/loan/liquidationHistory` |
+| [getCrossCollateralInterestHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1851) | :closed_lock_with_key:  | GET | `sapi/v1/futures/loan/interestHistory` |
+| [getAccountInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1863) | :closed_lock_with_key:  | GET | `sapi/v1/account/info` |
+| [getDailyAccountSnapshot()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1867) | :closed_lock_with_key:  | GET | `sapi/v1/accountSnapshot` |
+| [disableFastWithdrawSwitch()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1873) | :closed_lock_with_key:  | POST | `sapi/v1/account/disableFastWithdrawSwitch` |
+| [enableFastWithdrawSwitch()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1877) | :closed_lock_with_key:  | POST | `sapi/v1/account/enableFastWithdrawSwitch` |
+| [getAccountStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1881) | :closed_lock_with_key:  | GET | `sapi/v1/account/status` |
+| [getApiTradingStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1885) | :closed_lock_with_key:  | GET | `sapi/v1/account/apiTradingStatus` |
+| [getApiKeyPermissions()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1889) | :closed_lock_with_key:  | GET | `sapi/v1/account/apiRestrictions` |
+| [withdrawTravelRule()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1905) | :closed_lock_with_key:  | POST | `sapi/v1/localentity/withdraw/apply` |
+| [getTravelRuleWithdrawHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1916) | :closed_lock_with_key:  | GET | `sapi/v1/localentity/withdraw/history` |
+| [getTravelRuleWithdrawHistoryV2()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1925) | :closed_lock_with_key:  | GET | `sapi/v2/localentity/withdraw/history` |
+| [submitTravelRuleDepositQuestionnaire()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1937) | :closed_lock_with_key:  | PUT | `sapi/v1/localentity/deposit/provide-info` |
+| [getTravelRuleDepositHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1946) | :closed_lock_with_key:  | GET | `sapi/v1/localentity/deposit/history` |
+| [getOnboardedVASPList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1957) | :closed_lock_with_key:  | GET | `sapi/v1/localentity/vasp` |
+| [getSystemStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1967) |  | GET | `sapi/v1/system/status` |
+| [getDelistSchedule()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1971) | :closed_lock_with_key:  | GET | `sapi/v1/spot/delist-schedule` |
+| [createVirtualSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1981) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/virtualSubAccount` |
+| [getSubAccountList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1987) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/list` |
+| [subAccountEnableFutures()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L1993) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/futures/enable` |
+| [subAccountEnableMargin()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2001) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/margin/enable` |
+| [enableOptionsForSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2005) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/eoptions/enable` |
+| [subAccountEnableLeverageToken()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2015) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/blvt/enable` |
+| [getSubAccountStatusOnMarginOrFutures()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2021) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/status` |
+| [getSubAccountFuturesPositionRisk()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2027) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/futures/positionRisk` |
+| [getSubAccountFuturesPositionRiskV2()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2035) | :closed_lock_with_key:  | GET | `sapi/v2/sub-account/futures/positionRisk` |
+| [getSubAccountTransactionStatistics()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2041) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/transaction-statistics` |
+| [getSubAccountIPRestriction()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2056) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/subAccountApi/ipRestriction` |
+| [subAccountDeleteIPList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2065) | :closed_lock_with_key:  | DELETE | `sapi/v1/sub-account/subAccountApi/ipRestriction/ipList` |
+| [subAccountAddIPRestriction()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2074) | :closed_lock_with_key:  | POST | `sapi/v2/sub-account/subAccountApi/ipRestriction` |
+| [subAccountAddIPList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2087) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/subAccountApi/ipRestriction/ipList` |
+| [subAccountEnableOrDisableIPRestriction()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2100) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/subAccountApi/ipRestriction` |
+| [subAccountFuturesTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2115) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/futures/transfer` |
+| [getSubAccountFuturesAccountDetail()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2121) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/futures/account` |
+| [getSubAccountDetailOnFuturesAccountV2()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2127) | :closed_lock_with_key:  | GET | `sapi/v2/sub-account/futures/account` |
+| [getSubAccountDetailOnMarginAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2133) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/margin/account` |
+| [getSubAccountDepositAddress()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2139) | :closed_lock_with_key:  | GET | `sapi/v1/capital/deposit/subAddress` |
+| [getSubAccountDepositHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2145) | :closed_lock_with_key:  | GET | `sapi/v1/capital/deposit/subHisrec` |
+| [getSubAccountFuturesAccountSummary()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2151) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/futures/accountSummary` |
+| [getSubAccountSummaryOnFuturesAccountV2()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2155) | :closed_lock_with_key:  | GET | `sapi/v2/sub-account/futures/accountSummary` |
+| [getSubAccountsSummaryOfMarginAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2164) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/margin/accountSummary` |
+| [subAccountMarginTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2168) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/margin/transfer` |
+| [getSubAccountAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2174) | :closed_lock_with_key:  | GET | `sapi/v3/sub-account/assets` |
+| [getSubAccountAssetsMaster()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2180) | :closed_lock_with_key:  | GET | `sapi/v4/sub-account/assets` |
+| [getSubAccountFuturesAssetTransferHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2186) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/futures/internalTransfer` |
+| [getSubAccountSpotAssetTransferHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2195) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/sub/transfer/history` |
+| [getSubAccountSpotAssetsSummary()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2201) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/spotSummary` |
+| [getSubAccountUniversalTransferHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2207) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/universalTransfer` |
+| [subAccountFuturesAssetTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2213) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/futures/internalTransfer` |
+| [subAccountTransferHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2222) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/transfer/subUserHistory` |
+| [subAccountTransferToMaster()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2231) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/transfer/subToMaster` |
+| [subAccountTransferToSameMaster()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2237) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/transfer/subToSub` |
+| [subAccountUniversalTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2243) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/universalTransfer` |
+| [subAccountMovePosition()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2249) | :closed_lock_with_key:  | POST | `sapi/v1/sub-account/futures/move-position` |
+| [getSubAccountFuturesPositionMoveHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2258) | :closed_lock_with_key:  | GET | `sapi/v1/sub-account/futures/move-position` |
+| [depositAssetsIntoManagedSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2273) | :closed_lock_with_key:  | POST | `sapi/v1/managed-subaccount/deposit` |
+| [getManagedSubAccountDepositAddress()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2279) | :closed_lock_with_key:  | GET | `sapi/v1/managed-subaccount/deposit/address` |
+| [withdrawAssetsFromManagedSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2288) | :closed_lock_with_key:  | POST | `sapi/v1/managed-subaccount/withdraw` |
+| [getManagedSubAccountTransfersParent()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2294) | :closed_lock_with_key:  | GET | `sapi/v1/managed-subaccount/queryTransLogForTradeParent` |
+| [getManagedSubAccountTransferLog()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2306) | :closed_lock_with_key:  | GET | `sapi/v1/managed-subaccount/query-trans-log` |
+| [getManagedSubAccountTransfersInvestor()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2318) | :closed_lock_with_key:  | GET | `sapi/v1/managed-subaccount/queryTransLogForInvestor` |
+| [getManagedSubAccounts()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2330) | :closed_lock_with_key:  | GET | `sapi/v1/managed-subaccount/info` |
+| [getManagedSubAccountSnapshot()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2337) | :closed_lock_with_key:  | GET | `sapi/v1/managed-subaccount/accountSnapshot` |
+| [getManagedSubAccountAssetDetails()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2346) | :closed_lock_with_key:  | GET | `sapi/v1/managed-subaccount/asset` |
+| [getManagedSubAccountMarginAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2352) | :closed_lock_with_key:  | GET | `sapi/v1/managed-subaccount/marginAsset` |
+| [getManagedSubAccountFuturesAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2359) | :closed_lock_with_key:  | GET | `sapi/v1/managed-subaccount/fetch-future-asset` |
+| [getAutoInvestAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2375) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/all/asset` |
+| [getAutoInvestSourceAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2382) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/source-asset/list` |
+| [getAutoInvestTargetAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2391) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/target-asset/list` |
+| [getAutoInvestTargetAssetsROI()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2400) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/target-asset/roi/list` |
+| [getAutoInvestIndex()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2409) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/index/info` |
+| [getAutoInvestPlans()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2415) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/plan/list` |
+| [submitAutoInvestOneTimeTransaction()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2433) | :closed_lock_with_key:  | POST | `sapi/v1/lending/auto-invest/one-off` |
+| [updateAutoInvestPlanStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2449) | :closed_lock_with_key:  | POST | `sapi/v1/lending/auto-invest/plan/edit-status` |
+| [updateAutoInvestmentPlan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2458) | :closed_lock_with_key:  | POST | `sapi/v1/lending/auto-invest/plan/edit` |
+| [submitAutoInvestRedemption()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2475) | :closed_lock_with_key:  | POST | `sapi/v1/lending/auto-invest/redeem` |
+| [getAutoInvestSubscriptionTransactions()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2483) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/history/list` |
+| [getOneTimeTransactionStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2489) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/one-off/status` |
+| [submitAutoInvestmentPlan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2498) | :closed_lock_with_key:  | POST | `sapi/v1/lending/auto-invest/plan/add` |
+| [getAutoInvestRedemptionHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2513) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/redeem/history` |
+| [getAutoInvestPlan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2522) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/plan/id` |
+| [getAutoInvestUserIndex()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2526) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/index/user-summary` |
+| [getAutoInvestRebalanceHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2535) | :closed_lock_with_key:  | GET | `sapi/v1/lending/auto-invest/rebalance/history` |
+| [getConvertPairs()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2550) | :closed_lock_with_key:  | GET | `sapi/v1/convert/exchangeInfo` |
+| [getConvertAssetInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2554) | :closed_lock_with_key:  | GET | `sapi/v1/convert/assetInfo` |
+| [convertQuoteRequest()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2564) | :closed_lock_with_key:  | POST | `sapi/v1/convert/getQuote` |
+| [acceptQuoteRequest()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2568) | :closed_lock_with_key:  | POST | `sapi/v1/convert/acceptQuote` |
+| [getConvertTradeHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2572) | :closed_lock_with_key:  | GET | `sapi/v1/convert/tradeFlow` |
+| [getOrderStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2576) | :closed_lock_with_key:  | GET | `sapi/v1/convert/orderStatus` |
+| [submitConvertLimitOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2580) | :closed_lock_with_key:  | POST | `sapi/v1/convert/limit/placeOrder` |
+| [cancelConvertLimitOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2584) | :closed_lock_with_key:  | POST | `sapi/v1/convert/limit/cancelOrder` |
+| [getConvertLimitOpenOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2588) | :closed_lock_with_key:  | GET | `sapi/v1/convert/limit/queryOpenOrders` |
+| [getEthStakingAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2603) | :closed_lock_with_key:  | GET | `sapi/v1/eth-staking/account` |
+| [getEthStakingAccountV2()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2607) | :closed_lock_with_key:  | GET | `sapi/v2/eth-staking/account` |
+| [getEthStakingQuota()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2611) | :closed_lock_with_key:  | GET | `sapi/v1/eth-staking/eth/quota` |
+| [subscribeEthStakingV1()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2624) | :closed_lock_with_key:  | POST | `sapi/v1/eth-staking/eth/stake` |
+| [subscribeEthStakingV2()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2630) | :closed_lock_with_key:  | POST | `sapi/v2/eth-staking/eth/stake` |
+| [redeemEth()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2636) | :closed_lock_with_key:  | POST | `sapi/v1/eth-staking/eth/redeem` |
+| [wrapBeth()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2640) | :closed_lock_with_key:  | POST | `sapi/v1/eth-staking/wbeth/wrap` |
+| [getEthStakingHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2650) | :closed_lock_with_key:  | GET | `sapi/v1/eth-staking/eth/history/stakingHistory` |
+| [getEthRedemptionHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2660) | :closed_lock_with_key:  | GET | `sapi/v1/eth-staking/eth/history/redemptionHistory` |
+| [getBethRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2670) | :closed_lock_with_key:  | GET | `sapi/v1/eth-staking/eth/history/rewardsHistory` |
+| [getWbethRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2680) | :closed_lock_with_key:  | GET | `sapi/v1/eth-staking/eth/history/wbethRewardsHistory` |
+| [getEthRateHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2689) | :closed_lock_with_key:  | GET | `sapi/v1/eth-staking/eth/history/rateHistory` |
+| [getBethWrapHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2699) | :closed_lock_with_key:  | GET | `sapi/v1/eth-staking/wbeth/history/wrapHistory` |
+| [getBethUnwrapHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2709) | :closed_lock_with_key:  | GET | `sapi/v1/eth-staking/wbeth/history/unwrapHistory` |
+| [getBfusdAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2725) | :closed_lock_with_key:  | GET | `sapi/v1/bfusd/account` |
+| [getBfusdQuota()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2729) | :closed_lock_with_key:  | GET | `sapi/v1/bfusd/quota` |
+| [subscribeBfusd()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2733) | :closed_lock_with_key:  | POST | `sapi/v1/bfusd/subscribe` |
+| [redeemBfusd()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2739) | :closed_lock_with_key:  | POST | `sapi/v1/bfusd/redeem` |
+| [getBfusdSubscriptionHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2743) | :closed_lock_with_key:  | GET | `sapi/v1/bfusd/history/subscriptionHistory` |
+| [getBfusdRedemptionHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2749) | :closed_lock_with_key:  | GET | `sapi/v1/bfusd/history/redemptionHistory` |
+| [getBfusdRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2755) | :closed_lock_with_key:  | GET | `sapi/v1/bfusd/history/rewardsHistory` |
+| [getBfusdRateHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2761) | :closed_lock_with_key:  | GET | `sapi/v1/bfusd/history/rateHistory` |
+| [getRwusdAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2773) | :closed_lock_with_key:  | GET | `sapi/v1/rwusd/account` |
+| [getRwusdQuota()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2777) | :closed_lock_with_key:  | GET | `sapi/v1/rwusd/quota` |
+| [subscribeRwusd()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2781) | :closed_lock_with_key:  | POST | `sapi/v1/rwusd/subscribe` |
+| [redeemRwusd()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2787) | :closed_lock_with_key:  | POST | `sapi/v1/rwusd/redeem` |
+| [getRwusdSubscriptionHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2791) | :closed_lock_with_key:  | GET | `sapi/v1/rwusd/history/subscriptionHistory` |
+| [getRwusdRedemptionHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2797) | :closed_lock_with_key:  | GET | `sapi/v1/rwusd/history/redemptionHistory` |
+| [getRwusdRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2803) | :closed_lock_with_key:  | GET | `sapi/v1/rwusd/history/rewardsHistory` |
+| [getRwusdRateHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2809) | :closed_lock_with_key:  | GET | `sapi/v1/rwusd/history/rateHistory` |
+| [getStakingProducts()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2818) | :closed_lock_with_key:  | GET | `sapi/v1/staking/productList` |
+| [getStakingProductPosition()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2829) | :closed_lock_with_key:  | GET | `sapi/v1/staking/position` |
+| [getStakingHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2841) | :closed_lock_with_key:  | GET | `sapi/v1/staking/stakingRecord` |
+| [getPersonalLeftQuotaOfStakingProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2848) | :closed_lock_with_key:  | GET | `sapi/v1/staking/personalLeftQuota` |
+| [getSolStakingAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2861) | :closed_lock_with_key:  | GET | `sapi/v1/sol-staking/account` |
+| [getSolStakingQuota()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2865) | :closed_lock_with_key:  | GET | `sapi/v1/sol-staking/sol/quota` |
+| [subscribeSolStaking()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2875) | :closed_lock_with_key:  | POST | `sapi/v1/sol-staking/sol/stake` |
+| [redeemSol()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2881) | :closed_lock_with_key:  | POST | `sapi/v1/sol-staking/sol/redeem` |
+| [claimSolBoostRewards()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2885) | :closed_lock_with_key:  | POST | `sapi/v1/sol-staking/sol/claim` |
+| [getSolStakingHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2897) | :closed_lock_with_key:  | GET | `sapi/v1/sol-staking/sol/history/stakingHistory` |
+| [getSolRedemptionHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2907) | :closed_lock_with_key:  | GET | `sapi/v1/sol-staking/sol/history/redemptionHistory` |
+| [getBnsolRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2917) | :closed_lock_with_key:  | GET | `sapi/v1/sol-staking/sol/history/bnsolRewardsHistory` |
+| [getBnsolRateHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2928) | :closed_lock_with_key:  | GET | `sapi/v1/sol-staking/sol/history/rateHistory` |
+| [getSolBoostRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2938) | :closed_lock_with_key:  | GET | `sapi/v1/sol-staking/sol/history/boostRewardsHistory` |
+| [getSolUnclaimedRewards()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2948) | :closed_lock_with_key:  | GET | `sapi/v1/sol-staking/sol/history/unclaimedRewards` |
+| [getOnchainYieldsLockedProducts()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2963) | :closed_lock_with_key:  | GET | `sapi/v1/onchain-yields/locked/list` |
+| [getOnchainYieldsLockedPersonalLeftQuota()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2969) | :closed_lock_with_key:  | GET | `sapi/v1/onchain-yields/locked/personalLeftQuota` |
+| [getOnchainYieldsLockedPosition()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2978) | :closed_lock_with_key:  | GET | `sapi/v1/onchain-yields/locked/position` |
+| [getOnchainYieldsAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2984) | :closed_lock_with_key:  | GET | `sapi/v1/onchain-yields/account` |
+| [getOnchainYieldsLockedSubscriptionPreview()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L2994) | :closed_lock_with_key:  | GET | `sapi/v1/onchain-yields/locked/subscriptionPreview` |
+| [subscribeOnchainYieldsLockedProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3003) | :closed_lock_with_key:  | POST | `sapi/v1/onchain-yields/locked/subscribe` |
+| [setOnchainYieldsLockedAutoSubscribe()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3009) | :closed_lock_with_key:  | POST | `sapi/v1/onchain-yields/locked/setAutoSubscribe` |
+| [setOnchainYieldsLockedRedeemOption()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3018) | :closed_lock_with_key:  | POST | `sapi/v1/onchain-yields/locked/setRedeemOption` |
+| [redeemOnchainYieldsLockedProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3027) | :closed_lock_with_key:  | POST | `sapi/v1/onchain-yields/locked/redeem` |
+| [getOnchainYieldsLockedSubscriptionRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3039) | :closed_lock_with_key:  | GET | `sapi/v1/onchain-yields/locked/history/subscriptionRecord` |
+| [getOnchainYieldsLockedRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3048) | :closed_lock_with_key:  | GET | `sapi/v1/onchain-yields/locked/history/rewardsRecord` |
+| [getOnchainYieldsLockedRedemptionRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3057) | :closed_lock_with_key:  | GET | `sapi/v1/onchain-yields/locked/history/redemptionRecord` |
+| [getSoftStakingProductList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3072) | :closed_lock_with_key:  | GET | `sapi/v1/soft-staking/list` |
+| [setSoftStaking()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3078) | :closed_lock_with_key:  | GET | `sapi/v1/soft-staking/set` |
+| [getSoftStakingRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3084) | :closed_lock_with_key:  | GET | `sapi/v1/soft-staking/history/rewardsRecord` |
+| [getFuturesLeadTraderStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3099) | :closed_lock_with_key:  | GET | `sapi/v1/copyTrading/futures/userStatus` |
+| [getFuturesLeadTradingSymbolWhitelist()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3103) | :closed_lock_with_key:  | GET | `sapi/v1/copyTrading/futures/leadSymbol` |
+| [getMiningAlgos()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3115) |  | GET | `sapi/v1/mining/pub/algoList` |
+| [getMiningCoins()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3119) |  | GET | `sapi/v1/mining/pub/coinList` |
+| [getHashrateResales()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3123) | :closed_lock_with_key:  | GET | `sapi/v1/mining/hash-transfer/config/details/list` |
+| [getMiners()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3132) | :closed_lock_with_key:  | GET | `sapi/v1/mining/worker/list` |
+| [getMinerDetails()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3136) | :closed_lock_with_key:  | GET | `sapi/v1/mining/worker/detail` |
+| [getExtraBonuses()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3142) | :closed_lock_with_key:  | GET | `sapi/v1/mining/payment/other` |
+| [getMiningEarnings()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3148) | :closed_lock_with_key:  | GET | `sapi/v1/mining/payment/list` |
+| [cancelHashrateResaleConfig()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3154) | :closed_lock_with_key:  | POST | `sapi/v1/mining/hash-transfer/config/cancel` |
+| [getHashrateResale()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3163) | :closed_lock_with_key:  | GET | `sapi/v1/mining/hash-transfer/profit/details` |
+| [getMiningAccountEarnings()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3172) | :closed_lock_with_key:  | GET | `sapi/v1/mining/payment/uid` |
+| [getMiningStatistics()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3178) | :closed_lock_with_key:  | GET | `sapi/v1/mining/statistics/user/status` |
+| [submitHashrateResale()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3184) | :closed_lock_with_key:  | POST | `sapi/v1/mining/hash-transfer/config` |
+| [getMiningAccounts()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3188) | :closed_lock_with_key:  | GET | `sapi/v1/mining/statistics/user/list` |
+| [submitVpNewOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3200) | :closed_lock_with_key:  | POST | `sapi/v1/algo/futures/newOrderVp` |
+| [submitTwapNewOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3207) | :closed_lock_with_key:  | POST | `sapi/v1/algo/futures/newOrderTwap` |
+| [cancelAlgoOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3214) | :closed_lock_with_key:  | DELETE | `sapi/v1/algo/futures/order` |
+| [getAlgoSubOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3220) | :closed_lock_with_key:  | GET | `sapi/v1/algo/futures/subOrders` |
+| [getAlgoOpenOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3226) | :closed_lock_with_key:  | GET | `sapi/v1/algo/futures/openOrders` |
+| [getAlgoHistoricalOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3233) | :closed_lock_with_key:  | GET | `sapi/v1/algo/futures/historicalOrders` |
+| [submitSpotAlgoTwapOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3246) | :closed_lock_with_key:  | POST | `sapi/v1/algo/spot/newOrderTwap` |
+| [cancelSpotAlgoOrder()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3253) | :closed_lock_with_key:  | DELETE | `sapi/v1/algo/spot/order` |
+| [getSpotAlgoSubOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3259) | :closed_lock_with_key:  | GET | `sapi/v1/algo/spot/subOrders` |
+| [getSpotAlgoOpenOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3265) | :closed_lock_with_key:  | GET | `sapi/v1/algo/spot/openOrders` |
+| [getSpotAlgoHistoricalOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3272) | :closed_lock_with_key:  | GET | `sapi/v1/algo/spot/historicalOrders` |
+| [getCryptoLoanFlexibleCollateralAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3287) | :closed_lock_with_key:  | GET | `sapi/v2/loan/flexible/collateral/data` |
+| [getCryptoLoanFlexibleAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3296) | :closed_lock_with_key:  | GET | `sapi/v2/loan/flexible/loanable/data` |
+| [borrowCryptoLoanFlexible()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3309) | :closed_lock_with_key:  | POST | `sapi/v2/loan/flexible/borrow` |
+| [repayCryptoLoanFlexible()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3315) | :closed_lock_with_key:  | POST | `sapi/v2/loan/flexible/repay` |
+| [repayCryptoLoanFlexibleWithCollateral()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3321) | :closed_lock_with_key:  | POST | `sapi/v2/loan/flexible/repay/collateral` |
+| [adjustCryptoLoanFlexibleLTV()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3327) | :closed_lock_with_key:  | POST | `sapi/v2/loan/flexible/adjust/ltv` |
+| [getCryptoLoanFlexibleLTVAdjustmentHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3339) | :closed_lock_with_key:  | GET | `sapi/v2/loan/flexible/ltv/adjustment/history` |
+| [getFlexibleLoanCollateralRepayRate()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3351) | :closed_lock_with_key:  | GET | `sapi/v2/loan/flexible/repay/rate` |
+| [getLoanFlexibleBorrowHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3362) | :closed_lock_with_key:  | GET | `sapi/v2/loan/flexible/borrow/history` |
+| [getCryptoLoanFlexibleOngoingOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3371) | :closed_lock_with_key:  | GET | `sapi/v2/loan/flexible/ongoing/orders` |
+| [getFlexibleLoanLiquidationHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3380) | :closed_lock_with_key:  | GET | `sapi/v2/loan/flexible/liquidation/history` |
+| [getLoanFlexibleRepaymentHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3389) | :closed_lock_with_key:  | GET | `sapi/v2/loan/flexible/repay/history` |
+| [getCryptoLoanLoanableAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3407) | :closed_lock_with_key:  | GET | `sapi/v1/loan/loanable/data` |
+| [getCryptoLoanCollateralRepayRate()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3414) | :closed_lock_with_key:  | GET | `sapi/v1/loan/repay/collateral/rate` |
+| [getCryptoLoanCollateralAssetsData()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3423) | :closed_lock_with_key:  | GET | `sapi/v1/loan/collateral/data` |
+| [getCryptoLoansIncomeHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3432) | :closed_lock_with_key:  | GET | `sapi/v1/loan/income` |
+| [borrowCryptoLoan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3447) | :closed_lock_with_key:  | POST | `sapi/v1/loan/borrow` |
+| [repayCryptoLoan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3456) | :closed_lock_with_key:  | POST | `sapi/v1/loan/repay` |
+| [adjustCryptoLoanLTV()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3465) | :closed_lock_with_key:  | POST | `sapi/v1/loan/adjust/ltv` |
+| [customizeCryptoLoanMarginCall()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3474) | :closed_lock_with_key:  | POST | `sapi/v1/loan/customize/margin_call` |
+| [getCryptoLoanOngoingOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3490) | :closed_lock_with_key:  | GET | `sapi/v1/loan/ongoing/orders` |
+| [getCryptoLoanBorrowHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3497) | :closed_lock_with_key:  | GET | `sapi/v1/loan/borrow/history` |
+| [getCryptoLoanLTVAdjustmentHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3504) | :closed_lock_with_key:  | GET | `sapi/v1/loan/ltv/adjustment/history` |
+| [getCryptoLoanRepaymentHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3513) | :closed_lock_with_key:  | GET | `sapi/v1/loan/repay/history` |
+| [getSimpleEarnAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3525) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/account` |
+| [getFlexibleSavingProducts()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3529) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/flexible/list` |
+| [getSimpleEarnLockedProductList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3536) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/locked/list` |
+| [getFlexibleProductPosition()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3545) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/flexible/position` |
+| [getLockedProductPosition()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3554) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/locked/position` |
+| [getFlexiblePersonalLeftQuota()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3563) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/flexible/personalLeftQuota` |
+| [getLockedPersonalLeftQuota()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3572) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/locked/personalLeftQuota` |
+| [purchaseFlexibleProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3587) | :closed_lock_with_key:  | POST | `sapi/v1/simple-earn/flexible/subscribe` |
+| [subscribeSimpleEarnLockedProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3593) | :closed_lock_with_key:  | POST | `sapi/v1/simple-earn/locked/subscribe` |
+| [redeemFlexibleProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3599) | :closed_lock_with_key:  | POST | `sapi/v1/simple-earn/flexible/redeem` |
+| [redeemLockedProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3605) | :closed_lock_with_key:  | POST | `sapi/v1/simple-earn/locked/redeem` |
+| [setFlexibleAutoSubscribe()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3611) | :closed_lock_with_key:  | POST | `sapi/v1/simple-earn/flexible/setAutoSubscribe` |
+| [setLockedAutoSubscribe()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3620) | :closed_lock_with_key:  | POST | `sapi/v1/simple-earn/locked/setAutoSubscribe` |
+| [getFlexibleSubscriptionPreview()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3629) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/flexible/subscriptionPreview` |
+| [getLockedSubscriptionPreview()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3638) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/locked/subscriptionPreview` |
+| [setLockedProductRedeemOption()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3647) | :closed_lock_with_key:  | POST | `sapi/v1/simple-earn/locked/setRedeemOption` |
+| [getFlexibleSubscriptionRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3665) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/flexible/history/subscriptionRecord` |
+| [getLockedSubscriptionRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3677) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/locked/history/subscriptionRecord` |
+| [getFlexibleRedemptionRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3689) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/flexible/history/redemptionRecord` |
+| [getLockedRedemptionRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3701) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/locked/history/redemptionRecord` |
+| [getFlexibleRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3711) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/flexible/history/rewardsRecord` |
+| [getLockedRewardsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3721) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/locked/history/rewardsRecord` |
+| [getCollateralRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3731) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/flexible/history/collateralRecord` |
+| [getRateHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3741) | :closed_lock_with_key:  | GET | `sapi/v1/simple-earn/flexible/history/rateHistory` |
+| [getVipBorrowInterestRate()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3757) | :closed_lock_with_key:  | GET | `sapi/v1/loan/vip/request/interestRate` |
+| [getVipLoanInterestRateHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3763) | :closed_lock_with_key:  | GET | `sapi/v1/loan/vip/interestRateHistory` |
+| [getVipLoanableAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3772) | :closed_lock_with_key:  | GET | `sapi/v1/loan/vip/loanable/data` |
+| [getVipCollateralAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3779) | :closed_lock_with_key:  | GET | `sapi/v1/loan/vip/collateral/data` |
+| [getVipLoanOpenOrders()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3792) | :closed_lock_with_key:  | GET | `sapi/v1/loan/vip/ongoing/orders` |
+| [getVipLoanRepaymentHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3799) | :closed_lock_with_key:  | GET | `sapi/v1/loan/vip/repay/history` |
+| [checkVipCollateralAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3808) | :closed_lock_with_key:  | GET | `sapi/v1/loan/vip/collateral/account` |
+| [getVipApplicationStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3815) | :closed_lock_with_key:  | GET | `sapi/v1/loan/vip/request/data` |
+| [renewVipLoan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3828) | :closed_lock_with_key:  | POST | `sapi/v1/loan/vip/renew` |
+| [repayVipLoan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3832) | :closed_lock_with_key:  | POST | `sapi/v1/loan/vip/repay` |
+| [borrowVipLoan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3836) | :closed_lock_with_key:  | POST | `sapi/v1/loan/vip/borrow` |
+| [getDualInvestmentProducts()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3846) | :closed_lock_with_key:  | GET | `sapi/v1/dci/product/list` |
+| [subscribeDualInvestmentProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3861) | :closed_lock_with_key:  | POST | `sapi/v1/dci/product/subscribe` |
+| [getDualInvestmentPositions()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3867) | :closed_lock_with_key:  | GET | `sapi/v1/dci/product/positions` |
+| [getDualInvestmentAccounts()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3876) | :closed_lock_with_key:  | GET | `sapi/v1/dci/product/accounts` |
+| [getVipLoanAccruedInterest()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3880) | :closed_lock_with_key:  | GET | `sapi/v1/loan/vip/accruedInterest` |
+| [updateAutoCompoundStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3887) | :closed_lock_with_key:  | POST | `sapi/v1/dci/product/auto_compound/edit-status` |
+| [createGiftCard()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3902) | :closed_lock_with_key:  | POST | `sapi/v1/giftcard/createCode` |
+| [createDualTokenGiftCard()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3906) | :closed_lock_with_key:  | POST | `sapi/v1/giftcard/buyCode` |
+| [redeemGiftCard()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3910) | :closed_lock_with_key:  | POST | `sapi/v1/giftcard/redeemCode` |
+| [verifyGiftCard()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3914) | :closed_lock_with_key:  | GET | `sapi/v1/giftcard/verify` |
+| [getTokenLimit()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3918) | :closed_lock_with_key:  | GET | `sapi/v1/giftcard/buyCode/token-limit` |
+| [getRsaPublicKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3922) | :closed_lock_with_key:  | GET | `sapi/v1/giftcard/cryptography/rsa-public-key` |
+| [getNftTransactionHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3932) | :closed_lock_with_key:  | GET | `sapi/v1/nft/history/transactions` |
+| [getNftDepositHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3939) | :closed_lock_with_key:  | GET | `sapi/v1/nft/history/deposit` |
+| [getNftWithdrawHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3946) | :closed_lock_with_key:  | GET | `sapi/v1/nft/history/withdraw` |
+| [getNftAsset()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3953) | :closed_lock_with_key:  | GET | `sapi/v1/nft/user/getAsset` |
+| [getC2CTradeHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3966) | :closed_lock_with_key:  | GET | `sapi/v1/c2c/orderMatch/listUserOrderHistory` |
+| [getFiatOrderHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3981) | :closed_lock_with_key:  | GET | `sapi/v1/fiat/orders` |
+| [getFiatPaymentsHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3987) | :closed_lock_with_key:  | GET | `sapi/v1/fiat/payments` |
+| [fiatWithdraw()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3993) | :closed_lock_with_key:  | POST | `/sapi/v2/fiat/withdraw` |
+| [fiatDeposit()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L3997) | :closed_lock_with_key:  | POST | `sapi/v1/fiat/deposit` |
+| [getFiatOrderDetail()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4001) | :closed_lock_with_key:  | GET | `sapi/v1/fiat/get-order-detail` |
+| [getSpotRebateHistoryRecords()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4013) | :closed_lock_with_key:  | GET | `sapi/v1/rebate/taxQuery` |
+| [getPortfolioMarginIndexPrice()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4026) |  | GET | `sapi/v1/portfolio/asset-index-price` |
+| [getPortfolioMarginAssetLeverage()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4032) | :closed_lock_with_key:  | GET | `sapi/v1/portfolio/margin-asset-leverage` |
+| [getPortfolioMarginProCollateralRate()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4038) |  | GET | `sapi/v1/portfolio/collateralRate` |
+| [getPortfolioMarginProTieredCollateralRate()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4044) |  | GET | `sapi/v2/portfolio/collateralRate` |
+| [getPortfolioMarginProAccountInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4055) | :closed_lock_with_key:  | GET | `sapi/v1/portfolio/account` |
+| [setPortfolioMarginMarginCallLevel()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4059) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/margin-call-level` |
+| [getPortfolioMarginMarginCallLevel()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4065) | :closed_lock_with_key:  | GET | `sapi/v1/portfolio/margin-call-level` |
+| [deletePortfolioMarginMarginCallLevel()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4069) | :closed_lock_with_key:  | DELETE | `sapi/v1/portfolio/margin-call-level` |
+| [bnbTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4073) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/bnb-transfer` |
+| [submitPortfolioMarginProFullTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4079) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/auto-collection` |
+| [submitPortfolioMarginProSpecificTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4085) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/asset-collection` |
+| [repayPortfolioMarginProBankruptcyLoan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4091) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/repay` |
+| [getPortfolioMarginProBankruptcyLoanAmount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4099) | :closed_lock_with_key:  | GET | `sapi/v1/portfolio/pmLoan` |
+| [repayFuturesNegativeBalance()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4103) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/repay-futures-negative-balance` |
+| [updateAutoRepayFuturesStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4109) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/repay-futures-switch` |
+| [getAutoRepayFuturesStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4115) | :closed_lock_with_key:  | GET | `sapi/v1/portfolio/repay-futures-switch` |
+| [getPortfolioMarginProInterestHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4121) | :closed_lock_with_key:  | GET | `sapi/v1/portfolio/interest-history` |
+| [getPortfolioMarginProSpanAccountInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4127) | :closed_lock_with_key:  | GET | `sapi/v2/portfolio/account` |
+| [getPortfolioMarginProAccountBalance()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4131) | :closed_lock_with_key:  | GET | `sapi/v1/portfolio/balance` |
+| [mintPortfolioMarginBFUSD()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4141) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/mint` |
+| [redeemPortfolioMarginBFUSD()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4151) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/redeem` |
+| [getPortfolioMarginBankruptcyLoanRepayHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4159) | :closed_lock_with_key:  | GET | `sapi/v1/portfolio/pmLoan-history` |
+| [transferLDUSDTPortfolioMargin()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4174) | :closed_lock_with_key:  | POST | `sapi/v1/portfolio/earn-asset-transfer` |
+| [getTransferableEarnAssetBalanceForPortfolioMargin()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4187) | :closed_lock_with_key:  | GET | `sapi/v1/portfolio/earn-asset-balance` |
+| [getFuturesTickLevelOrderbookDataLink()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4204) | :closed_lock_with_key:  | GET | `sapi/v1/futures/histDataLink` |
+| [getBlvtInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4218) |  | GET | `sapi/v1/blvt/tokenInfo` |
+| [subscribeBlvt()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4222) | :closed_lock_with_key:  | POST | `sapi/v1/blvt/subscribe` |
+| [getBlvtSubscriptionRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4226) | :closed_lock_with_key:  | GET | `sapi/v1/blvt/subscribe/record` |
+| [redeemBlvt()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4232) | :closed_lock_with_key:  | POST | `sapi/v1/blvt/redeem` |
+| [getBlvtRedemptionRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4236) | :closed_lock_with_key:  | GET | `sapi/v1/blvt/redeem/record` |
+| [getBlvtUserLimitInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4242) | :closed_lock_with_key:  | GET | `sapi/v1/blvt/userLimit` |
+| [getPayTransactions()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4253) | :closed_lock_with_key:  | GET | `sapi/v1/pay/transactions` |
+| [getInstLoanRiskUnit()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4263) | :closed_lock_with_key:  | GET | `sapi/v1/margin/loan-group/ltv-details` |
+| [closeInstLoanRiskUnit()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4269) | :closed_lock_with_key:  | DELETE | `sapi/v1/margin/loan-group` |
+| [addInstLoanCollateralAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4273) | :closed_lock_with_key:  | POST | `sapi/v1/margin/loan-group/edit-member` |
+| [getActiveInstLoanRiskUnits()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4279) | :closed_lock_with_key:  | GET | `sapi/v1/margin/loan-groups/activated` |
+| [getClosedInstLoanRiskUnits()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4283) | :closed_lock_with_key:  | GET | `sapi/v1/margin/loan-groups/closed` |
+| [getInstLoanForceLiquidationRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4295) | :closed_lock_with_key:  | GET | `sapi/v1/margin/loan-group/force-liquidation` |
+| [transferInstLoanRiskUnit()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4309) | :closed_lock_with_key:  | POST | `sapi/v1/margin/loan-group/transfer-out` |
+| [borrowInstitutionalLoan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4321) | :closed_lock_with_key:  | POST | `sapi/v1/margin/loan-group/borrow` |
+| [getInstLoanInterestHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4327) | :closed_lock_with_key:  | GET | `sapi/v1/margin/loan-group/interest-history` |
+| [repayInstitutionalLoan()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4336) | :closed_lock_with_key:  | POST | `sapi/v1/margin/loan-group/repay` |
+| [getInstLoanBorrowRepayRecords()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4342) | :closed_lock_with_key:  | GET | `sapi/v1/margin/loan-group/borrow-repay` |
+| [getMarginInterestRebateBalance()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4348) | :closed_lock_with_key:  | GET | `sapi/v1/margin/loan-group/interest-rebate-balance` |
+| [getMarginInterestRebateBalanceRecords()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4352) | :closed_lock_with_key:  | GET | `sapi/v1/margin/loan-group/interest-rebate-balance/records` |
+| [getAlphaTokenList()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4367) |  | GET | `bapi/defi/v1/public/wallet-direct/buw/wallet/cex/alpha/all/token/list` |
+| [getAlphaExchangeInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4374) |  | GET | `bapi/defi/v1/public/alpha-trade/get-exchange-info` |
+| [getAlphaAggTrades()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4381) |  | GET | `bapi/defi/v1/public/alpha-trade/agg-trades` |
+| [getAlphaKlines()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4389) |  | GET | `bapi/defi/v1/public/alpha-trade/klines` |
+| [getAlphaTicker()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4397) |  | GET | `bapi/defi/v1/public/alpha-trade/ticker` |
+| [getAlphaFullDepth()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4405) |  | GET | `bapi/defi/v1/public/alpha-trade/fullDepth` |
+| [createBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4421) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccount` |
+| [getBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4427) | :closed_lock_with_key:  | GET | `sapi/v1/broker/subAccount` |
+| [enableMarginBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4433) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccount/futures` |
+| [createApiKeyBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4439) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccountApi` |
+| [changePermissionApiKeyBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4445) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccountApi/permission` |
+| [changeComissionBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4451) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccountApi/permission` |
+| [enableUniversalTransferApiKeyBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4457) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccountApi/permission/universalTransfer` |
+| [updateIpRestrictionForSubAccountApiKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4466) | :closed_lock_with_key:  | POST | `sapi/v2/broker/subAccountApi/ipRestriction` |
+| [deleteIPRestrictionForSubAccountApiKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4480) | :closed_lock_with_key:  | DELETE | `sapi/v1/broker/subAccountApi/ipRestriction/ipList` |
+| [deleteApiKeyBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4496) | :closed_lock_with_key:  | DELETE | `sapi/v1/broker/subAccountApi` |
+| [getSubAccountBrokerIpRestriction()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4502) | :closed_lock_with_key:  | GET | `sapi/v1/broker/subAccountApi/ipRestriction` |
+| [getApiKeyBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4518) | :closed_lock_with_key:  | GET | `sapi/v1/broker/subAccountApi` |
+| [getBrokerInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4524) | :closed_lock_with_key:  | GET | `sapi/v1/broker/info` |
+| [updateSubAccountBNBBurn()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4528) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccount/bnbBurn/spot` |
+| [updateSubAccountMarginInterestBNBBurn()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4538) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccount/bnbBurn/marginInterest` |
+| [getSubAccountBNBBurnStatus()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4551) | :closed_lock_with_key:  | GET | `sapi/v1/broker/subAccount/bnbBurn/status` |
+| [deleteBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4567) | :closed_lock_with_key:  | DELETE | `/sapi/v1/broker/subAccount` |
+| [transferBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4577) | :closed_lock_with_key:  | POST | `sapi/v1/broker/transfer` |
+| [getBrokerSubAccountHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4583) | :closed_lock_with_key:  | GET | `sapi/v1/broker/transfer` |
+| [submitBrokerSubFuturesTransfer()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4589) | :closed_lock_with_key:  | POST | `sapi/v1/broker/transfer/futures` |
+| [getSubAccountFuturesTransferHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4604) | :closed_lock_with_key:  | GET | `sapi/v1/broker/transfer/futures` |
+| [getBrokerSubDepositHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4616) | :closed_lock_with_key:  | GET | `sapi/v1/broker/subAccount/depositHist` |
+| [getBrokerSubAccountSpotAssets()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4622) | :closed_lock_with_key:  | GET | `sapi/v1/broker/subAccount/spotSummary` |
+| [getSubAccountMarginAssetInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4631) | :closed_lock_with_key:  | GET | `sapi/v1/broker/subAccount/marginSummary` |
+| [querySubAccountFuturesAssetInfo()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4640) | :closed_lock_with_key:  | GET | `sapi/v3/broker/subAccount/futuresSummary` |
+| [universalTransferBroker()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4649) | :closed_lock_with_key:  | POST | `sapi/v1/broker/universalTransfer` |
+| [getUniversalTransferBroker()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4656) | :closed_lock_with_key:  | GET | `sapi/v1/broker/universalTransfer` |
+| [updateBrokerSubAccountCommission()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4668) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccountApi/commission` |
+| [updateBrokerSubAccountFuturesCommission()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4674) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccountApi/commission/futures` |
+| [getBrokerSubAccountFuturesCommission()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4683) | :closed_lock_with_key:  | GET | `sapi/v1/broker/subAccountApi/commission/futures` |
+| [updateBrokerSubAccountCoinFuturesCommission()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4692) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccountApi/commission/coinFutures` |
+| [getBrokerSubAccountCoinFuturesCommission()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4701) | :closed_lock_with_key:  | GET | `sapi/v1/broker/subAccountApi/commission/coinFutures` |
+| [getBrokerSpotCommissionRebate()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4710) | :closed_lock_with_key:  | GET | `sapi/v1/broker/rebate/recentRecord` |
+| [getBrokerFuturesCommissionRebate()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4716) | :closed_lock_with_key:  | GET | `sapi/v1/broker/rebate/futures/recentRecord` |
+| [getBrokerIfNewSpotUser()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4753) | :closed_lock_with_key:  | GET | `sapi/v1/apiReferral/ifNewUser` |
+| [getBrokerSubAccountDepositHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4764) | :closed_lock_with_key:  | GET | `sapi/v1/bv1/apiReferral/ifNewUser` |
+| [enableFuturesBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4783) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccount` |
+| [enableMarginApiKeyBrokerSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4793) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccount/margin` |
+| [getSpotUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4834) |  | POST | `api/v3/userDataStream` |
+| [keepAliveSpotUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4838) |  | PUT | `api/v3/userDataStream?listenKey=${listenKey}` |
+| [closeSpotUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4842) |  | DELETE | `api/v3/userDataStream?listenKey=${listenKey}` |
+| [getMarginUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4849) |  | POST | `sapi/v1/userDataStream` |
+| [keepAliveMarginUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4853) |  | PUT | `sapi/v1/userDataStream?listenKey=${listenKey}` |
+| [closeMarginUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4857) |  | DELETE | `sapi/v1/userDataStream?listenKey=${listenKey}` |
+| [getIsolatedMarginUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4862) |  | POST | `sapi/v1/userDataStream/isolated?${serialiseParams(params` |
+| [keepAliveIsolatedMarginUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4870) |  | PUT | `sapi/v1/userDataStream/isolated?${serialiseParams(params` |
+| [closeIsolatedMarginUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4879) |  | DELETE | `sapi/v1/userDataStream/isolated?${serialiseParams(params` |
+| [getMarginRiskUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4891) |  | POST | `sapi/v1/margin/listen-key` |
+| [keepAliveMarginRiskUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4895) |  | PUT | `sapi/v1/margin/listen-key?listenKey=${listenKey}` |
+| [closeMarginRiskUserDataListenKey()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4899) |  | DELETE | `sapi/v1/margin/listen-key` |
+| [getMarginListenToken()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4907) | :closed_lock_with_key:  | POST | `sapi/v1/userListenToken` |
+| [getBSwapLiquidity()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4929) | :closed_lock_with_key:  | GET | `sapi/v1/bswap/liquidity` |
+| [addBSwapLiquidity()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4936) | :closed_lock_with_key:  | POST | `sapi/v1/bswap/liquidityAdd` |
+| [removeBSwapLiquidity()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4945) | :closed_lock_with_key:  | POST | `sapi/v1/bswap/liquidityRemove` |
+| [getBSwapOperations()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4954) | :closed_lock_with_key:  | GET | `sapi/v1/bswap/liquidityOps` |
+| [getLeftDailyPurchaseQuotaFlexibleProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4969) | :closed_lock_with_key:  | GET | `sapi/v1/lending/daily/userLeftQuota` |
+| [getLeftDailyRedemptionQuotaFlexibleProduct()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4978) | :closed_lock_with_key:  | GET | `sapi/v1/lending/daily/userRedemptionQuota` |
+| [purchaseFixedAndActivityProject()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L4992) | :closed_lock_with_key:  | POST | `sapi/v1/lending/customizedFixed/purchase` |
+| [getFixedAndActivityProjects()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L5002) | :closed_lock_with_key:  | GET | `sapi/v1/lending/project/list` |
+| [getFixedAndActivityProductPosition()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L5011) | :closed_lock_with_key:  | GET | `sapi/v1/lending/project/position/list` |
+| [getLendingAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L5020) | :closed_lock_with_key:  | GET | `sapi/v1/lending/union/account` |
+| [getPurchaseRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L5027) | :closed_lock_with_key:  | GET | `sapi/v1/lending/union/purchaseRecord` |
+| [getRedemptionRecord()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L5034) | :closed_lock_with_key:  | GET | `sapi/v1/lending/union/redemptionRecord` |
+| [getInterestHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L5041) | :closed_lock_with_key:  | GET | `sapi/v1/lending/union/interestHistory` |
+| [changeFixedAndActivityPositionToDailyPosition()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L5048) | :closed_lock_with_key:  | POST | `sapi/v1/lending/positionChanged` |
+| [enableConvertSubAccount()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L5065) | :closed_lock_with_key:  | POST | `sapi/v1/broker/subAccount/convert` |
+| [convertBUSD()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L5073) | :closed_lock_with_key:  | POST | `sapi/v1/asset/convert-transfer` |
+| [getConvertBUSDHistory()](https://github.com/tiagosiebler/binance/blob/master/src/main-client.ts#L5080) | :closed_lock_with_key:  | GET | `sapi/v1/asset/convert-transfer/queryByPage` |
 
 # usdm-client.ts
 
@@ -875,70 +882,71 @@ This client provides WebSocket API endpoints which allow for faster interactions
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [disconnectAll()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L261) |  | WS | `ping` |
-| [testSpotConnectivity()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L274) |  | WS | `ping` |
-| [getSpotServerTime()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L286) |  | WS | `time` |
-| [getSpotExchangeInfo()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L300) |  | WS | `exchangeInfo` |
-| [getSpotOrderBook()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L322) |  | WS | `depth` |
-| [getSpotRecentTrades()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L338) |  | WS | `trades.recent` |
-| [getSpotHistoricalTrades()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L354) |  | WS | `trades.historical` |
-| [getSpotAggregateTrades()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L370) |  | WS | `trades.aggregate` |
-| [getSpotKlines()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L386) |  | WS | `klines` |
-| [getSpotUIKlines()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L402) |  | WS | `uiKlines` |
-| [getSpotAveragePrice()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L417) |  | WS | `avgPrice` |
-| [getSpotExecutionRules()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L432) |  | WS | `executionRules` |
-| [getSpotReferencePrice()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L447) |  | WS | `referencePrice` |
-| [getSpotReferencePriceCalculation()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L462) |  | WS | `referencePrice.calculation` |
-| [getSpot24hrTicker()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L478) |  | WS | `ticker.24hr` |
-| [getSpotTradingDayTicker()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L497) |  | WS | `ticker.tradingDay` |
-| [getSpotTicker()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L517) |  | WS | `ticker` |
-| [getSpotSymbolPriceTicker()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L537) |  | WS | `ticker.price` |
-| [getSpotSymbolOrderBookTicker()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L553) |  | WS | `ticker.book` |
-| [getSpotSessionStatus()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L573) |  | WS | `session.status` |
-| [submitNewSpotOrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L591) |  | WS | `order.place` |
-| [testSpotOrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L606) |  | WS | `order.test` |
-| [getSpotOrderStatus()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L623) |  | WS | `order.status` |
-| [cancelSpotOrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L638) |  | WS | `order.cancel` |
-| [cancelReplaceSpotOrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L653) |  | WS | `order.cancelReplace` |
-| [amendSpotOrderKeepPriority()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L669) |  | WS | `order.amend.keepPriority` |
-| [getSpotOpenOrders()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L684) |  | WS | `openOrders.status` |
-| [cancelAllSpotOpenOrders()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L699) |  | WS | `openOrders.cancelAll` |
-| [placeSpotOrderList()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L716) |  | WS | `orderList.place` |
-| [placeSpotOCOOrderList()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L731) |  | WS | `orderList.place.oco` |
-| [placeSpotOTOOrderList()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L746) |  | WS | `orderList.place.oto` |
-| [placeSpotOTOCOOrderList()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L761) |  | WS | `orderList.place.otoco` |
-| [placeSpotOPOOrderList()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L776) |  | WS | `orderList.place.opo` |
-| [placeSpotOPOCOOrderList()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L791) |  | WS | `orderList.place.opoco` |
-| [getSpotOrderListStatus()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L806) |  | WS | `orderList.status` |
-| [cancelSpotOrderList()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L821) |  | WS | `orderList.cancel` |
-| [getSpotOpenOrderLists()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L836) |  | WS | `openOrderLists.status` |
-| [placeSpotSOROrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L851) |  | WS | `sor.order.place` |
-| [testSpotSOROrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L866) |  | WS | `sor.order.test` |
-| [getSpotAccountInformation()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L891) |  | WS | `account.status` |
-| [getSpotOrderRateLimits()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L906) |  | WS | `account.rateLimits.orders` |
-| [getSpotAllOrders()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L921) |  | WS | `allOrders` |
-| [getSpotAllOrderLists()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L936) |  | WS | `allOrderLists` |
-| [getSpotMyTrades()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L951) |  | WS | `myTrades` |
-| [getSpotPreventedMatches()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L966) |  | WS | `myPreventedMatches` |
-| [getSpotAllocations()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L981) |  | WS | `myAllocations` |
-| [getSpotAccountCommission()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L996) |  | WS | `account.commission` |
-| [getFuturesOrderBook()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1017) |  | WS | `depth` |
-| [getFuturesSymbolPriceTicker()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1032) |  | WS | `ticker.price` |
-| [getFuturesSymbolOrderBookTicker()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1049) |  | WS | `ticker.book` |
-| [submitNewFuturesOrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1071) |  | WS | `order.place` |
-| [modifyFuturesOrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1087) |  | WS | `order.modify` |
-| [cancelFuturesOrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1103) |  | WS | `order.cancel` |
-| [getFuturesOrderStatus()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1119) |  | WS | `order.status` |
-| [getFuturesPositionV2()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1134) |  | WS | `v2/account.position` |
-| [getFuturesPosition()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1150) |  | WS | `account.position` |
-| [submitNewFuturesAlgoOrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1166) |  | WS | `algoOrder.place` |
-| [cancelFuturesAlgoOrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1182) |  | WS | `algoOrder.cancel` |
-| [getFuturesAccountBalanceV2()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1202) |  | WS | `v2/account.balance` |
-| [getFuturesAccountBalance()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1218) |  | WS | `account.balance` |
-| [getFuturesAccountStatusV2()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1233) |  | WS | `v2/account.status` |
-| [getFuturesAccountStatus()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1249) |  | WS | `account.status` |
-| [startUserDataStreamForKey()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1275) |  | WS | `userDataStream.start` |
-| [pingUserDataStreamForKey()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1295) |  | WS | `userDataStream.ping` |
-| [stopUserDataStreamForKey()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1309) |  | WS | `userDataStream.stop` |
-| [subscribeUserDataStream()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1340) |  | WS | `userDataStream.unsubscribe` |
-| [unsubscribeUserDataStream()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1469) |  | WS | `userDataStream.unsubscribe` |
+| [disconnectAll()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L263) |  | WS | `ping` |
+| [testSpotConnectivity()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L276) |  | WS | `ping` |
+| [getSpotServerTime()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L288) |  | WS | `time` |
+| [getSpotExchangeInfo()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L302) |  | WS | `exchangeInfo` |
+| [getSpotOrderBook()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L324) |  | WS | `depth` |
+| [getSpotRecentTrades()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L340) |  | WS | `trades.recent` |
+| [getSpotHistoricalTrades()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L356) |  | WS | `trades.historical` |
+| [getSpotHistoricalBlockTrades()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L371) |  | WS | `blockTrades.historical` |
+| [getSpotAggregateTrades()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L387) |  | WS | `trades.aggregate` |
+| [getSpotKlines()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L403) |  | WS | `klines` |
+| [getSpotUIKlines()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L419) |  | WS | `uiKlines` |
+| [getSpotAveragePrice()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L434) |  | WS | `avgPrice` |
+| [getSpotExecutionRules()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L449) |  | WS | `executionRules` |
+| [getSpotReferencePrice()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L464) |  | WS | `referencePrice` |
+| [getSpotReferencePriceCalculation()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L479) |  | WS | `referencePrice.calculation` |
+| [getSpot24hrTicker()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L495) |  | WS | `ticker.24hr` |
+| [getSpotTradingDayTicker()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L514) |  | WS | `ticker.tradingDay` |
+| [getSpotTicker()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L534) |  | WS | `ticker` |
+| [getSpotSymbolPriceTicker()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L554) |  | WS | `ticker.price` |
+| [getSpotSymbolOrderBookTicker()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L570) |  | WS | `ticker.book` |
+| [getSpotSessionStatus()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L590) |  | WS | `session.status` |
+| [submitNewSpotOrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L608) |  | WS | `order.place` |
+| [testSpotOrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L623) |  | WS | `order.test` |
+| [getSpotOrderStatus()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L640) |  | WS | `order.status` |
+| [cancelSpotOrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L655) |  | WS | `order.cancel` |
+| [cancelReplaceSpotOrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L670) |  | WS | `order.cancelReplace` |
+| [amendSpotOrderKeepPriority()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L686) |  | WS | `order.amend.keepPriority` |
+| [getSpotOpenOrders()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L701) |  | WS | `openOrders.status` |
+| [cancelAllSpotOpenOrders()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L716) |  | WS | `openOrders.cancelAll` |
+| [placeSpotOrderList()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L733) |  | WS | `orderList.place` |
+| [placeSpotOCOOrderList()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L748) |  | WS | `orderList.place.oco` |
+| [placeSpotOTOOrderList()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L763) |  | WS | `orderList.place.oto` |
+| [placeSpotOTOCOOrderList()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L778) |  | WS | `orderList.place.otoco` |
+| [placeSpotOPOOrderList()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L793) |  | WS | `orderList.place.opo` |
+| [placeSpotOPOCOOrderList()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L808) |  | WS | `orderList.place.opoco` |
+| [getSpotOrderListStatus()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L823) |  | WS | `orderList.status` |
+| [cancelSpotOrderList()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L838) |  | WS | `orderList.cancel` |
+| [getSpotOpenOrderLists()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L853) |  | WS | `openOrderLists.status` |
+| [placeSpotSOROrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L868) |  | WS | `sor.order.place` |
+| [testSpotSOROrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L883) |  | WS | `sor.order.test` |
+| [getSpotAccountInformation()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L908) |  | WS | `account.status` |
+| [getSpotOrderRateLimits()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L923) |  | WS | `account.rateLimits.orders` |
+| [getSpotAllOrders()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L938) |  | WS | `allOrders` |
+| [getSpotAllOrderLists()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L953) |  | WS | `allOrderLists` |
+| [getSpotMyTrades()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L968) |  | WS | `myTrades` |
+| [getSpotPreventedMatches()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L983) |  | WS | `myPreventedMatches` |
+| [getSpotAllocations()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L998) |  | WS | `myAllocations` |
+| [getSpotAccountCommission()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1013) |  | WS | `account.commission` |
+| [getFuturesOrderBook()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1034) |  | WS | `depth` |
+| [getFuturesSymbolPriceTicker()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1049) |  | WS | `ticker.price` |
+| [getFuturesSymbolOrderBookTicker()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1066) |  | WS | `ticker.book` |
+| [submitNewFuturesOrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1088) |  | WS | `order.place` |
+| [modifyFuturesOrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1104) |  | WS | `order.modify` |
+| [cancelFuturesOrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1120) |  | WS | `order.cancel` |
+| [getFuturesOrderStatus()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1136) |  | WS | `order.status` |
+| [getFuturesPositionV2()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1151) |  | WS | `v2/account.position` |
+| [getFuturesPosition()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1167) |  | WS | `account.position` |
+| [submitNewFuturesAlgoOrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1183) |  | WS | `algoOrder.place` |
+| [cancelFuturesAlgoOrder()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1199) |  | WS | `algoOrder.cancel` |
+| [getFuturesAccountBalanceV2()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1219) |  | WS | `v2/account.balance` |
+| [getFuturesAccountBalance()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1235) |  | WS | `account.balance` |
+| [getFuturesAccountStatusV2()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1250) |  | WS | `v2/account.status` |
+| [getFuturesAccountStatus()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1266) |  | WS | `account.status` |
+| [startUserDataStreamForKey()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1292) |  | WS | `userDataStream.start` |
+| [pingUserDataStreamForKey()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1312) |  | WS | `userDataStream.ping` |
+| [stopUserDataStreamForKey()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1326) |  | WS | `userDataStream.stop` |
+| [subscribeUserDataStream()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1357) |  | WS | `userDataStream.unsubscribe` |
+| [unsubscribeUserDataStream()](https://github.com/tiagosiebler/binance/blob/master/src/websocket-api-client.ts#L1486) |  | WS | `userDataStream.unsubscribe` |

--- a/llms.txt
+++ b/llms.txt
@@ -48,6 +48,8 @@ Notes:
 ================================================================
 Directory Structure
 ================================================================
+docs/
+  BINANCE_SDK_QUICKSTART_GUIDE.md
 examples/
   auth/
     rest-private-ed25519.md
@@ -273,13 +275,6 @@ import {
   NewFuturesOrderParams,
   USDMClient,
 } from '../../../src/index';
-⋮----
-// TODO: check balance and do other validations
-⋮----
-// create three orders
-// 1. entry order,
-// 2. passive reduce-only take profit limit order,
-// 3. stop loss Algo Service order
 
 ================
 File: examples/REST/Futures/rest-usdm-demo.ts
@@ -303,42 +298,14 @@ async function start()
 ================
 File: examples/REST/Futures/rest-usdm-order-sl.ts
 ================
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { USDMClient } from '../../../src/index';
+import { FuturesNewAlgoOrderParams, USDMClient } from '../../../src/index';
 ⋮----
 // or
-// import { USDMClient } from 'binance';
+// import { FuturesNewAlgoOrderParams, USDMClient } from 'binance';
 ⋮----
 async function start()
 ⋮----
-// ### This is for Hedge Mode Only ###
-// assuming you currently have a open position, and you want to modify the SL order.
-⋮----
-/**
-     * first we get all long and short positions status
-     * the result of this method in hedge mode is array of two objects
-     * first index for LONG and second index for SHORT
-     */
-⋮----
-// if longAmount is bigger than 0 means we have open long position and if shortAmount is below 0 means we have open short position
-⋮----
-// if we have any open position then we continue
-⋮----
-// we get ourstop loss here
-⋮----
-// we want to modify our long position SL here
-⋮----
-// we get the StopLoss order which is realted to long
-⋮----
-// if it exists, cancel it.
-⋮----
-// creating SL order
-⋮----
-side: 'SELL', // the action of order, means this order will sell which is sl for long position
-positionSide: 'LONG', // based on the headge mode we either LONG or SHORT, here we are doing it for our long pos
-⋮----
-closePosition: 'true', // this is here because we don't have the position quantity value, and it means closee all quantity
-stopPrice: parseFloat((markPrice * 0.99).toFixed(3)), // set sl price 1% below current price
+// Hedge Mode example: find each open hedge position and replace its SL.
 
 ================
 File: examples/REST/Futures/rest-usdm-order.ts
@@ -823,105 +790,6 @@ import { MainClient } from '../../../src/index';
 // );
 
 ================
-File: examples/README.md
-================
-# Binance API - Examples
-
-This folder contains ready to go examples demonstrating various aspects of this API implementation, written in TypeScript (but they are compatible with pure JavaScript projects).
-
-Found something difficult to implement? Contribute to these examples and help others!
-
-## Getting started
-
-- Clone the project (or download it as a zip, or install the module in your own project `npm install binance`).
-- Edit the sample as needed (some samples require edits, e.g API keys or import statements to import from npm, not src).
-- Execute the sample using tsx: `tsx examples/REST/rest-spot-public.ts`.
-
-Samples that refer to API credentials using `process.env.API_KEY_COM` can be spawned with environment variables. Unix/macOS example:
-```
-APIKEY='apikeypastedhere' APISECRET='apisecretpastedhere' tsx examples/WebSockets/ws-userdata-listenkey.ts
-```
-
-Or edit the example directly to hardcode your API keys.
-
-### WebSockets
-
-All examples relating to WebSockets can be found in the [examples/WebSockets](./WebSockets/) folder. High level summary of available examples:
-
-#### Consumers
-
-These are purely for receiving data from Binance's WebSockets (market data, account updates, etc).
-
-##### Market Data
-
-These examples demonstrate subscribing to & receiving market data from Binance's WebSockets:
-
-- ws-public.ts
-  - Demonstration on general usage of the WebSocket client to subscribe to / unsubscribe from one or more market data topics.
-- ws-public-spot-orderbook.ts
-  - Subscribing to orderbook events for multiple symbols in spot markets.
--	ws-public-spot-trades.ts
-  - Subscribing to raw trades for multiple symbols in spot markets.
-- ws-unsubscribe.ts
-  - Subscribing to a list of topics, and then unsubscribing from a few topics in that list.
-- ws-public-usdm-funding.ts
-  - Simple example subscribing to a general topic, and how to process incoming events to only extract funding rates from those events.
-
-##### Account Data
-
-These examples demonstrate receiving account update events from Binance's WebSockets:
-
--	ws-userdata-listenkey.ts
-  - Demonstration on subscribing to various user data streams (spot, margin, futures),
-  - Handling incoming user data events
-  - Using provided type guards to determine which product group the user data event is for (spot, margin, futures, etc).
-- ws-userdata-listenKey-testnet.ts
-  - Similar to above, but on testnet.
-- ws-userdata-connection-safety.ts
-  - Demonstration on extra safety around the first user data stream connection.
-  - Note: this is overkill in most situations...
-
-##### WebSocket API
-
-These examples demonstrate how to send commands using Binance's WebSocket API (e.g. submitting orders). Very similar to the REST API, but using a persisted WebSocket connection instead of HTTP requests.
-
-- ws-api-client.ts
-  - Demonstration of using Binance's WebSocket API in Node.js/JavaScript/TypeScript, using the WebsocketAPIClient.
-  - This WebsocketAPIClient is very similar to a REST client, with one method per available command (endpoint) and fully typed requests & responses.
-  - Routing is automatically handled via the WebsocketClient, including authentication and connection persistence. Just call the functions you need - the SDK does the rest.
-  - From a usage perspective, it feels like a REST API - you can await responses just like a HTTP request.
-- ws-api-raw-promises.ts
-  - More verbose usage of the WebSocket API using the `sendWSAPIRequest()` method.
-  - The `WebsocketAPIClient` uses this method too, so in most cases it is simple to just use the `WebsocketAPIClient` instead.
-- ws-userdata-wsapi.ts
-  - The listenKey workflow for the user data stream is deprecated (in spot markets).
-  - This example demonstrates how to subscribe to the user data stream in spot markets, without a listen key, using the WebSocket API.
-
-##### Misc Workflows
-
-These are miscellaneous examples that cover one or more of the above categories:
-
-- ws-close.ts
-  - Closing the (old listen-key driven) user data stream.
-  - Unsubscribing from various topics.
-- ws-proxy-socks.ts
-  - Using WebSockets over a SOCKS proxy.
-- deprecated-ws-public.ts
-
-
-### REST APIs
-
-All examples relating to REST APIs can be found in the [examples/REST](./REST/) folder. Most examples are named around functionality & product group. Any examples with "private" involve API calls relating to your account (such as changing settings or submitting orders, etc),
-
-High level summary for some of the available examples, but check the folder for a complete list:
-
-#### REST USDM Examples
-
-- `rest-future-bracket-order.ts` Creates an entry order plus a passive reduce-only TP limit order and an SL Algo Service order.
-- `rest-usdm-order.ts` Creates single entry, using `submitNewOrder`
-- `rest-usdm-order-sl.ts` Modify current Stop Loss order(HedgeMode only)
-
-================
 File: src/types/coin.ts
 ================
 import { FuturesContractType, PositionSide } from './futures';
@@ -1049,460 +917,22 @@ export interface FuturesTransactionHistoryDownloadLink {
 }
 
 ================
-File: src/types/shared.ts
+File: webpack/webpack.config.js
 ================
-// Generic numeric value stored as a string. Can be parsed via parseInt or parseFloat.
-// Beautifier may convert these to number, if enabled.
-export type numberInString = string | number;
+function generateConfig(name)
 ⋮----
-export type ExchangeSymbol = string;
+// Add '.ts' and '.tsx' as resolvable extensions.
 ⋮----
-export type BooleanString = 'true' | 'false';
-export type BooleanStringCapitalised = 'TRUE' | 'FALSE';
+// Node.js core modules not available in browsers
+// The REST client's https.Agent (for keepAlive) is Node.js-only and won't work in browsers
 ⋮----
-export type BinanceBaseUrlKey =
-  | 'spot'
-  | 'spot1'
-  | 'spot2'
-  | 'spot3'
-  | 'spot4'
-  | 'spottest'
-  | 'usdmtest'
-  | 'usdm'
-  | 'coinm'
-  | 'coinmtest'
-  | 'voptions'
-  | 'voptionstest'
-  | 'papi'
-  | 'www';
+// All files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'.
 ⋮----
-/**
- * Time in force. Note: `GTE_GTC` is not officially documented, use at your own risk.
- */
-export type OrderTimeInForce =
-  | 'GTC'
-  | 'IOC'
-  | 'FOK'
-  | 'GTX'
-  | 'GTE_GTC'
-  | 'GTD';
+// All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
 ⋮----
-export type StringBoolean = 'TRUE' | 'FALSE';
-⋮----
-export type SideEffects =
-  | 'MARGIN_BUY'
-  | 'AUTO_REPAY'
-  | 'NO_SIDE_EFFECT'
-  | 'AUTO_BORROW_REPAY'
-  | 'NO_SIDE_EFFECT';
-⋮----
-/**
- * ACK = confirmation of order acceptance (no placement/fill information)
- * RESULT = fill state
- * FULL = fill state + detail on fills and other detail
- */
-export type OrderResponseType = 'ACK' | 'RESULT' | 'FULL';
-⋮----
-export type OrderIdProperty =
-  | 'newClientOrderId'
-  | 'newClientStrategyId'
-  | 'listClientOrderId'
-  | 'limitClientOrderId'
-  | 'stopClientOrderId'
-  | 'clientAlgoId'
-  | 'aboveClientOrderId'
-  | 'belowClientOrderId'
-  | 'workingClientOrderId'
-  | 'pendingAboveClientOrderId'
-  | 'pendingBelowClientOrderId'
-  | 'pendingClientOrderId';
-⋮----
-export type OrderSide = 'BUY' | 'SELL';
-⋮----
-export type OrderStatus =
-  | 'NEW'
-  | 'PARTIALLY_FILLED'
-  | 'FILLED'
-  | 'CANCELED'
-  | 'PENDING_CANCEL'
-  | 'REJECTED'
-  | 'EXPIRED';
-⋮----
-export type OrderExecutionType =
-  | 'NEW'
-  | 'CANCELED'
-  | 'REJECTED'
-  | 'TRADE'
-  | 'EXPIRED';
-⋮----
-// listStatusType
-export type OCOStatus = 'RESPONSE' | 'EXEC_STARTED' | 'ALL_DONE';
-⋮----
-// listOrderStatus
-export type OCOOrderStatus = 'EXECUTING' | 'ALL_DONE' | 'REJECT';
-⋮----
-export type OrderType =
-  | 'LIMIT'
-  | 'LIMIT_MAKER'
-  | 'MARKET'
-  | 'STOP_LOSS'
-  | 'STOP_LOSS_LIMIT'
-  | 'TAKE_PROFIT'
-  | 'TAKE_PROFIT_LIMIT';
-⋮----
-export type OrderListOrderType =
-  | 'STOP_LOSS_LIMIT'
-  | 'STOP_LOSS'
-  | 'LIMIT_MAKER'
-  | 'TAKE_PROFIT'
-  | 'TAKE_PROFIT_LIMIT';
-⋮----
-export type SelfTradePreventionMode =
-  | 'EXPIRE_TAKER'
-  | 'EXPIRE_MAKER'
-  | 'EXPIRE_BOTH'
-  | 'NONE';
-⋮----
-export interface BasicAssetParam {
-  asset: string;
-}
-⋮----
-export interface BasicSymbolParam {
-  symbol: string;
-  isIsolated?: StringBoolean;
-}
-⋮----
-export interface SymbolArrayParam {
-  symbols: string[];
-}
-⋮----
-export interface BasicAssetPaginatedParams {
-  asset?: string;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-}
-export interface BasicSymbolPaginatedParams {
-  symbol?: string;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-}
-⋮----
-export interface SymbolPrice {
-  symbol: string;
-  price: numberInString;
-  time?: number;
-}
-⋮----
-// used by spot and usdm
-export interface OrderBookParams {
-  symbol: string;
-  limit?: 5 | 10 | 20 | 50 | 100 | 500 | 1000 | 5000;
-  symbolStatus?: string;
-}
-⋮----
-export type KlineInterval =
-  | '1s'
-  | '1m'
-  | '3m'
-  | '5m'
-  | '15m'
-  | '30m'
-  | '1h'
-  | '2h'
-  | '4h'
-  | '6h'
-  | '8h'
-  | '12h'
-  | '1d'
-  | '3d'
-  | '1w'
-  | '1M';
-⋮----
-export interface GetOrderParams {
-  symbol: string;
-  orderId?: number;
-  origClientOrderId?: string;
-}
-⋮----
-export interface GetOrderModifyHistoryParams {
-  symbol: string;
-  orderId?: number;
-  origClientOrderId?: string;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-}
-⋮----
-export interface HistoricalTradesParams {
-  symbol: string;
-  limit?: number;
-  fromId?: number;
-}
-⋮----
-export interface KlinesParams {
-  symbol: string;
-  interval: KlineInterval;
-  startTime?: number;
-  endTime?: number;
-  timeZone?: string;
-  limit?: number;
-}
-⋮----
-export type Kline = [
-  number, // open time
-  numberInString, // open
-  numberInString, // high
-  numberInString, // low
-  numberInString, // close
-  numberInString, // volume
-  number, // close time
-  numberInString, // quote asset volume
-  number, // number of trades
-  numberInString, // taker buy base asset vol
-  numberInString, // taker buy quote asset vol
-  numberInString, // ignore?
-];
-⋮----
-number, // open time
-numberInString, // open
-numberInString, // high
-numberInString, // low
-numberInString, // close
-numberInString, // volume
-number, // close time
-numberInString, // quote asset volume
-number, // number of trades
-numberInString, // taker buy base asset vol
-numberInString, // taker buy quote asset vol
-numberInString, // ignore?
-⋮----
-/** @deprecated `FuturesKline` will be removed soon. Use `Kline` instead. **/
-export type FuturesKline = Kline;
-export interface RecentTradesParams {
-  symbol: string;
-  limit?: number;
-}
-⋮----
-export interface CancelOrderParams {
-  symbol: string;
-  orderId?: number;
-  origClientOrderId?: string;
-}
-⋮----
-export interface AmendKeepPriorityParams {
-  symbol: string;
-  orderId?: number;
-  origClientOrderId?: string;
-  newClientOrderId?: string;
-  newQty: numberInString;
-}
-⋮----
-export interface CancelOCOParams {
-  symbol: string;
-  orderListId?: number;
-  listClientOrderId?: string;
-  newClientOrderId?: string;
-}
-⋮----
-export interface NewOCOParams {
-  symbol: string;
-  listClientOrderId?: string;
-  side: OrderSide;
-  quantity: number;
-  limitClientOrderId?: string;
-  limitStrategyId?: number;
-  limitStrategyType?: number;
-  price: number;
-  limitIcebergQty?: number;
-  trailingDelta?: number;
-  stopClientOrderId?: string;
-  stopPrice: number;
-  stopStrategyId?: number;
-  stopStrategyType?: number;
-  stopLimitPrice?: number;
-  stopIcebergQty?: number;
-  stopLimitTimeInForce?: OrderTimeInForce;
-  newOrderRespType?: OrderResponseType;
-  /** For isolated margin trading only */
-  isIsolated?: StringBoolean;
-  /** Define a side effect, only for margin trading */
-  sideEffectType?: SideEffects;
-}
-⋮----
-/** For isolated margin trading only */
-⋮----
-/** Define a side effect, only for margin trading */
-⋮----
-export interface NewOrderListParams<
-  T extends OrderResponseType = OrderResponseType,
-> {
-  symbol: string;
-  listClientOrderId?: string;
-  side: OrderSide;
-  quantity: number;
-  aboveType: OrderListOrderType;
-  aboveClientOrderId?: string;
-  aboveIcebergQty?: number;
-  abovePrice?: number;
-  aboveStopPrice?: number;
-  aboveTrailingDelta?: number;
-  aboveTimeInForce?: OrderTimeInForce;
-  aboveStrategyId?: number;
-  aboveStrategyType?: number;
-  belowType: OrderListOrderType;
-  belowClientOrderId?: string;
-  belowIcebergQty?: number;
-  belowPrice?: number;
-  belowStopPrice?: number;
-  belowTrailingDelta?: number;
-  belowTimeInForce?: OrderTimeInForce;
-  belowStrategyId?: number;
-  belowStrategyType?: number;
-  newOrderRespType?: T;
-  selfTradePreventionMode?: SelfTradePreventionMode;
-}
-⋮----
-export interface SymbolFromPaginatedRequestFromId {
-  symbol: string;
-  fromId?: number;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-}
-⋮----
-export interface GetAllOrdersParams {
-  symbol: string;
-  orderId?: number;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-}
-⋮----
-export interface RateLimiter {
-  rateLimitType: 'REQUEST_WEIGHT' | 'ORDERS' | 'RAW_REQUESTS';
-  interval: 'SECOND' | 'MINUTE' | 'DAY';
-  intervalNum: number;
-  limit: number;
-}
-⋮----
-export interface SymbolPriceFilter {
-  filterType: 'PRICE_FILTER';
-  minPrice: numberInString;
-  maxPrice: numberInString;
-  tickSize: numberInString;
-}
-⋮----
-export interface SymbolPercentPriceFilter {
-  filterType: 'PERCENT_PRICE';
-  multiplierUp: numberInString;
-  multiplierDown: numberInString;
-  avgPriceMins: number;
-}
-⋮----
-export interface SymbolLotSizeFilter {
-  filterType: 'LOT_SIZE';
-  minQty: numberInString;
-  maxQty: numberInString;
-  stepSize: numberInString;
-}
-⋮----
-export interface SymbolMinNotionalFilter {
-  filterType: 'NOTIONAL';
-  minNotional: numberInString;
-  applyMinToMarket: boolean;
-  maxNotional: numberInString;
-  applyMaxToMarket: boolean;
-  avgPriceMins: number;
-}
-⋮----
-export interface SymbolIcebergPartsFilter {
-  filterType: 'ICEBERG_PARTS';
-  limit: number;
-}
-⋮----
-export interface SymbolMarketLotSizeFilter {
-  filterType: 'MARKET_LOT_SIZE';
-  minQty: numberInString;
-  maxQty: numberInString;
-  stepSize: numberInString;
-}
-⋮----
-export interface SymbolMaxOrdersFilter {
-  filterType: 'MAX_NUM_ORDERS';
-  maxNumOrders: number;
-}
-⋮----
-export interface SymbolMaxAlgoOrdersFilter {
-  filterType: 'MAX_NUM_ALGO_ORDERS';
-  maxNumAlgoOrders: number;
-}
-⋮----
-export interface SymbolMaxIcebergOrdersFilter {
-  filterType: 'MAX_NUM_ICEBERG_ORDERS';
-  maxNumIcebergOrders: number;
-}
-⋮----
-export interface SymbolMaxPositionFilter {
-  filterType: 'MAX_POSITION';
-  maxPosition: numberInString;
-}
-⋮----
-export type SymbolFilter =
-  | SymbolPriceFilter
-  | SymbolPercentPriceFilter
-  | SymbolLotSizeFilter
-  | SymbolMinNotionalFilter
-  | SymbolIcebergPartsFilter
-  | SymbolMarketLotSizeFilter
-  | SymbolMaxOrdersFilter
-  | SymbolMaxAlgoOrdersFilter
-  | SymbolMaxIcebergOrdersFilter
-  | SymbolMaxPositionFilter;
-⋮----
-export interface ExchangeMaxNumOrdersFilter {
-  filterType: 'EXCHANGE_MAX_NUM_ORDERS';
-  maxNumOrders: number;
-}
-⋮----
-export interface ExchangeMaxAlgoOrdersFilter {
-  filterType: 'EXCHANGE_MAX_ALGO_ORDERS';
-  maxNumAlgoOrders: number;
-}
-⋮----
-export type ExchangeFilter =
-  | ExchangeMaxNumOrdersFilter
-  | ExchangeMaxAlgoOrdersFilter;
-⋮----
-export type OrderBookPrice = numberInString;
-export type OrderBookAmount = numberInString;
-⋮----
-export type OrderBookRow = [OrderBookPrice, OrderBookAmount];
-⋮----
-export type OrderBookPriceFormatted = number;
-export type OrderBookAmountFormatted = number;
-export type OrderBookRowFormatted = [
-  OrderBookPriceFormatted,
-  OrderBookAmountFormatted,
-];
-⋮----
-export interface GenericCodeMsgError {
-  code: number;
-  msg: string;
-}
-⋮----
-export interface RowsWithTotal<T> {
-  rows: T[];
-  total: number;
-}
-⋮----
-export interface CoinStartEndLimit {
-  coin?: string;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-}
+// new webpack.DefinePlugin({
+//   'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+// }),
 
 ================
 File: .jshintrc
@@ -2673,6 +2103,787 @@ const optionsExpiration = '260128'; // YYMMDD
 // wsClient.subscribeDiffBookDepth(symbol, 100, 'spot');
 // wsClient.subscribeContractInfoStream('usdm');
 // wsClient.subscribeContractInfoStream('coinm');
+
+================
+File: src/types/websockets/ws-api-responses.ts
+================
+import type {
+  FuturesAlgoConditionalOrderTypes,
+  FuturesAlgoOrderStatus,
+  FuturesAlgoOrderType,
+  PositionSide,
+  PriceMatchMode,
+  WorkingType,
+} from '../futures.js';
+import {
+  numberInString,
+  OrderSide,
+  OrderTimeInForce,
+  SelfTradePreventionMode,
+} from '../shared';
+import { OrderResponse } from '../spot';
+⋮----
+/**
+ * Error response type
+ */
+export interface ErrorResponse {
+  code: number;
+  msg: string;
+}
+⋮----
+export interface WSAPISessionStatus {
+  apiKey: string;
+  authorizedSince: number;
+  connectedSince: number;
+  returnRateLimits: boolean;
+  serverTime: number;
+  userDataStream: boolean;
+}
+⋮----
+/**
+ * General response types
+ */
+export interface WSAPIServerTime {
+  serverTime: number;
+}
+⋮----
+/**
+ * Market data response types
+ */
+export interface WSAPIOrderBook {
+  lastUpdateId: number;
+  // [price, quantity]
+  bids: [numberInString, numberInString][];
+  asks: [numberInString, numberInString][];
+}
+⋮----
+// [price, quantity]
+⋮----
+export interface WSAPITrade {
+  id: number;
+  price: numberInString;
+  qty: numberInString;
+  quoteQty: numberInString;
+  time: number;
+  isBuyerMaker: boolean;
+  isBestMatch: boolean;
+}
+⋮----
+export interface WSAPIAggregateTrade {
+  a: number; // Aggregate trade ID
+  p: numberInString; // Price
+  q: numberInString; // Quantity
+  f: number; // First trade ID
+  l: number; // Last trade ID
+  T: number; // Timestamp
+  m: boolean; // Was the buyer the maker?
+  M: boolean; // Was the trade the best price match?
+}
+⋮----
+a: number; // Aggregate trade ID
+p: numberInString; // Price
+q: numberInString; // Quantity
+f: number; // First trade ID
+l: number; // Last trade ID
+T: number; // Timestamp
+m: boolean; // Was the buyer the maker?
+M: boolean; // Was the trade the best price match?
+⋮----
+export type WSAPIKline = [
+  number, // Kline open time
+  numberInString, // Open price
+  numberInString, // High price
+  numberInString, // Low price
+  numberInString, // Close price
+  numberInString, // Volume
+  number, // Kline close time
+  numberInString, // Quote asset volume
+  number, // Number of trades
+  numberInString, // Taker buy base asset volume
+  numberInString, // Taker buy quote asset volume
+  numberInString, // Unused field
+];
+⋮----
+number, // Kline open time
+numberInString, // Open price
+numberInString, // High price
+numberInString, // Low price
+numberInString, // Close price
+numberInString, // Volume
+number, // Kline close time
+numberInString, // Quote asset volume
+number, // Number of trades
+numberInString, // Taker buy base asset volume
+numberInString, // Taker buy quote asset volume
+numberInString, // Unused field
+⋮----
+export interface WSAPIAvgPrice {
+  mins: number; // Average price interval (in minutes)
+  price: numberInString; // Average price
+  closeTime: number; // Last trade time
+}
+⋮----
+mins: number; // Average price interval (in minutes)
+price: numberInString; // Average price
+closeTime: number; // Last trade time
+⋮----
+export interface WSAPIFullTicker {
+  symbol: string;
+  priceChange: numberInString;
+  priceChangePercent: numberInString;
+  weightedAvgPrice: numberInString;
+  prevClosePrice: numberInString;
+  lastPrice: numberInString;
+  lastQty: numberInString;
+  bidPrice: numberInString;
+  bidQty: numberInString;
+  askPrice: numberInString;
+  askQty: numberInString;
+  openPrice: numberInString;
+  highPrice: numberInString;
+  lowPrice: numberInString;
+  volume: numberInString;
+  quoteVolume: numberInString;
+  openTime: number;
+  closeTime: number;
+  firstId: number; // First trade ID
+  lastId: number; // Last trade ID
+  count: number; // Number of trades
+}
+⋮----
+firstId: number; // First trade ID
+lastId: number; // Last trade ID
+count: number; // Number of trades
+⋮----
+export interface WSAPIMiniTicker {
+  symbol: string;
+  openPrice: numberInString;
+  highPrice: numberInString;
+  lowPrice: numberInString;
+  lastPrice: numberInString;
+  volume: numberInString;
+  quoteVolume: numberInString;
+  openTime: number;
+  closeTime: number;
+  firstId: number; // First trade ID
+  lastId: number; // Last trade ID
+  count: number; // Number of trades
+}
+⋮----
+firstId: number; // First trade ID
+lastId: number; // Last trade ID
+count: number; // Number of trades
+⋮----
+export interface WSAPIPriceTicker {
+  symbol: string;
+  price: numberInString;
+}
+⋮----
+export interface WSAPIBookTicker {
+  symbol: string;
+  bidPrice: numberInString;
+  bidQty: numberInString;
+  askPrice: numberInString;
+  askQty: numberInString;
+}
+⋮----
+/**
+ * Futures market data response types
+ */
+export interface WSAPIFuturesOrderBook {
+  lastUpdateId: number;
+  E: number; // Message output time
+  T: number; // Transaction time
+  // [price, quantity]
+  bids: [numberInString, numberInString][];
+  asks: [numberInString, numberInString][];
+}
+⋮----
+E: number; // Message output time
+T: number; // Transaction time
+// [price, quantity]
+⋮----
+export interface WSAPIFuturesPriceTicker {
+  symbol: string;
+  price: numberInString;
+  time: number; // Transaction time
+}
+⋮----
+time: number; // Transaction time
+⋮----
+export interface WSAPIFuturesBookTicker {
+  lastUpdateId: number;
+  symbol: string;
+  bidPrice: numberInString;
+  bidQty: numberInString;
+  askPrice: numberInString;
+  askQty: numberInString;
+  time: number; // Transaction time
+}
+⋮----
+time: number; // Transaction time
+⋮----
+/**
+ * Account response types
+ */
+export interface WSAPIAccountInformation {
+  makerCommission: number;
+  takerCommission: number;
+  buyerCommission: number;
+  sellerCommission: number;
+  canTrade: boolean;
+  canWithdraw: boolean;
+  canDeposit: boolean;
+  commissionRates: {
+    maker: numberInString;
+    taker: numberInString;
+    buyer: numberInString;
+    seller: numberInString;
+  };
+  brokered: boolean;
+  requireSelfTradePrevention: boolean;
+  preventSor: boolean;
+  updateTime: number;
+  accountType: string;
+  balances: {
+    asset: string;
+    free: numberInString;
+    locked: numberInString;
+  }[];
+  permissions: string[];
+  uid: number;
+}
+⋮----
+export interface WSAPIAccountCommission {
+  symbol: string;
+  standardCommission: {
+    maker: numberInString;
+    taker: numberInString;
+    buyer: numberInString;
+    seller: numberInString;
+  };
+  taxCommission: {
+    maker: numberInString;
+    taker: numberInString;
+    buyer: numberInString;
+    seller: numberInString;
+  };
+  discount: {
+    enabledForAccount: boolean;
+    enabledForSymbol: boolean;
+    discountAsset: string;
+    discount: numberInString;
+  };
+}
+⋮----
+export interface WSAPIRateLimit {
+  rateLimitType: string;
+  interval: string;
+  intervalNum: number;
+  limit: number;
+  count: number;
+}
+⋮----
+export interface WSAPIOrder {
+  symbol: string;
+  orderId: number;
+  orderListId: number;
+  clientOrderId: string;
+  price: numberInString;
+  origQty: numberInString;
+  executedQty: numberInString;
+  cummulativeQuoteQty: numberInString;
+  status: string;
+  timeInForce: string;
+  type: string;
+  side: string;
+  stopPrice: numberInString;
+  icebergQty: numberInString;
+  time: number;
+  updateTime: number;
+  isWorking: boolean;
+  workingTime: number;
+  origQuoteOrderQty: numberInString;
+  selfTradePreventionMode: string;
+  preventedMatchId?: number;
+  preventedQuantity?: numberInString;
+  /** Present only for expired orders. */
+  expiryReason?: string;
+}
+⋮----
+/** Present only for expired orders. */
+⋮----
+export interface WSAPIBlockTrade {
+  id: number;
+  price: numberInString;
+  qty: numberInString;
+  quoteQty: numberInString;
+  time: number;
+  isBuyerMaker: boolean;
+}
+⋮----
+export interface WSAPIOrderList {
+  orderListId: number;
+  contingencyType: string;
+  listStatusType: string;
+  listOrderStatus: string;
+  listClientOrderId: string;
+  transactionTime: number;
+  symbol: string;
+  orders: {
+    symbol: string;
+    orderId: number;
+    clientOrderId: string;
+  }[];
+}
+⋮----
+export interface WSAPITrade {
+  symbol: string;
+  id: number;
+  orderId: number;
+  orderListId: number;
+  price: numberInString;
+  qty: numberInString;
+  quoteQty: numberInString;
+  commission: numberInString;
+  commissionAsset: string;
+  time: number;
+  isBuyer: boolean;
+  isMaker: boolean;
+  isBestMatch: boolean;
+}
+⋮----
+export interface WSAPIPreventedMatch {
+  symbol: string;
+  preventedMatchId: number;
+  takerOrderId: number;
+  makerSymbol: string;
+  makerOrderId: number;
+  tradeGroupId: number;
+  selfTradePreventionMode: string;
+  price: numberInString;
+  makerPreventedQuantity: numberInString;
+  transactTime: number;
+}
+⋮----
+export interface WSAPIAllocation {
+  symbol: string;
+  allocationId: number;
+  allocationType: string;
+  orderId: number;
+  orderListId: number;
+  price: numberInString;
+  qty: numberInString;
+  quoteQty: numberInString;
+  commission: numberInString;
+  commissionAsset: string;
+  time: number;
+  isBuyer: boolean;
+  isMaker: boolean;
+  isAllocator: boolean;
+}
+⋮----
+/**
+ * Trading response types
+ */
+export interface WSAPIOrderTestResponse {
+  // Empty response object
+  [key: string]: never;
+}
+⋮----
+// Empty response object
+⋮----
+export interface WSAPIOrderTestWithCommission {
+  standardCommissionForOrder: {
+    maker: numberInString;
+    taker: numberInString;
+  };
+  taxCommissionForOrder: {
+    maker: numberInString;
+    taker: numberInString;
+  };
+  discount: {
+    enabledForAccount: boolean;
+    enabledForSymbol: boolean;
+    discountAsset: string;
+    discount: numberInString;
+  };
+}
+⋮----
+export interface WSAPIOrderCancel {
+  symbol: string;
+  origClientOrderId: string;
+  orderId: number;
+  orderListId: number;
+  clientOrderId: string;
+  transactTime: number;
+  price: numberInString;
+  origQty: numberInString;
+  executedQty: numberInString;
+  origQuoteOrderQty: numberInString;
+  cummulativeQuoteQty: numberInString;
+  status: string;
+  timeInForce: string;
+  type: string;
+  side: string;
+  stopPrice?: numberInString;
+  trailingDelta?: number;
+  trailingTime?: number;
+  icebergQty?: numberInString;
+  strategyId?: number;
+  strategyType?: number;
+  selfTradePreventionMode: string;
+}
+⋮----
+export interface WSAPIOrderCancelReplaceResponse {
+  cancelResult: 'SUCCESS' | 'FAILURE' | 'NOT_ATTEMPTED';
+  newOrderResult: 'SUCCESS' | 'FAILURE' | 'NOT_ATTEMPTED';
+  cancelResponse: WSAPIOrderCancel | ErrorResponse;
+  newOrderResponse: OrderResponse | ErrorResponse | null;
+}
+⋮----
+export interface WSAPIOrderListCancelResponse {
+  orderListId: number;
+  contingencyType: string;
+  listStatusType: string;
+  listOrderStatus: string;
+  listClientOrderId: string;
+  transactionTime: number;
+  symbol: string;
+  orders: {
+    symbol: string;
+    orderId: number;
+    clientOrderId: string;
+  }[];
+  orderReports: WSAPIOrderCancel[];
+}
+⋮----
+/**
+ * Order list response types
+ */
+export interface WSAPIOrderListPlaceResponse {
+  orderListId: number;
+  contingencyType: string;
+  listStatusType: string;
+  listOrderStatus: string;
+  listClientOrderId: string;
+  transactionTime: number;
+  symbol: string;
+  orders: {
+    symbol: string;
+    orderId: number;
+    clientOrderId: string;
+  }[];
+  orderReports: OrderResponse[];
+}
+⋮----
+export interface WSAPIOrderListStatusResponse {
+  orderListId: number;
+  contingencyType: string;
+  listStatusType: string;
+  listOrderStatus: string;
+  listClientOrderId: string;
+  transactionTime: number;
+  symbol: string;
+  orders: {
+    symbol: string;
+    orderId: number;
+    clientOrderId: string;
+    /** Present only for expired orders. */
+    expiryReason?: string;
+  }[];
+}
+⋮----
+/** Present only for expired orders. */
+⋮----
+/**
+ * SOR response types
+ */
+export interface WSAPISOROrderPlaceResponse {
+  symbol: string;
+  orderId: number;
+  orderListId: number;
+  clientOrderId: string;
+  transactTime: number;
+  price: string;
+  origQty: string;
+  executedQty: string;
+  origQuoteOrderQty: string;
+  cummulativeQuoteQty: string;
+  status: string;
+  timeInForce: string;
+  type: string;
+  side: string;
+  workingTime: number;
+  /** With newOrderRespType RESULT or FULL when the order has an expiry reason. */
+  expiryReason?: string;
+  fills: {
+    matchType: string;
+    price: string;
+    qty: string;
+    commission: string;
+    commissionAsset: string;
+    tradeId: number;
+    allocId: number;
+  }[];
+  workingFloor: string;
+  selfTradePreventionMode: string;
+  usedSor: boolean;
+}
+⋮----
+/** With newOrderRespType RESULT or FULL when the order has an expiry reason. */
+⋮----
+export interface WSAPISOROrderTestResponse {
+  // Empty response object
+  [key: string]: never;
+}
+⋮----
+// Empty response object
+⋮----
+export interface WSAPISOROrderTestResponseWithCommission {
+  standardCommissionForOrder: {
+    maker: numberInString;
+    taker: numberInString;
+  };
+  taxCommissionForOrder: {
+    maker: numberInString;
+    taker: numberInString;
+  };
+  discount: {
+    enabledForAccount: boolean;
+    enabledForSymbol: boolean;
+    discountAsset: string;
+    discount: numberInString;
+  };
+}
+⋮----
+/**
+ * Futures trading response types
+ */
+export interface WSAPIFuturesOrder {
+  orderId: number;
+  symbol: string;
+  status: string;
+  clientOrderId: string;
+  price: string;
+  avgPrice: string;
+  origQty: string;
+  executedQty: string;
+  cumQty: string;
+  cumQuote: string;
+  timeInForce: string;
+  type: string;
+  reduceOnly: boolean;
+  closePosition: boolean;
+  side: string;
+  positionSide: string;
+  stopPrice: string;
+  workingType: string;
+  priceProtect: boolean;
+  origType: string;
+  priceMatch: string;
+  selfTradePreventionMode: string;
+  goodTillDate: number;
+  updateTime: number;
+  time?: number;
+  activatePrice?: string;
+  priceRate?: string;
+}
+⋮----
+export interface WSAPIFuturesPosition {
+  entryPrice: string;
+  breakEvenPrice: string;
+  marginType: string;
+  isAutoAddMargin: string;
+  isolatedMargin: string;
+  leverage: string;
+  liquidationPrice: string;
+  markPrice: string;
+  maxNotionalValue: string;
+  positionAmt: string;
+  notional: string;
+  isolatedWallet: string;
+  symbol: string;
+  unRealizedProfit: string;
+  positionSide: string;
+  updateTime: number;
+}
+⋮----
+export interface WSAPIFuturesPositionV2 {
+  symbol: string;
+  positionSide: string;
+  positionAmt: string;
+  entryPrice: string;
+  breakEvenPrice: string;
+  markPrice: string;
+  unrealizedProfit: string;
+  liquidationPrice: string;
+  isolatedMargin: string;
+  notional: string;
+  marginAsset: string;
+  isolatedWallet: string;
+  initialMargin: string;
+  maintMargin: string;
+  positionInitialMargin: string;
+  openOrderInitialMargin: string;
+  adl: number;
+  bidNotional: string;
+  askNotional: string;
+  updateTime: number;
+}
+⋮----
+export interface WSAPIFuturesAlgoOrder {
+  algoId: number;
+  clientAlgoId: string;
+  algoType: FuturesAlgoOrderType;
+  orderType: FuturesAlgoConditionalOrderTypes;
+  symbol: string;
+  side: OrderSide;
+  positionSide: PositionSide;
+  timeInForce: OrderTimeInForce;
+  quantity: numberInString;
+  algoStatus: FuturesAlgoOrderStatus;
+  triggerPrice: numberInString;
+  price: numberInString;
+  icebergQuantity: numberInString | null;
+  selfTradePreventionMode: SelfTradePreventionMode;
+  workingType: WorkingType;
+  priceMatch: PriceMatchMode;
+  closePosition: boolean;
+  priceProtect: boolean;
+  reduceOnly: boolean;
+  createTime: number;
+  updateTime: number;
+  triggerTime: number;
+  goodTillDate: number;
+}
+⋮----
+export interface WSAPIFuturesAlgoOrderCancelResponse extends ErrorResponse {
+  algoId: number;
+  clientAlgoId: string;
+}
+⋮----
+/**
+ * Futures account response types
+ */
+export interface WSAPIFuturesAccountBalanceItem {
+  accountAlias: string;
+  asset: string;
+  balance: string;
+  crossWalletBalance: string;
+  crossUnPnl: string;
+  availableBalance: string;
+  maxWithdrawAmount: string;
+  marginAvailable: boolean;
+  updateTime: number;
+}
+⋮----
+export interface WSAPIFuturesAccountAsset {
+  asset: string;
+  walletBalance: string;
+  unrealizedProfit: string;
+  marginBalance: string;
+  maintMargin: string;
+  initialMargin: string;
+  positionInitialMargin: string;
+  openOrderInitialMargin: string;
+  crossWalletBalance: string;
+  crossUnPnl: string;
+  availableBalance: string;
+  maxWithdrawAmount: string;
+  marginAvailable?: boolean;
+  updateTime: number;
+}
+⋮----
+export interface WSAPIFuturesAccountPosition {
+  symbol: string;
+  initialMargin?: string;
+  maintMargin?: string;
+  unrealizedProfit: string;
+  positionInitialMargin?: string;
+  openOrderInitialMargin?: string;
+  leverage?: string;
+  isolated?: boolean;
+  entryPrice?: string;
+  breakEvenPrice?: string;
+  maxNotional?: string;
+  bidNotional?: string;
+  askNotional?: string;
+  positionSide: string;
+  positionAmt: string;
+  updateTime: number;
+}
+⋮----
+export interface WSAPIFuturesAccountStatus {
+  feeTier?: number;
+  canTrade?: boolean;
+  canDeposit?: boolean;
+  canWithdraw?: boolean;
+  updateTime: number;
+  multiAssetsMargin: boolean;
+  tradeGroupId?: number;
+  totalInitialMargin: string;
+  totalMaintMargin: string;
+  totalWalletBalance: string;
+  totalUnrealizedProfit: string;
+  totalMarginBalance: string;
+  totalPositionInitialMargin: string;
+  totalOpenOrderInitialMargin: string;
+  totalCrossWalletBalance: string;
+  totalCrossUnPnl: string;
+  availableBalance: string;
+  maxWithdrawAmount: string;
+  assets: WSAPIFuturesAccountAsset[];
+  positions: WSAPIFuturesAccountPosition[];
+}
+⋮----
+/**
+ * Spot Order response types based on newOrderRespType parameter
+ */
+export interface WSAPISpotOrderACK {
+  symbol: string;
+  orderId: number;
+  orderListId: number; // always -1 for singular orders
+  clientOrderId: string;
+  transactTime: number;
+}
+⋮----
+orderListId: number; // always -1 for singular orders
+⋮----
+export interface WSAPISpotOrderRESULT extends WSAPISpotOrderACK {
+  price: numberInString;
+  origQty: numberInString;
+  executedQty: numberInString;
+  origQuoteOrderQty: numberInString;
+  cummulativeQuoteQty: numberInString;
+  status: string;
+  timeInForce: string;
+  type: string;
+  side: string;
+  workingTime: number;
+  selfTradePreventionMode: string;
+  /** With newOrderRespType RESULT or FULL when the order has an expiry reason. */
+  expiryReason?: string;
+}
+⋮----
+/** With newOrderRespType RESULT or FULL when the order has an expiry reason. */
+⋮----
+export interface WSAPISpotOrderFill {
+  price: numberInString;
+  qty: numberInString;
+  commission: numberInString;
+  commissionAsset: string;
+  tradeId: number;
+}
+⋮----
+export interface WSAPISpotOrderFULL extends WSAPISpotOrderRESULT {
+  fills: WSAPISpotOrderFill[];
+}
+⋮----
+export type WSAPISpotOrderResponse =
+  | WSAPISpotOrderACK
+  | WSAPISpotOrderRESULT
+  | WSAPISpotOrderFULL;
 
 ================
 File: src/types/portfolio-margin.ts
@@ -4403,6 +4614,505 @@ export interface PortfolioTradFiPerpsContractSignResponse {
 }
 
 ================
+File: src/types/shared.ts
+================
+// Generic numeric value stored as a string. Can be parsed via parseInt or parseFloat.
+// Beautifier may convert these to number, if enabled.
+export type numberInString = string | number;
+⋮----
+export type ExchangeSymbol = string;
+⋮----
+export type BooleanString = 'true' | 'false';
+⋮----
+export type BinanceBaseUrlKey =
+  | 'spot'
+  | 'spot1'
+  | 'spot2'
+  | 'spot3'
+  | 'spot4'
+  | 'spottest'
+  | 'usdmtest'
+  | 'usdm'
+  | 'coinm'
+  | 'coinmtest'
+  | 'voptions'
+  | 'voptionstest'
+  | 'papi'
+  | 'www';
+⋮----
+/**
+ * Time in force. Note: `GTE_GTC` is not officially documented, use at your own risk.
+ */
+export type OrderTimeInForce =
+  | 'GTC'
+  | 'IOC'
+  | 'FOK'
+  | 'GTX'
+  | 'GTE_GTC'
+  | 'GTD';
+⋮----
+export type StringBoolean = 'TRUE' | 'FALSE';
+⋮----
+export type SideEffects =
+  | 'MARGIN_BUY'
+  | 'AUTO_REPAY'
+  | 'NO_SIDE_EFFECT'
+  | 'AUTO_BORROW_REPAY'
+  | 'NO_SIDE_EFFECT';
+⋮----
+/**
+ * ACK = confirmation of order acceptance (no placement/fill information)
+ * RESULT = fill state
+ * FULL = fill state + detail on fills and other detail
+ */
+export type OrderResponseType = 'ACK' | 'RESULT' | 'FULL';
+⋮----
+export type OrderIdProperty =
+  | 'newClientOrderId'
+  | 'newClientStrategyId'
+  | 'listClientOrderId'
+  | 'limitClientOrderId'
+  | 'stopClientOrderId'
+  | 'clientAlgoId'
+  | 'aboveClientOrderId'
+  | 'belowClientOrderId'
+  | 'workingClientOrderId'
+  | 'pendingAboveClientOrderId'
+  | 'pendingBelowClientOrderId'
+  | 'pendingClientOrderId';
+⋮----
+export type OrderSide = 'BUY' | 'SELL';
+⋮----
+export type OrderStatus =
+  | 'NEW'
+  | 'PARTIALLY_FILLED'
+  | 'FILLED'
+  | 'CANCELED'
+  | 'PENDING_CANCEL'
+  | 'REJECTED'
+  | 'EXPIRED';
+⋮----
+export type OrderExecutionType =
+  | 'NEW'
+  | 'CANCELED'
+  | 'REJECTED'
+  | 'TRADE'
+  | 'EXPIRED';
+⋮----
+// listStatusType
+export type OCOStatus = 'RESPONSE' | 'EXEC_STARTED' | 'ALL_DONE';
+⋮----
+// listOrderStatus
+export type OCOOrderStatus = 'EXECUTING' | 'ALL_DONE' | 'REJECT';
+⋮----
+export type OrderType =
+  | 'LIMIT'
+  | 'LIMIT_MAKER'
+  | 'MARKET'
+  | 'STOP_LOSS'
+  | 'STOP_LOSS_LIMIT'
+  | 'TAKE_PROFIT'
+  | 'TAKE_PROFIT_LIMIT';
+⋮----
+export type OrderListOrderType =
+  | 'STOP_LOSS_LIMIT'
+  | 'STOP_LOSS'
+  | 'LIMIT_MAKER'
+  | 'TAKE_PROFIT'
+  | 'TAKE_PROFIT_LIMIT';
+⋮----
+export type SelfTradePreventionMode =
+  | 'EXPIRE_TAKER'
+  | 'EXPIRE_MAKER'
+  | 'EXPIRE_BOTH'
+  | 'NONE';
+⋮----
+export interface BasicAssetParam {
+  asset: string;
+}
+⋮----
+export interface BasicSymbolParam {
+  symbol: string;
+  isIsolated?: StringBoolean;
+}
+⋮----
+export interface SymbolArrayParam {
+  symbols: string[];
+}
+⋮----
+export interface BasicAssetPaginatedParams {
+  asset?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+}
+export interface BasicSymbolPaginatedParams {
+  symbol?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+}
+⋮----
+export interface SymbolPrice {
+  symbol: string;
+  price: numberInString;
+  time?: number;
+}
+⋮----
+// used by spot and usdm
+export interface OrderBookParams {
+  symbol: string;
+  limit?: 5 | 10 | 20 | 50 | 100 | 500 | 1000 | 5000;
+  symbolStatus?: string;
+}
+⋮----
+export type KlineInterval =
+  | '1s'
+  | '1m'
+  | '3m'
+  | '5m'
+  | '15m'
+  | '30m'
+  | '1h'
+  | '2h'
+  | '4h'
+  | '6h'
+  | '8h'
+  | '12h'
+  | '1d'
+  | '3d'
+  | '1w'
+  | '1M';
+⋮----
+export interface GetOrderParams {
+  symbol: string;
+  orderId?: number;
+  origClientOrderId?: string;
+}
+⋮----
+export interface GetOrderModifyHistoryParams {
+  symbol: string;
+  orderId?: number;
+  origClientOrderId?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+}
+⋮----
+export interface HistoricalTradesParams {
+  symbol: string;
+  limit?: number;
+  fromId?: number;
+}
+⋮----
+export interface KlinesParams {
+  symbol: string;
+  interval: KlineInterval;
+  startTime?: number;
+  endTime?: number;
+  timeZone?: string;
+  limit?: number;
+}
+⋮----
+export type Kline = [
+  number, // open time
+  numberInString, // open
+  numberInString, // high
+  numberInString, // low
+  numberInString, // close
+  numberInString, // volume
+  number, // close time
+  numberInString, // quote asset volume
+  number, // number of trades
+  numberInString, // taker buy base asset vol
+  numberInString, // taker buy quote asset vol
+  numberInString, // ignore?
+];
+⋮----
+number, // open time
+numberInString, // open
+numberInString, // high
+numberInString, // low
+numberInString, // close
+numberInString, // volume
+number, // close time
+numberInString, // quote asset volume
+number, // number of trades
+numberInString, // taker buy base asset vol
+numberInString, // taker buy quote asset vol
+numberInString, // ignore?
+⋮----
+/** @deprecated `FuturesKline` will be removed soon. Use `Kline` instead. **/
+export type FuturesKline = Kline;
+export interface RecentTradesParams {
+  symbol: string;
+  limit?: number;
+}
+⋮----
+export interface CancelOrderParams {
+  symbol: string;
+  orderId?: number;
+  origClientOrderId?: string;
+}
+⋮----
+export interface AmendKeepPriorityParams {
+  symbol: string;
+  orderId?: number;
+  origClientOrderId?: string;
+  newClientOrderId?: string;
+  newQty: numberInString;
+}
+⋮----
+export interface CancelOCOParams {
+  symbol: string;
+  orderListId?: number;
+  listClientOrderId?: string;
+  newClientOrderId?: string;
+}
+⋮----
+export interface NewOCOParams {
+  symbol: string;
+  listClientOrderId?: string;
+  side: OrderSide;
+  quantity: number;
+  limitClientOrderId?: string;
+  limitStrategyId?: number;
+  limitStrategyType?: number;
+  price: number;
+  limitIcebergQty?: number;
+  trailingDelta?: number;
+  stopClientOrderId?: string;
+  stopPrice: number;
+  stopStrategyId?: number;
+  stopStrategyType?: number;
+  stopLimitPrice?: number;
+  stopIcebergQty?: number;
+  stopLimitTimeInForce?: OrderTimeInForce;
+  newOrderRespType?: OrderResponseType;
+  /** For isolated margin trading only */
+  isIsolated?: StringBoolean;
+  /** Define a side effect, only for margin trading */
+  sideEffectType?: SideEffects;
+}
+⋮----
+/** For isolated margin trading only */
+⋮----
+/** Define a side effect, only for margin trading */
+⋮----
+export interface NewOrderListParams<
+  T extends OrderResponseType = OrderResponseType,
+> {
+  symbol: string;
+  listClientOrderId?: string;
+  side: OrderSide;
+  quantity: number;
+  aboveType: OrderListOrderType;
+  aboveClientOrderId?: string;
+  aboveIcebergQty?: number;
+  abovePrice?: number;
+  aboveStopPrice?: number;
+  aboveTrailingDelta?: number;
+  aboveTimeInForce?: OrderTimeInForce;
+  aboveStrategyId?: number;
+  aboveStrategyType?: number;
+  belowType: OrderListOrderType;
+  belowClientOrderId?: string;
+  belowIcebergQty?: number;
+  belowPrice?: number;
+  belowStopPrice?: number;
+  belowTrailingDelta?: number;
+  belowTimeInForce?: OrderTimeInForce;
+  belowStrategyId?: number;
+  belowStrategyType?: number;
+  newOrderRespType?: T;
+  selfTradePreventionMode?: SelfTradePreventionMode;
+}
+⋮----
+export interface SymbolFromPaginatedRequestFromId {
+  symbol: string;
+  fromId?: number;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+}
+⋮----
+export interface GetAllOrdersParams {
+  symbol: string;
+  orderId?: number;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+}
+⋮----
+export interface RateLimiter {
+  rateLimitType: 'REQUEST_WEIGHT' | 'ORDERS' | 'RAW_REQUESTS';
+  interval: 'SECOND' | 'MINUTE' | 'DAY';
+  intervalNum: number;
+  limit: number;
+}
+⋮----
+export interface SymbolPriceFilter {
+  filterType: 'PRICE_FILTER';
+  minPrice: numberInString;
+  maxPrice: numberInString;
+  tickSize: numberInString;
+}
+⋮----
+export interface SymbolPercentPriceFilter {
+  filterType: 'PERCENT_PRICE';
+  multiplierUp: numberInString;
+  multiplierDown: numberInString;
+  avgPriceMins: number;
+}
+⋮----
+export interface SymbolPercentPriceBySideFilter {
+  filterType: 'PERCENT_PRICE_BY_SIDE';
+  bidMultiplierUp: numberInString;
+  bidMultiplierDown: numberInString;
+  askMultiplierUp: numberInString;
+  askMultiplierDown: numberInString;
+  avgPriceMins: number;
+}
+⋮----
+export interface SymbolLegacyMinNotionalFilter {
+  filterType: 'MIN_NOTIONAL';
+  minNotional: numberInString;
+  applyToMarket: boolean;
+  avgPriceMins: number;
+}
+⋮----
+export interface SymbolLotSizeFilter {
+  filterType: 'LOT_SIZE';
+  minQty: numberInString;
+  maxQty: numberInString;
+  stepSize: numberInString;
+}
+⋮----
+export interface SymbolMinNotionalFilter {
+  filterType: 'NOTIONAL';
+  minNotional: numberInString;
+  applyMinToMarket: boolean;
+  maxNotional: numberInString;
+  applyMaxToMarket: boolean;
+  avgPriceMins: number;
+}
+⋮----
+export interface SymbolIcebergPartsFilter {
+  filterType: 'ICEBERG_PARTS';
+  limit: number;
+}
+⋮----
+export interface SymbolMarketLotSizeFilter {
+  filterType: 'MARKET_LOT_SIZE';
+  minQty: numberInString;
+  maxQty: numberInString;
+  stepSize: numberInString;
+}
+⋮----
+export interface SymbolMaxOrdersFilter {
+  filterType: 'MAX_NUM_ORDERS';
+  maxNumOrders: number;
+}
+⋮----
+export interface SymbolMaxAlgoOrdersFilter {
+  filterType: 'MAX_NUM_ALGO_ORDERS';
+  maxNumAlgoOrders: number;
+}
+⋮----
+export interface SymbolMaxIcebergOrdersFilter {
+  filterType: 'MAX_NUM_ICEBERG_ORDERS';
+  maxNumIcebergOrders: number;
+}
+⋮----
+export interface SymbolMaxPositionFilter {
+  filterType: 'MAX_POSITION';
+  maxPosition: numberInString;
+}
+⋮----
+export type SymbolFilter =
+  | SymbolPriceFilter
+  | SymbolPercentPriceFilter
+  | SymbolPercentPriceBySideFilter
+  | SymbolLegacyMinNotionalFilter
+  | SymbolLotSizeFilter
+  | SymbolMinNotionalFilter
+  | SymbolIcebergPartsFilter
+  | SymbolMarketLotSizeFilter
+  | SymbolMaxOrdersFilter
+  | SymbolMaxAlgoOrdersFilter
+  | SymbolMaxIcebergOrdersFilter
+  | SymbolMaxPositionFilter;
+⋮----
+export interface ExchangeMaxNumOrdersFilter {
+  filterType: 'EXCHANGE_MAX_NUM_ORDERS';
+  maxNumOrders: number;
+}
+⋮----
+export interface ExchangeMaxAlgoOrdersFilter {
+  filterType: 'EXCHANGE_MAX_ALGO_ORDERS';
+  maxNumAlgoOrders: number;
+}
+⋮----
+export type ExchangeFilter =
+  | ExchangeMaxNumOrdersFilter
+  | ExchangeMaxAlgoOrdersFilter;
+⋮----
+export type OrderBookPrice = numberInString;
+export type OrderBookAmount = numberInString;
+⋮----
+export type OrderBookRow = [OrderBookPrice, OrderBookAmount];
+⋮----
+export type OrderBookPriceFormatted = number;
+export type OrderBookAmountFormatted = number;
+export type OrderBookRowFormatted = [
+  OrderBookPriceFormatted,
+  OrderBookAmountFormatted,
+];
+⋮----
+export interface GenericCodeMsgError {
+  code: number;
+  msg: string;
+}
+⋮----
+export interface RowsWithTotal<T> {
+  rows: T[];
+  total: number;
+}
+⋮----
+export interface CoinStartEndLimit {
+  coin?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+}
+
+================
+File: src/index.ts
+================
+
+
+================
+File: .gitignore
+================
+.vscode/
+.idea/
+.nyc_output/
+node_modules/
+util/config.js
+coverage/
+yarn-error.log
+lib/*
+testfile.ts
+privaterepotracker
+restClientRegex.ts
+.DS_Store
+dist
+localtest.ts
+repomix.sh
+doc
+*.pem
+
+================
 File: eslint.config.cjs
 ================
 
@@ -5188,2709 +5898,103 @@ For detailed examples, refer to the examples in this folder, as well as the foll
 - Binance JavaScript SDK Readme: https://www.npmjs.com/package/binance
 
 ================
-File: src/types/websockets/ws-api-requests.ts
+File: examples/README.md
 ================
-import {
-  FuturesAlgoConditionalOrderTypes,
-  FuturesAlgoOrderType,
-  FuturesOrderType,
-  PositionSide,
-  PriceMatchMode,
-  WorkingType,
-} from '../futures';
-import {
-  BooleanString,
-  BooleanStringCapitalised,
-  KlineInterval,
-  numberInString,
-  OrderResponseType,
-  OrderSide,
-  OrderTimeInForce,
-  OrderType,
-  SelfTradePreventionMode,
-} from '../shared';
-⋮----
-/**
- * Simple request params with timestamp (required) & recv window (optional)
- */
-export type WSAPIRecvWindowTimestamp = {
-  recvWindow?: number;
-  timestamp: number;
-};
-⋮----
-/**
- *
- * Authentication request types
- *
- */
-export interface WSAPISessionLogonRequest {
-  timestamp: number;
-}
-⋮----
-/**
- *
- * General request types
- *
- */
-export interface WSAPIExchangeInfoRequest {
-  symbol?: string;
-  symbols?: string[];
-  permissions?: string[];
-  showPermissionSets?: boolean;
-  symbolStatus?: string;
-}
-⋮----
-/**
- *
- * Market data request types
- *
- */
-⋮----
-export interface WSAPIOrderBookRequest {
-  symbol: string;
-  limit?: number;
-  symbolStatus?: string;
-}
-⋮----
-export interface WSAPITradesRecentRequest {
-  symbol: string;
-  limit?: number;
-}
-⋮----
-export interface WSAPITradesHistoricalRequest {
-  symbol: string;
-  fromId?: number;
-  limit?: number;
-}
-⋮----
-export interface WSAPITradesAggregateRequest {
-  symbol: string;
-  fromId?: number;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-}
-⋮----
-export interface WSAPIKlinesRequest {
-  symbol: string;
-  interval: KlineInterval;
-  startTime?: number;
-  endTime?: number;
-  timeZone?: string;
-  limit?: number;
-}
-⋮----
-export interface WSAPIAvgPriceRequest {
-  symbol: string;
-}
-⋮----
-/**
- * Query execution rules (e.g. PRICE_RANGE). Only one of symbol, symbols, or symbolStatus per request.
- */
-export interface WSAPIExecutionRulesRequest {
-  symbol?: string;
-  symbols?: string[];
-  symbolStatus?: 'TRADING' | 'HALT' | 'BREAK';
-}
-⋮----
-export interface WSAPIReferencePriceRequest {
-  symbol: string;
-}
-⋮----
-export interface WSAPIReferencePriceCalculationRequest {
-  symbol: string;
-  symbolStatus?: 'TRADING' | 'HALT' | 'BREAK';
-}
-⋮----
-/**
- * Symbol for single symbol, or symbols for multiple symbols
- */
-export interface WSAPITicker24hrRequest {
-  symbol?: string;
-  symbols?: string[];
-  type?: 'FULL' | 'MINI';
-  symbolStatus?: string;
-}
-⋮----
-/**
- * Symbol for single symbol, or symbols for multiple symbols
- */
-export interface WSAPITickerTradingDayRequest {
-  symbol?: string;
-  symbols?: string[];
-  timeZone?: string;
-  type?: 'FULL' | 'MINI';
-  symbolStatus?: string;
-}
-⋮----
-/**
- * Symbol for single symbol, or symbols for multiple symbols
- */
-export interface WSAPITickerRequest {
-  symbol?: string;
-  symbols?: string[];
-  windowSize?: string; // '1m', '2m' ... '59m', '1h', '2h' ... '23h', '1d', '2d' ... '7d'
-  type?: 'FULL' | 'MINI';
-  symbolStatus?: string;
-}
-⋮----
-windowSize?: string; // '1m', '2m' ... '59m', '1h', '2h' ... '23h', '1d', '2d' ... '7d'
-⋮----
-/**
- * Symbol for single symbol, or symbols for multiple symbols
- */
-export interface WSAPITickerPriceRequest {
-  symbol?: string;
-  symbols?: string[];
-  symbolStatus?: string;
-}
-⋮----
-/**
- * Symbol for single symbol, or symbols for multiple symbols
- */
-export interface WSAPITickerBookRequest {
-  symbol?: string;
-  symbols?: string[];
-  symbolStatus?: string;
-}
-⋮----
-/**
- *
- * Account request types - Spot
- *
- */
-⋮----
-export interface WSAPIAllOrdersRequest {
-  symbol: string;
-  orderId?: number;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-}
-⋮----
-export interface WSAPIAllOrderListsRequest {
-  fromId?: number;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-}
-⋮----
-export interface WSAPIMyTradesRequest {
-  symbol: string;
-  orderId?: number;
-  startTime?: number;
-  endTime?: number;
-  fromId?: number;
-  limit?: number;
-}
-⋮----
-export interface WSAPIMyPreventedMatchesRequest {
-  symbol: string;
-  preventedMatchId?: number;
-  orderId?: number;
-  fromPreventedMatchId?: number;
-  limit?: number;
-}
-⋮----
-export interface WSAPIMyAllocationsRequest {
-  symbol: string;
-  startTime?: number;
-  endTime?: number;
-  fromAllocationId?: number;
-  limit?: number;
-  orderId?: number;
-}
-⋮----
-/**
- * Trading request types
- */
-⋮----
-export interface WSAPINewSpotOrderRequest {
-  symbol: string;
-  side: OrderSide;
-  type: OrderType;
-  timeInForce?: OrderTimeInForce;
-  price?: numberInString;
-  quantity?: numberInString;
-  quoteOrderQty?: numberInString;
-  newClientOrderId?: string;
-  newOrderRespType?: 'ACK' | 'RESULT' | 'FULL';
-  stopPrice?: numberInString;
-  trailingDelta?: number;
-  icebergQty?: numberInString;
-  strategyId?: number;
-  strategyType?: number;
-  selfTradePreventionMode?: string;
-}
-⋮----
-export interface WSAPIOrderTestRequest {
-  symbol: string;
-  side: 'BUY' | 'SELL';
-  type: string;
-  timeInForce?: string;
-  price?: numberInString;
-  quantity?: numberInString;
-  quoteOrderQty?: numberInString;
-  newClientOrderId?: string;
-  stopPrice?: numberInString;
-  trailingDelta?: number;
-  icebergQty?: numberInString;
-  strategyId?: number;
-  strategyType?: number;
-  selfTradePreventionMode?: string;
-  computeCommissionRates?: boolean;
-  timestamp: number;
-  recvWindow?: number;
-}
-⋮----
-export interface WSAPIOrderStatusRequest {
-  symbol: string;
-  orderId?: number;
-  origClientOrderId?: string;
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-export interface WSAPIOrderCancelRequest {
-  symbol: string;
-  orderId?: number;
-  origClientOrderId?: string;
-  newClientOrderId?: string;
-  cancelRestrictions?: 'ONLY_NEW' | 'ONLY_PARTIALLY_FILLED';
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-export interface WSAPIOrderCancelReplaceRequest {
-  symbol: string;
-  cancelReplaceMode: 'STOP_ON_FAILURE' | 'ALLOW_FAILURE';
-  cancelOrderId?: number;
-  cancelOrigClientOrderId?: string;
-  cancelNewClientOrderId?: string;
-  side: 'BUY' | 'SELL';
-  type: string;
-  timeInForce?: string;
-  price?: numberInString;
-  quantity?: numberInString;
-  quoteOrderQty?: numberInString;
-  newClientOrderId?: string;
-  newOrderRespType?: 'ACK' | 'RESULT' | 'FULL';
-  stopPrice?: numberInString;
-  trailingDelta?: number;
-  icebergQty?: numberInString;
-  strategyId?: number;
-  strategyType?: number;
-  selfTradePreventionMode?: string;
-  cancelRestrictions?: 'ONLY_NEW' | 'ONLY_PARTIALLY_FILLED';
-  orderRateLimitExceededMode?: 'DO_NOTHING' | 'CANCEL_ONLY';
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-export interface WSAPIOrderAmendKeepPriorityRequest {
-  symbol: string;
-  orderId?: number | string;
-  origClientOrderId?: string;
-  newClientOrderId?: string;
-  newQty?: string;
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-export interface WSAPIOpenOrdersStatusRequest {
-  symbol?: string;
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-export interface WSAPIOpenOrdersCancelAllRequest {
-  symbol: string;
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-/**
- * Order list request types
- */
-export interface WSAPIOrderListPlaceRequest {
-  symbol: string;
-  side: 'BUY' | 'SELL';
-  price: numberInString;
-  quantity: numberInString;
-  listClientOrderId?: string;
-  limitClientOrderId?: string;
-  limitIcebergQty?: numberInString;
-  limitStrategyId?: number;
-  limitStrategyType?: number;
-  stopPrice?: numberInString;
-  trailingDelta?: number;
-  stopClientOrderId?: string;
-  stopLimitPrice?: numberInString;
-  stopLimitTimeInForce?: string;
-  stopIcebergQty?: numberInString;
-  stopStrategyId?: number;
-  stopStrategyType?: number;
-  newOrderRespType?: 'ACK' | 'RESULT' | 'FULL';
-  selfTradePreventionMode?: string;
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-export interface WSAPIOrderListPlaceOCORequest {
-  symbol: string;
-  side: 'BUY' | 'SELL';
-  quantity: numberInString;
-  listClientOrderId?: string;
-  aboveType:
-    | 'STOP_LOSS_LIMIT'
-    | 'STOP_LOSS'
-    | 'LIMIT_MAKER'
-    | 'TAKE_PROFIT'
-    | 'TAKE_PROFIT_LIMIT';
-  aboveClientOrderId?: string;
-  aboveIcebergQty?: numberInString;
-  abovePrice?: numberInString;
-  aboveStopPrice?: numberInString;
-  aboveTrailingDelta?: number;
-  aboveTimeInForce?: string;
-  aboveStrategyId?: number;
-  aboveStrategyType?: number;
-  belowType:
-    | 'STOP_LOSS'
-    | 'STOP_LOSS_LIMIT'
-    | 'TAKE_PROFIT'
-    | 'TAKE_PROFIT_LIMIT'
-    | 'LIMIT_MAKER';
-  belowClientOrderId?: string;
-  belowIcebergQty?: numberInString;
-  belowPrice?: numberInString;
-  belowStopPrice?: numberInString;
-  belowTrailingDelta?: number;
-  belowTimeInForce?: string;
-  belowStrategyId?: number;
-  belowStrategyType?: number;
-  newOrderRespType?: 'ACK' | 'RESULT' | 'FULL';
-  selfTradePreventionMode?: string;
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-export interface WSAPIOrderListPlaceOTORequest {
-  symbol: string;
-  listClientOrderId?: string;
-  newOrderRespType?: 'ACK' | 'RESULT' | 'FULL';
-  selfTradePreventionMode?: string;
-  workingType: 'LIMIT' | 'LIMIT_MAKER';
-  workingSide: 'BUY' | 'SELL';
-  workingClientOrderId?: string;
-  workingPrice: numberInString;
-  workingQuantity: numberInString;
-  workingIcebergQty?: numberInString;
-  workingTimeInForce?: string;
-  workingStrategyId?: number;
-  workingStrategyType?: number;
-  pendingType: string;
-  pendingSide: 'BUY' | 'SELL';
-  pendingClientOrderId?: string;
-  pendingPrice?: numberInString;
-  pendingStopPrice?: numberInString;
-  pendingTrailingDelta?: numberInString;
-  pendingQuantity: numberInString;
-  pendingIcebergQty?: numberInString;
-  pendingTimeInForce?: string;
-  pendingStrategyId?: number;
-  pendingStrategyType?: number;
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-export interface WSAPIOrderListPlaceOTOCORequest {
-  symbol: string;
-  listClientOrderId?: string;
-  newOrderRespType?: 'ACK' | 'RESULT' | 'FULL';
-  selfTradePreventionMode?: string;
-  workingType: 'LIMIT' | 'LIMIT_MAKER';
-  workingSide: 'BUY' | 'SELL';
-  workingClientOrderId?: string;
-  workingPrice: numberInString;
-  workingQuantity: numberInString;
-  workingIcebergQty?: numberInString;
-  workingTimeInForce?: string;
-  workingStrategyId?: number;
-  workingStrategyType?: number;
-  pendingSide: 'BUY' | 'SELL';
-  pendingQuantity: number | string;
-  pendingAboveType:
-    | 'STOP_LOSS_LIMIT'
-    | 'STOP_LOSS'
-    | 'LIMIT_MAKER'
-    | 'TAKE_PROFIT'
-    | 'TAKE_PROFIT_LIMIT';
-  pendingAboveClientOrderId?: string;
-  pendingAbovePrice?: numberInString;
-  pendingAboveStopPrice?: numberInString;
-  pendingAboveTrailingDelta?: numberInString;
-  pendingAboveIcebergQty?: numberInString;
-  pendingAboveTimeInForce?: string;
-  pendingAboveStrategyId?: number;
-  pendingAboveStrategyType?: number;
-  pendingBelowType:
-    | 'STOP_LOSS'
-    | 'STOP_LOSS_LIMIT'
-    | 'TAKE_PROFIT'
-    | 'TAKE_PROFIT_LIMIT'
-    | 'LIMIT_MAKER';
-  pendingBelowClientOrderId?: string;
-  pendingBelowPrice?: numberInString;
-  pendingBelowStopPrice?: numberInString;
-  pendingBelowTrailingDelta?: numberInString;
-  pendingBelowIcebergQty?: numberInString;
-  pendingBelowTimeInForce?: string;
-  pendingBelowStrategyId?: number;
-  pendingBelowStrategyType?: number;
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-export interface WSAPIOrderListPlaceOPORequest {
-  symbol: string;
-  listClientOrderId?: string;
-  newOrderRespType?: 'ACK' | 'RESULT' | 'FULL';
-  selfTradePreventionMode?: string;
-  workingType: 'LIMIT' | 'LIMIT_MAKER';
-  workingSide: 'BUY' | 'SELL';
-  workingClientOrderId?: string;
-  workingPrice: numberInString;
-  workingQuantity: numberInString;
-  workingIcebergQty?: numberInString;
-  workingTimeInForce?: string;
-  workingStrategyId?: number;
-  workingStrategyType?: number;
-  workingPegPriceType?: string;
-  workingPegOffsetType?: string;
-  workingPegOffsetValue?: number;
-  pendingType: string;
-  pendingSide: 'BUY' | 'SELL';
-  pendingClientOrderId?: string;
-  pendingPrice?: numberInString;
-  pendingStopPrice?: numberInString;
-  pendingTrailingDelta?: numberInString;
-  pendingIcebergQty?: numberInString;
-  pendingTimeInForce?: string;
-  pendingStrategyId?: number;
-  pendingStrategyType?: number;
-  pendingPegPriceType?: string;
-  pendingPegOffsetType?: string;
-  pendingPegOffsetValue?: number;
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-export interface WSAPIOrderListPlaceOPOCORequest {
-  symbol: string;
-  listClientOrderId?: string;
-  newOrderRespType?: 'ACK' | 'RESULT' | 'FULL';
-  selfTradePreventionMode?: string;
-  workingType: 'LIMIT' | 'LIMIT_MAKER';
-  workingSide: 'BUY' | 'SELL';
-  workingClientOrderId?: string;
-  workingPrice: numberInString;
-  workingQuantity: numberInString;
-  workingIcebergQty?: numberInString;
-  workingTimeInForce?: string;
-  workingStrategyId?: number;
-  workingStrategyType?: number;
-  workingPegPriceType?: string;
-  workingPegOffsetType?: string;
-  workingPegOffsetValue?: number;
-  pendingSide: 'BUY' | 'SELL';
-  pendingAboveType:
-    | 'STOP_LOSS_LIMIT'
-    | 'STOP_LOSS'
-    | 'LIMIT_MAKER'
-    | 'TAKE_PROFIT'
-    | 'TAKE_PROFIT_LIMIT';
-  pendingAboveClientOrderId?: string;
-  pendingAbovePrice?: numberInString;
-  pendingAboveStopPrice?: numberInString;
-  pendingAboveTrailingDelta?: numberInString;
-  pendingAboveIcebergQty?: numberInString;
-  pendingAboveTimeInForce?: string;
-  pendingAboveStrategyId?: number;
-  pendingAboveStrategyType?: number;
-  pendingAbovePegPriceType?: string;
-  pendingAbovePegOffsetType?: string;
-  pendingAbovePegOffsetValue?: number;
-  pendingBelowType?:
-    | 'STOP_LOSS'
-    | 'STOP_LOSS_LIMIT'
-    | 'TAKE_PROFIT'
-    | 'TAKE_PROFIT_LIMIT';
-  pendingBelowClientOrderId?: string;
-  pendingBelowPrice?: numberInString;
-  pendingBelowStopPrice?: numberInString;
-  pendingBelowTrailingDelta?: numberInString;
-  pendingBelowIcebergQty?: numberInString;
-  pendingBelowTimeInForce?: string;
-  pendingBelowStrategyId?: number;
-  pendingBelowStrategyType?: number;
-  pendingBelowPegPriceType?: string;
-  pendingBelowPegOffsetType?: string;
-  pendingBelowPegOffsetValue?: number;
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-export interface WSAPIOrderListStatusRequest {
-  origClientOrderId?: string;
-  orderListId?: number;
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-export interface WSAPIOrderListCancelRequest {
-  symbol: string;
-  orderListId?: number;
-  listClientOrderId?: string;
-  newClientOrderId?: string;
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-/**
- * SOR request types
- */
-export interface WSAPISOROrderPlaceRequest {
-  symbol: string;
-  side: 'BUY' | 'SELL';
-  type: 'LIMIT' | 'MARKET';
-  timeInForce?: string;
-  price?: numberInString;
-  quantity: numberInString;
-  newClientOrderId?: string;
-  newOrderRespType?: 'ACK' | 'RESULT' | 'FULL';
-  icebergQty?: numberInString;
-  strategyId?: number;
-  strategyType?: number;
-  selfTradePreventionMode?: string;
-  timestamp: number;
-  recvWindow?: number;
-}
-⋮----
-export type WSAPISOROrderTestRequest = WSAPISOROrderPlaceRequest & {
-  computeCommissionRates?: boolean;
-};
-⋮----
-/**
- * Futures market data request types
- */
-⋮----
-export interface WSAPIFuturesOrderBookRequest {
-  symbol: string;
-  limit?: number;
-}
-⋮----
-export interface WSAPIFuturesTickerPriceRequest {
-  symbol?: string;
-}
-⋮----
-export interface WSAPIFuturesTickerBookRequest {
-  symbol?: string;
-}
-⋮----
-/**
- * Futures trading request types
- */
-⋮----
-export interface WSAPINewFuturesOrderRequest<numberType = numberInString> {
-  symbol: string;
-  side: OrderSide;
-  positionSide?: PositionSide;
-  type: FuturesOrderType;
-  timeInForce?: OrderTimeInForce;
-  quantity?: numberType;
-  reduceOnly?: BooleanString;
-  price?: numberType;
-  newClientOrderId?: string;
-  stopPrice?: numberType;
-  closePosition?: BooleanString;
-  activationPrice?: numberType;
-  callbackRate?: numberType;
-  workingType?: WorkingType;
-  priceProtect?: BooleanStringCapitalised;
-  newOrderRespType?: 'ACK' | 'RESULT';
-  selfTradePreventionMode?: SelfTradePreventionMode;
-  priceMatch?: PriceMatchMode;
-  goodTillDate?: number; // Mandatory when timeInForce is GTD
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-goodTillDate?: number; // Mandatory when timeInForce is GTD
-⋮----
-export interface WSAPIFuturesOrderModifyRequest {
-  symbol: string;
-  orderId?: number;
-  origClientOrderId?: string;
-  side: 'BUY' | 'SELL';
-  quantity: numberInString;
-  price: numberInString;
-  priceMatch?:
-    | 'NONE'
-    | 'OPPONENT'
-    | 'OPPONENT_5'
-    | 'OPPONENT_10'
-    | 'OPPONENT_20'
-    | 'QUEUE'
-    | 'QUEUE_5'
-    | 'QUEUE_10'
-    | 'QUEUE_20';
-  origType?: string;
-  positionSide?: 'BOTH' | 'LONG' | 'SHORT';
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-export interface WSAPIFuturesOrderCancelRequest {
-  symbol: string;
-  orderId?: number;
-  origClientOrderId?: string;
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-export interface WSAPIFuturesOrderStatusRequest {
-  symbol: string;
-  orderId?: number;
-  origClientOrderId?: string;
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-export interface WSAPIFuturesPositionRequest {
-  symbol?: string;
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-export interface WSAPIFuturesPositionV2Request {
-  symbol?: string;
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-export interface WSAPIAccountInformationRequest {
-  omitZeroBalances?: boolean;
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-export interface WSAPIAccountCommissionWSAPIRequest {
-  symbol: string;
-}
-⋮----
-/**
- * Ref: https://developers.binance.com/docs/derivatives/usds-margined-futures/trade/websocket-api
- */
-export interface WSAPINewFuturesAlgoOrderRequest<numberType = numberInString> {
-  algoType: FuturesAlgoOrderType;
-  symbol: string;
-  side: OrderSide;
-  positionSide?: PositionSide;
-  type: FuturesAlgoConditionalOrderTypes;
-  timeInForce?: OrderTimeInForce;
-  quantity?: numberType;
-  reduceOnly?: BooleanString;
-  price?: numberInString;
-  newClientOrderId?: string;
-  stopPrice?: numberInString;
-  closePosition?: BooleanString;
-  activatePrice?: numberInString;
-  callbackRate?: numberInString;
-  workingType?: WorkingType;
-  priceProtect?: BooleanStringCapitalised;
-  newOrderRespType?: OrderResponseType;
-  priceMatch?: PriceMatchMode;
-  selfTradePreventionMode?: SelfTradePreventionMode;
-  goodTillDate?: number; // Mandatory when timeInForce is GTD
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-goodTillDate?: number; // Mandatory when timeInForce is GTD
-⋮----
-/**
- * Ref: https://developers.binance.com/docs/derivatives/usds-margined-futures/trade/websocket-api/Cancel-Algo-Order
- */
-export interface WSAPIFuturesAlgoOrderCancelRequest {
-  algoid?: number;
-  clientalgoid?: string;
-  recvWindow?: number;
-  timestamp: number;
-}
+# Binance API - Examples
 
-================
-File: src/types/websockets/ws-api-responses.ts
-================
-import type {
-  FuturesAlgoConditionalOrderTypes,
-  FuturesAlgoOrderStatus,
-  FuturesAlgoOrderType,
-  PositionSide,
-  PriceMatchMode,
-  WorkingType,
-} from '../futures.js';
-import {
-  numberInString,
-  OrderSide,
-  OrderTimeInForce,
-  SelfTradePreventionMode,
-} from '../shared';
-import { OrderResponse } from '../spot';
-⋮----
-/**
- * Error response type
- */
-export interface ErrorResponse {
-  code: number;
-  msg: string;
-}
-⋮----
-export interface WSAPISessionStatus {
-  apiKey: string;
-  authorizedSince: number;
-  connectedSince: number;
-  returnRateLimits: boolean;
-  serverTime: number;
-  userDataStream: boolean;
-}
-⋮----
-/**
- * General response types
- */
-export interface WSAPIServerTime {
-  serverTime: number;
-}
-⋮----
-/**
- * Market data response types
- */
-export interface WSAPIOrderBook {
-  lastUpdateId: number;
-  // [price, quantity]
-  bids: [numberInString, numberInString][];
-  asks: [numberInString, numberInString][];
-}
-⋮----
-// [price, quantity]
-⋮----
-export interface WSAPITrade {
-  id: number;
-  price: numberInString;
-  qty: numberInString;
-  quoteQty: numberInString;
-  time: number;
-  isBuyerMaker: boolean;
-  isBestMatch: boolean;
-}
-⋮----
-export interface WSAPIAggregateTrade {
-  a: number; // Aggregate trade ID
-  p: numberInString; // Price
-  q: numberInString; // Quantity
-  f: number; // First trade ID
-  l: number; // Last trade ID
-  T: number; // Timestamp
-  m: boolean; // Was the buyer the maker?
-  M: boolean; // Was the trade the best price match?
-}
-⋮----
-a: number; // Aggregate trade ID
-p: numberInString; // Price
-q: numberInString; // Quantity
-f: number; // First trade ID
-l: number; // Last trade ID
-T: number; // Timestamp
-m: boolean; // Was the buyer the maker?
-M: boolean; // Was the trade the best price match?
-⋮----
-export type WSAPIKline = [
-  number, // Kline open time
-  numberInString, // Open price
-  numberInString, // High price
-  numberInString, // Low price
-  numberInString, // Close price
-  numberInString, // Volume
-  number, // Kline close time
-  numberInString, // Quote asset volume
-  number, // Number of trades
-  numberInString, // Taker buy base asset volume
-  numberInString, // Taker buy quote asset volume
-  numberInString, // Unused field
-];
-⋮----
-number, // Kline open time
-numberInString, // Open price
-numberInString, // High price
-numberInString, // Low price
-numberInString, // Close price
-numberInString, // Volume
-number, // Kline close time
-numberInString, // Quote asset volume
-number, // Number of trades
-numberInString, // Taker buy base asset volume
-numberInString, // Taker buy quote asset volume
-numberInString, // Unused field
-⋮----
-export interface WSAPIAvgPrice {
-  mins: number; // Average price interval (in minutes)
-  price: numberInString; // Average price
-  closeTime: number; // Last trade time
-}
-⋮----
-mins: number; // Average price interval (in minutes)
-price: numberInString; // Average price
-closeTime: number; // Last trade time
-⋮----
-export interface WSAPIFullTicker {
-  symbol: string;
-  priceChange: numberInString;
-  priceChangePercent: numberInString;
-  weightedAvgPrice: numberInString;
-  prevClosePrice: numberInString;
-  lastPrice: numberInString;
-  lastQty: numberInString;
-  bidPrice: numberInString;
-  bidQty: numberInString;
-  askPrice: numberInString;
-  askQty: numberInString;
-  openPrice: numberInString;
-  highPrice: numberInString;
-  lowPrice: numberInString;
-  volume: numberInString;
-  quoteVolume: numberInString;
-  openTime: number;
-  closeTime: number;
-  firstId: number; // First trade ID
-  lastId: number; // Last trade ID
-  count: number; // Number of trades
-}
-⋮----
-firstId: number; // First trade ID
-lastId: number; // Last trade ID
-count: number; // Number of trades
-⋮----
-export interface WSAPIMiniTicker {
-  symbol: string;
-  openPrice: numberInString;
-  highPrice: numberInString;
-  lowPrice: numberInString;
-  lastPrice: numberInString;
-  volume: numberInString;
-  quoteVolume: numberInString;
-  openTime: number;
-  closeTime: number;
-  firstId: number; // First trade ID
-  lastId: number; // Last trade ID
-  count: number; // Number of trades
-}
-⋮----
-firstId: number; // First trade ID
-lastId: number; // Last trade ID
-count: number; // Number of trades
-⋮----
-export interface WSAPIPriceTicker {
-  symbol: string;
-  price: numberInString;
-}
-⋮----
-export interface WSAPIBookTicker {
-  symbol: string;
-  bidPrice: numberInString;
-  bidQty: numberInString;
-  askPrice: numberInString;
-  askQty: numberInString;
-}
-⋮----
-/**
- * Futures market data response types
- */
-export interface WSAPIFuturesOrderBook {
-  lastUpdateId: number;
-  E: number; // Message output time
-  T: number; // Transaction time
-  // [price, quantity]
-  bids: [numberInString, numberInString][];
-  asks: [numberInString, numberInString][];
-}
-⋮----
-E: number; // Message output time
-T: number; // Transaction time
-// [price, quantity]
-⋮----
-export interface WSAPIFuturesPriceTicker {
-  symbol: string;
-  price: numberInString;
-  time: number; // Transaction time
-}
-⋮----
-time: number; // Transaction time
-⋮----
-export interface WSAPIFuturesBookTicker {
-  lastUpdateId: number;
-  symbol: string;
-  bidPrice: numberInString;
-  bidQty: numberInString;
-  askPrice: numberInString;
-  askQty: numberInString;
-  time: number; // Transaction time
-}
-⋮----
-time: number; // Transaction time
-⋮----
-/**
- * Account response types
- */
-export interface WSAPIAccountInformation {
-  makerCommission: number;
-  takerCommission: number;
-  buyerCommission: number;
-  sellerCommission: number;
-  canTrade: boolean;
-  canWithdraw: boolean;
-  canDeposit: boolean;
-  commissionRates: {
-    maker: numberInString;
-    taker: numberInString;
-    buyer: numberInString;
-    seller: numberInString;
-  };
-  brokered: boolean;
-  requireSelfTradePrevention: boolean;
-  preventSor: boolean;
-  updateTime: number;
-  accountType: string;
-  balances: {
-    asset: string;
-    free: numberInString;
-    locked: numberInString;
-  }[];
-  permissions: string[];
-  uid: number;
-}
-⋮----
-export interface WSAPIAccountCommission {
-  symbol: string;
-  standardCommission: {
-    maker: numberInString;
-    taker: numberInString;
-    buyer: numberInString;
-    seller: numberInString;
-  };
-  taxCommission: {
-    maker: numberInString;
-    taker: numberInString;
-    buyer: numberInString;
-    seller: numberInString;
-  };
-  discount: {
-    enabledForAccount: boolean;
-    enabledForSymbol: boolean;
-    discountAsset: string;
-    discount: numberInString;
-  };
-}
-⋮----
-export interface WSAPIRateLimit {
-  rateLimitType: string;
-  interval: string;
-  intervalNum: number;
-  limit: number;
-  count: number;
-}
-⋮----
-export interface WSAPIOrder {
-  symbol: string;
-  orderId: number;
-  orderListId: number;
-  clientOrderId: string;
-  price: numberInString;
-  origQty: numberInString;
-  executedQty: numberInString;
-  cummulativeQuoteQty: numberInString;
-  status: string;
-  timeInForce: string;
-  type: string;
-  side: string;
-  stopPrice: numberInString;
-  icebergQty: numberInString;
-  time: number;
-  updateTime: number;
-  isWorking: boolean;
-  workingTime: number;
-  origQuoteOrderQty: numberInString;
-  selfTradePreventionMode: string;
-  preventedMatchId?: number;
-  preventedQuantity?: numberInString;
-}
-⋮----
-export interface WSAPIOrderList {
-  orderListId: number;
-  contingencyType: string;
-  listStatusType: string;
-  listOrderStatus: string;
-  listClientOrderId: string;
-  transactionTime: number;
-  symbol: string;
-  orders: {
-    symbol: string;
-    orderId: number;
-    clientOrderId: string;
-  }[];
-}
-⋮----
-export interface WSAPITrade {
-  symbol: string;
-  id: number;
-  orderId: number;
-  orderListId: number;
-  price: numberInString;
-  qty: numberInString;
-  quoteQty: numberInString;
-  commission: numberInString;
-  commissionAsset: string;
-  time: number;
-  isBuyer: boolean;
-  isMaker: boolean;
-  isBestMatch: boolean;
-}
-⋮----
-export interface WSAPIPreventedMatch {
-  symbol: string;
-  preventedMatchId: number;
-  takerOrderId: number;
-  makerSymbol: string;
-  makerOrderId: number;
-  tradeGroupId: number;
-  selfTradePreventionMode: string;
-  price: numberInString;
-  makerPreventedQuantity: numberInString;
-  transactTime: number;
-}
-⋮----
-export interface WSAPIAllocation {
-  symbol: string;
-  allocationId: number;
-  allocationType: string;
-  orderId: number;
-  orderListId: number;
-  price: numberInString;
-  qty: numberInString;
-  quoteQty: numberInString;
-  commission: numberInString;
-  commissionAsset: string;
-  time: number;
-  isBuyer: boolean;
-  isMaker: boolean;
-  isAllocator: boolean;
-}
-⋮----
-/**
- * Trading response types
- */
-export interface WSAPIOrderTestResponse {
-  // Empty response object
-  [key: string]: never;
-}
-⋮----
-// Empty response object
-⋮----
-export interface WSAPIOrderTestWithCommission {
-  standardCommissionForOrder: {
-    maker: numberInString;
-    taker: numberInString;
-  };
-  taxCommissionForOrder: {
-    maker: numberInString;
-    taker: numberInString;
-  };
-  discount: {
-    enabledForAccount: boolean;
-    enabledForSymbol: boolean;
-    discountAsset: string;
-    discount: numberInString;
-  };
-}
-⋮----
-export interface WSAPIOrderCancel {
-  symbol: string;
-  origClientOrderId: string;
-  orderId: number;
-  orderListId: number;
-  clientOrderId: string;
-  transactTime: number;
-  price: numberInString;
-  origQty: numberInString;
-  executedQty: numberInString;
-  origQuoteOrderQty: numberInString;
-  cummulativeQuoteQty: numberInString;
-  status: string;
-  timeInForce: string;
-  type: string;
-  side: string;
-  stopPrice?: numberInString;
-  trailingDelta?: number;
-  trailingTime?: number;
-  icebergQty?: numberInString;
-  strategyId?: number;
-  strategyType?: number;
-  selfTradePreventionMode: string;
-}
-⋮----
-export interface WSAPIOrderCancelReplaceResponse {
-  cancelResult: 'SUCCESS' | 'FAILURE' | 'NOT_ATTEMPTED';
-  newOrderResult: 'SUCCESS' | 'FAILURE' | 'NOT_ATTEMPTED';
-  cancelResponse: WSAPIOrderCancel | ErrorResponse;
-  newOrderResponse: OrderResponse | ErrorResponse | null;
-}
-⋮----
-export interface WSAPIOrderListCancelResponse {
-  orderListId: number;
-  contingencyType: string;
-  listStatusType: string;
-  listOrderStatus: string;
-  listClientOrderId: string;
-  transactionTime: number;
-  symbol: string;
-  orders: {
-    symbol: string;
-    orderId: number;
-    clientOrderId: string;
-  }[];
-  orderReports: WSAPIOrderCancel[];
-}
-⋮----
-/**
- * Order list response types
- */
-export interface WSAPIOrderListPlaceResponse {
-  orderListId: number;
-  contingencyType: string;
-  listStatusType: string;
-  listOrderStatus: string;
-  listClientOrderId: string;
-  transactionTime: number;
-  symbol: string;
-  orders: {
-    symbol: string;
-    orderId: number;
-    clientOrderId: string;
-  }[];
-  orderReports: OrderResponse[];
-}
-⋮----
-export interface WSAPIOrderListStatusResponse {
-  orderListId: number;
-  contingencyType: string;
-  listStatusType: string;
-  listOrderStatus: string;
-  listClientOrderId: string;
-  transactionTime: number;
-  symbol: string;
-  orders: {
-    symbol: string;
-    orderId: number;
-    clientOrderId: string;
-  }[];
-}
-⋮----
-/**
- * SOR response types
- */
-export interface WSAPISOROrderPlaceResponse {
-  symbol: string;
-  orderId: number;
-  orderListId: number;
-  clientOrderId: string;
-  transactTime: number;
-  price: string;
-  origQty: string;
-  executedQty: string;
-  origQuoteOrderQty: string;
-  cummulativeQuoteQty: string;
-  status: string;
-  timeInForce: string;
-  type: string;
-  side: string;
-  workingTime: number;
-  /** With newOrderRespType RESULT or FULL when the order has an expiry reason. */
-  expiryReason?: string;
-  fills: {
-    matchType: string;
-    price: string;
-    qty: string;
-    commission: string;
-    commissionAsset: string;
-    tradeId: number;
-    allocId: number;
-  }[];
-  workingFloor: string;
-  selfTradePreventionMode: string;
-  usedSor: boolean;
-}
-⋮----
-/** With newOrderRespType RESULT or FULL when the order has an expiry reason. */
-⋮----
-export interface WSAPISOROrderTestResponse {
-  // Empty response object
-  [key: string]: never;
-}
-⋮----
-// Empty response object
-⋮----
-export interface WSAPISOROrderTestResponseWithCommission {
-  standardCommissionForOrder: {
-    maker: numberInString;
-    taker: numberInString;
-  };
-  taxCommissionForOrder: {
-    maker: numberInString;
-    taker: numberInString;
-  };
-  discount: {
-    enabledForAccount: boolean;
-    enabledForSymbol: boolean;
-    discountAsset: string;
-    discount: numberInString;
-  };
-}
-⋮----
-/**
- * Futures trading response types
- */
-export interface WSAPIFuturesOrder {
-  orderId: number;
-  symbol: string;
-  status: string;
-  clientOrderId: string;
-  price: string;
-  avgPrice: string;
-  origQty: string;
-  executedQty: string;
-  cumQty: string;
-  cumQuote: string;
-  timeInForce: string;
-  type: string;
-  reduceOnly: boolean;
-  closePosition: boolean;
-  side: string;
-  positionSide: string;
-  stopPrice: string;
-  workingType: string;
-  priceProtect: boolean;
-  origType: string;
-  priceMatch: string;
-  selfTradePreventionMode: string;
-  goodTillDate: number;
-  updateTime: number;
-  time?: number;
-  activatePrice?: string;
-  priceRate?: string;
-}
-⋮----
-export interface WSAPIFuturesPosition {
-  entryPrice: string;
-  breakEvenPrice: string;
-  marginType: string;
-  isAutoAddMargin: string;
-  isolatedMargin: string;
-  leverage: string;
-  liquidationPrice: string;
-  markPrice: string;
-  maxNotionalValue: string;
-  positionAmt: string;
-  notional: string;
-  isolatedWallet: string;
-  symbol: string;
-  unRealizedProfit: string;
-  positionSide: string;
-  updateTime: number;
-}
-⋮----
-export interface WSAPIFuturesPositionV2 {
-  symbol: string;
-  positionSide: string;
-  positionAmt: string;
-  entryPrice: string;
-  breakEvenPrice: string;
-  markPrice: string;
-  unrealizedProfit: string;
-  liquidationPrice: string;
-  isolatedMargin: string;
-  notional: string;
-  marginAsset: string;
-  isolatedWallet: string;
-  initialMargin: string;
-  maintMargin: string;
-  positionInitialMargin: string;
-  openOrderInitialMargin: string;
-  adl: number;
-  bidNotional: string;
-  askNotional: string;
-  updateTime: number;
-}
-⋮----
-export interface WSAPIFuturesAlgoOrder {
-  algoId: number;
-  clientAlgoId: string;
-  algoType: FuturesAlgoOrderType;
-  orderType: FuturesAlgoConditionalOrderTypes;
-  symbol: string;
-  side: OrderSide;
-  positionSide: PositionSide;
-  timeInForce: OrderTimeInForce;
-  quantity: numberInString;
-  algoStatus: FuturesAlgoOrderStatus;
-  triggerPrice: numberInString;
-  price: numberInString;
-  icebergQuantity: numberInString | null;
-  selfTradePreventionMode: SelfTradePreventionMode;
-  workingType: WorkingType;
-  priceMatch: PriceMatchMode;
-  closePosition: boolean;
-  priceProtect: boolean;
-  reduceOnly: boolean;
-  createTime: number;
-  updateTime: number;
-  triggerTime: number;
-  goodTillDate: number;
-}
-⋮----
-export interface WSAPIFuturesAlgoOrderCancelResponse extends ErrorResponse {
-  algoId: number;
-  clientAlgoId: string;
-}
-⋮----
-/**
- * Futures account response types
- */
-export interface WSAPIFuturesAccountBalanceItem {
-  accountAlias: string;
-  asset: string;
-  balance: string;
-  crossWalletBalance: string;
-  crossUnPnl: string;
-  availableBalance: string;
-  maxWithdrawAmount: string;
-  marginAvailable: boolean;
-  updateTime: number;
-}
-⋮----
-export interface WSAPIFuturesAccountAsset {
-  asset: string;
-  walletBalance: string;
-  unrealizedProfit: string;
-  marginBalance: string;
-  maintMargin: string;
-  initialMargin: string;
-  positionInitialMargin: string;
-  openOrderInitialMargin: string;
-  crossWalletBalance: string;
-  crossUnPnl: string;
-  availableBalance: string;
-  maxWithdrawAmount: string;
-  marginAvailable?: boolean;
-  updateTime: number;
-}
-⋮----
-export interface WSAPIFuturesAccountPosition {
-  symbol: string;
-  initialMargin?: string;
-  maintMargin?: string;
-  unrealizedProfit: string;
-  positionInitialMargin?: string;
-  openOrderInitialMargin?: string;
-  leverage?: string;
-  isolated?: boolean;
-  entryPrice?: string;
-  breakEvenPrice?: string;
-  maxNotional?: string;
-  bidNotional?: string;
-  askNotional?: string;
-  positionSide: string;
-  positionAmt: string;
-  updateTime: number;
-}
-⋮----
-export interface WSAPIFuturesAccountStatus {
-  feeTier?: number;
-  canTrade?: boolean;
-  canDeposit?: boolean;
-  canWithdraw?: boolean;
-  updateTime: number;
-  multiAssetsMargin: boolean;
-  tradeGroupId?: number;
-  totalInitialMargin: string;
-  totalMaintMargin: string;
-  totalWalletBalance: string;
-  totalUnrealizedProfit: string;
-  totalMarginBalance: string;
-  totalPositionInitialMargin: string;
-  totalOpenOrderInitialMargin: string;
-  totalCrossWalletBalance: string;
-  totalCrossUnPnl: string;
-  availableBalance: string;
-  maxWithdrawAmount: string;
-  assets: WSAPIFuturesAccountAsset[];
-  positions: WSAPIFuturesAccountPosition[];
-}
-⋮----
-/**
- * Spot Order response types based on newOrderRespType parameter
- */
-export interface WSAPISpotOrderACK {
-  symbol: string;
-  orderId: number;
-  orderListId: number; // always -1 for singular orders
-  clientOrderId: string;
-  transactTime: number;
-}
-⋮----
-orderListId: number; // always -1 for singular orders
-⋮----
-export interface WSAPISpotOrderRESULT extends WSAPISpotOrderACK {
-  price: numberInString;
-  origQty: numberInString;
-  executedQty: numberInString;
-  origQuoteOrderQty: numberInString;
-  cummulativeQuoteQty: numberInString;
-  status: string;
-  timeInForce: string;
-  type: string;
-  side: string;
-  workingTime: number;
-  selfTradePreventionMode: string;
-  /** With newOrderRespType RESULT or FULL when the order has an expiry reason. */
-  expiryReason?: string;
-}
-⋮----
-/** With newOrderRespType RESULT or FULL when the order has an expiry reason. */
-⋮----
-export interface WSAPISpotOrderFill {
-  price: numberInString;
-  qty: numberInString;
-  commission: numberInString;
-  commissionAsset: string;
-  tradeId: number;
-}
-⋮----
-export interface WSAPISpotOrderFULL extends WSAPISpotOrderRESULT {
-  fills: WSAPISpotOrderFill[];
-}
-⋮----
-export type WSAPISpotOrderResponse =
-  | WSAPISpotOrderACK
-  | WSAPISpotOrderRESULT
-  | WSAPISpotOrderFULL;
+This folder contains ready to go examples demonstrating various aspects of this API implementation, written in TypeScript (but they are compatible with pure JavaScript projects).
 
-================
-File: src/types/futures.ts
-================
-import {
-  BooleanString,
-  BooleanStringCapitalised,
-  ExchangeFilter,
-  KlineInterval,
-  numberInString,
-  OrderBookRow,
-  OrderSide,
-  OrderStatus,
-  OrderTimeInForce,
-  OrderType,
-  RateLimiter,
-  SelfTradePreventionMode,
-  SymbolIcebergPartsFilter,
-  SymbolLotSizeFilter,
-  SymbolMarketLotSizeFilter,
-  SymbolMaxIcebergOrdersFilter,
-  SymbolMaxPositionFilter,
-  SymbolPriceFilter,
-} from './shared';
-⋮----
-export type FuturesContractType =
-  | 'PERPETUAL'
-  | 'CURRENT_MONTH'
-  | 'NEXT_MONTH'
-  | 'CURRENT_QUARTER'
-  | 'NEXT_QUARTER';
-⋮----
-export interface ContinuousContractKlinesParams {
-  pair: string;
-  contractType: FuturesContractType;
-  interval: KlineInterval;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-}
-⋮----
-export interface IndexPriceKlinesParams {
-  pair: string;
-  interval: KlineInterval;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-}
-⋮----
-export interface SymbolKlinePaginatedParams {
-  symbol: string;
-  interval: KlineInterval;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-}
-⋮----
-export interface FuturesDataPaginatedParams {
-  symbol: string;
-  contractType?: string;
-  period: '5m' | '15m' | '30m' | '1h' | '2h' | '4h' | '6h' | '12h' | '1d';
-  limit?: number;
-  startTime?: number;
-  endTime?: number;
-}
-⋮----
-export interface FuturesCoinMTakerBuySellVolumeParams {
-  pair: string;
-  contractType: 'ALL' | 'CURRENT_QUARTER' | 'NEXT_QUARTER' | 'PERPETUAL';
-  period: '5m' | '15m' | '30m' | '1h' | '2h' | '4h' | '6h' | '12h' | '1d';
-  limit?: number;
-  startTime?: number;
-  endTime?: number;
-}
-⋮----
-export interface FuturesCoinMBasisParams {
-  pair: string;
-  contractType: 'CURRENT_QUARTER' | 'NEXT_QUARTER' | 'PERPETUAL';
-  period: '5m' | '15m' | '30m' | '1h' | '2h' | '4h' | '6h' | '12h' | '1d';
-  limit?: number;
-  startTime?: number;
-  endTime?: number;
-}
-⋮----
-export enum EnumDualSideMode {
-  HedgeMode = 'true',
-  OneWayMode = 'false',
-}
-⋮----
-export type DualSideMode = `${EnumDualSideMode}`;
-⋮----
-export enum EnumMultiAssetMode {
-  MultiAssetsMode = 'true',
-  SingleAssetsMode = 'false',
-}
-⋮----
-export type MultiAssetsMode = `${EnumMultiAssetMode}`;
-⋮----
-export type PositionSide = 'BOTH' | 'LONG' | 'SHORT';
-⋮----
-export type MarginType = 'ISOLATED' | 'CROSSED';
-⋮----
-export type WorkingType = 'MARK_PRICE' | 'CONTRACT_PRICE';
-⋮----
-export type FuturesOrderType =
-  | 'LIMIT'
-  | 'MARKET'
-  | 'STOP'
-  | 'STOP_MARKET'
-  | 'TAKE_PROFIT'
-  | 'TAKE_PROFIT_MARKET'
-  | 'TRAILING_STOP_MARKET';
-⋮----
-export type PriceMatchMode =
-  | 'NONE'
-  | 'OPPONENT'
-  | 'OPPONENT_5'
-  | 'OPPONENT_10'
-  | 'OPPONENT_20'
-  | 'QUEUE'
-  | 'QUEUE_5'
-  | 'QUEUE_10'
-  | 'QUEUE_20';
-⋮----
-// When using the submitMultipleOrders() endpoint, it seems to expect strings instead of numbers. All other endpoints use numbers.
-export interface NewFuturesOrderParams<numberType = number> {
-  symbol: string;
-  side: OrderSide;
-  positionSide?: PositionSide;
-  type: FuturesOrderType;
-  timeInForce?: OrderTimeInForce;
-  quantity?: numberType;
-  reduceOnly?: BooleanString;
-  price?: numberType;
-  newClientOrderId?: string;
-  stopPrice?: numberType;
-  closePosition?: BooleanString;
-  activationPrice?: numberType;
-  callbackRate?: numberType;
-  workingType?: WorkingType;
-  priceProtect?: BooleanStringCapitalised;
-  newOrderRespType?: 'ACK' | 'RESULT';
-  selfTradePreventionMode?: SelfTradePreventionMode;
-  priceMatch?: PriceMatchMode;
-  goodTillDate?: number; // Mandatory when timeInForce is GTD
-}
-⋮----
-goodTillDate?: number; // Mandatory when timeInForce is GTD
-⋮----
-export interface ModifyFuturesOrderParams<numberType = number> {
-  orderId?: number;
-  origClientOrderId?: string;
-  symbol: string;
-  side: OrderSide;
-  quantity?: numberType;
-  price?: numberType;
-  priceMatch?: PriceMatchMode;
-}
-⋮----
-export enum EnumPositionMarginChangeType {
-  AddPositionMargin = 1,
-  ReducePositionMargin = 0,
-}
-⋮----
-export type PositionMarginChangeType = `${EnumPositionMarginChangeType}`;
-⋮----
-export type IncomeType =
-  | 'TRANSFER'
-  | 'WELCOME_BONUS'
-  | 'REALIZED_PNL'
-  | 'FUNDING_FEE'
-  | 'COMMISSION'
-  | 'INSURANCE_CLEAR';
-⋮----
-export interface CancelMultipleOrdersParams {
-  symbol: string;
-  orderIdList?: number[];
-  origClientOrderIdList?: string[];
-}
-⋮----
-export interface CancelOrdersTimeoutParams {
-  symbol: string;
-  countdownTime?: 0 | number;
-}
-⋮----
-export interface SetLeverageParams {
-  symbol: string;
-  leverage: number;
-}
-⋮----
-export interface SetLeverageResult {
-  leverage: number;
-  maxNotionalValue: numberInString;
-  symbol: string;
-}
-⋮----
-export interface SetMarginTypeParams {
-  symbol: string;
-  marginType: MarginType;
-}
-⋮----
-export interface SetIsolatedMarginParams {
-  symbol: string;
-  positionSide?: PositionSide;
-  amount: number;
-  type: PositionMarginChangeType;
-}
-⋮----
-export interface SetIsolatedMarginResult {
-  amount: numberInString;
-  code: 200 | number;
-  msg: string;
-  type: 1 | 2;
-}
-⋮----
-export interface GetPositionMarginChangeHistoryParams {
-  symbol: string;
-  type?: PositionMarginChangeType;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-}
-⋮----
-export interface GetIncomeHistoryParams {
-  symbol?: string;
-  incomeType?: IncomeType;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-  page?: number;
-}
-⋮----
-export interface IncomeHistory {
-  symbol?: string;
-  incomeType: IncomeType;
-  income: string;
-  asset: string;
-  time: number;
-  info: string;
-  tranId: number;
-  tradeId: string;
-}
-⋮----
-export type ForceOrderCloseType = 'LIQUIDATION' | 'ADL';
-⋮----
-export interface GetForceOrdersParams {
-  symbol?: string;
-  autoCloseType?: ForceOrderCloseType;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-}
-⋮----
-export type ContactType =
-  | 'PERPETUAL'
-  | 'CURRENT_MONTH'
-  | 'NEXT_MONTH'
-  | 'CURRENT_QUARTER'
-  | 'NEXT_QUARTER';
-⋮----
-export type ContractStatus =
-  | 'PENDING_TRADING'
-  | 'TRADING'
-  | 'PRE_DELIVERING'
-  | 'DELIVERING'
-  | 'DELIVERED'
-  | 'CANCELLED'
-  | 'PRE_SETTLE'
-  | 'SETTLING'
-  | 'CLOSE';
-⋮----
-export interface FuturesSymbolPercentPriceFilter {
-  filterType: 'PERCENT_PRICE';
-  multiplierUp: numberInString;
-  multiplierDown: numberInString;
-  multiplierDecimal: numberInString;
-}
-⋮----
-export interface FuturesSymbolMaxOrdersFilter {
-  filterType: 'MAX_NUM_ORDERS';
-  limit: number;
-}
-⋮----
-export interface FuturesSymbolMaxAlgoOrdersFilter {
-  filterType: 'MAX_NUM_ALGO_ORDERS';
-  limit: number;
-}
-⋮----
-export interface FuturesSymbolMinNotionalFilter {
-  filterType: 'MIN_NOTIONAL';
-  notional: numberInString;
-}
-⋮----
-export type FuturesSymbolFilter =
-  | SymbolPriceFilter
-  | FuturesSymbolPercentPriceFilter
-  | SymbolLotSizeFilter
-  | FuturesSymbolMinNotionalFilter
-  | SymbolIcebergPartsFilter
-  | SymbolMarketLotSizeFilter
-  | FuturesSymbolMaxOrdersFilter
-  | FuturesSymbolMaxAlgoOrdersFilter
-  | SymbolMaxIcebergOrdersFilter
-  | SymbolMaxPositionFilter;
-⋮----
-export interface FuturesSymbolExchangeInfo {
-  symbol: string;
-  pair: string;
-  contractType: ContactType;
-  deliveryDate: number;
-  onboardDate: number;
-  status: ContractStatus;
-  maintMarginPercent: numberInString;
-  requiredMarginPercent: numberInString;
-  baseAsset: string;
-  quoteAsset: string;
-  marginAsset: string;
-  pricePrecision: number;
-  quantityPrecision: number;
-  baseAssetPrecision: number;
-  quotePrecision: number;
-  underlyingType: 'COIN' | 'INDEX'; // No other known values
-  underlyingSubType: string[]; // DEFI / NFT / BSC / HOT / etc
-  settlePlan: number;
-  triggerProtect: numberInString;
-  filters: FuturesSymbolFilter[];
-  OrderType: OrderType[];
-  timeInForce: OrderTimeInForce[];
-  liquidationFee: numberInString;
-  marketTakeBound: numberInString;
-  contractSize?: number;
-}
-⋮----
-underlyingType: 'COIN' | 'INDEX'; // No other known values
-underlyingSubType: string[]; // DEFI / NFT / BSC / HOT / etc
-⋮----
-export interface FuturesExchangeInfo {
-  exchangeFilters: ExchangeFilter[];
-  rateLimits: RateLimiter[];
-  serverTime: number;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  assets: any[];
-  symbols: FuturesSymbolExchangeInfo[];
-  timezone: string;
-}
-⋮----
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-⋮----
-export interface FuturesOrderBook {
-  lastUpdateId: number;
-  E: number;
-  T: number;
-  bids: OrderBookRow[];
-  asks: OrderBookRow[];
-}
-⋮----
-export interface RawFuturesTrade {
-  id: number;
-  price: numberInString;
-  qty: numberInString;
-  quoteQty: numberInString;
-  time: number;
-  isBuyerMaker: boolean;
-}
-⋮----
-export interface AggregateFuturesTrade {
-  a: number;
-  p: numberInString;
-  q: numberInString;
-  f: number;
-  l: number;
-  T: number;
-  m: boolean;
-}
-⋮----
-export interface MarkPrice {
-  symbol: string;
-  markPrice: numberInString;
-  indexPrice: numberInString;
-  estimatedSettlePrice: numberInString;
-  lastFundingRate: numberInString;
-  interestRate: numberInString;
-  nextFundingTime: number;
-  time: number;
-}
-⋮----
-export interface FundingRateHistory {
-  symbol: string;
-  fundingRate: numberInString;
-  fundingTime: number;
-  markPrice: numberInString;
-}
-⋮----
-export interface FuturesSymbolOrderBookTicker {
-  symbol: string;
-  bidPrice: numberInString;
-  bidQty: numberInString;
-  askPrice: numberInString;
-  askQty: numberInString;
-  time: number;
-}
-⋮----
-export interface OpenInterest {
-  openInterest: numberInString;
-  symbol: string;
-  time: number;
-}
-⋮----
-export interface HistoricOpenInterest {
-  symbol: string;
-  sumOpenInterest: string;
-  sumOpenInterestValue: string;
-  CMCCirculatingSupply: string;
-  timestamp: number;
-}
-⋮----
-export interface PositionModeParams {
-  dualSidePosition: DualSideMode;
-}
-⋮----
-export interface ModeChangeResult {
-  code: 200 | number;
-  msg: 'success' | string;
-}
-⋮----
-export interface PositionModeResponse {
-  dualSidePosition: boolean;
-}
-⋮----
-export interface MultiAssetModeResponse {
-  multiAssetsMargin: boolean;
-}
-⋮----
-export interface NewOrderResult {
-  clientOrderId: string;
-  cumQty: numberInString;
-  cumQuote: numberInString;
-  executedQty: numberInString;
-  orderId: number;
-  avgPrice: numberInString;
-  origQty: numberInString;
-  price: numberInString;
-  reduceOnly: boolean;
-  side: OrderSide;
-  positionSide: PositionSide;
-  status: OrderStatus;
-  stopPrice: numberInString;
-  closePosition: boolean;
-  symbol: string;
-  timeInForce: OrderTimeInForce;
-  type: FuturesOrderType;
-  origType: FuturesOrderType;
-  activatePrice: numberInString;
-  priceRate: numberInString;
-  updateTime: number;
-  workingType: WorkingType;
-  priceProtect: boolean;
-  selfTradePreventionMode: SelfTradePreventionMode;
-  priceMatch: PriceMatchMode;
-}
-⋮----
-export interface NewOrderError {
-  code: number;
-  msg: string;
-}
-⋮----
-export interface OrderResult {
-  avgPrice: numberInString;
-  clientOrderId: string;
-  cumQuote: numberInString;
-  executedQty: numberInString;
-  orderId: number;
-  origQty: numberInString;
-  origType: FuturesOrderType;
-  price: numberInString;
-  reduceOnly: boolean;
-  side: OrderSide;
-  positionSide: PositionSide;
-  status: OrderStatus;
-  stopPrice: numberInString;
-  closePosition: boolean;
-  symbol: string;
-  time: number;
-  timeInForce: OrderTimeInForce;
-  type: FuturesOrderType;
-  activatePrice: numberInString;
-  priceRate: numberInString;
-  updateTime: number;
-  workingType: WorkingType;
-  priceProtect: boolean;
-  selfTradePreventionMode: SelfTradePreventionMode;
-  priceMatch: PriceMatchMode;
-  goodTillDate: number;
-}
-⋮----
-export interface ModifyFuturesOrderResult {
-  orderId: number;
-  symbol: string;
-  pair: string;
-  status: OrderStatus;
-  clientOrderId: string;
-  price: numberInString;
-  avgPrice: numberInString;
-  origQty: numberInString;
-  executedQty: numberInString;
-  cumQty: numberInString;
-  cumBase: numberInString;
-  timeInForce: OrderTimeInForce;
-  type: FuturesOrderType;
-  reduceOnly: boolean;
-  closePosition: boolean;
-  side: OrderSide;
-  positionSide: PositionSide;
-  stopPrice: numberInString;
-  workingType: WorkingType;
-  priceProtect: boolean;
-  origType: FuturesOrderType;
-  updateTime: number;
-  selfTradePreventionMode: SelfTradePreventionMode;
-  priceMatch: PriceMatchMode;
-}
-⋮----
-export interface CancelFuturesOrderResult {
-  clientOrderId: string;
-  cumQty: numberInString;
-  cumQuote: numberInString;
-  executedQty: numberInString;
-  orderId: number;
-  origQty: numberInString;
-  origType: FuturesOrderType;
-  price: numberInString;
-  reduceOnly: boolean;
-  side: OrderSide;
-  positionSide: PositionSide;
-  status: OrderStatus;
-  stopPrice: numberInString;
-  closePosition: boolean;
-  symbol: string;
-  timeInForce: OrderTimeInForce;
-  type: FuturesOrderType;
-  activatePrice: numberInString;
-  priceRate: numberInString;
-  updateTime: number;
-  workingType: WorkingType;
-  priceProtect: boolean;
-  selfTradePreventionMode: SelfTradePreventionMode;
-  priceMatch: PriceMatchMode;
-}
-⋮----
-export interface CancelAllOpenOrdersResult {
-  code: 200 | numberInString;
-  msg: string;
-}
-⋮----
-export interface FuturesAccountBalance {
-  accountAlias: string;
-  asset: string;
-  balance: numberInString;
-  crossWalletBalance: numberInString;
-  crossUnPnl: numberInString;
-  availableBalance: numberInString;
-  maxWithdrawAmount: numberInString;
-  marginAvailable: boolean;
-  updateTime: numberInString;
-}
-⋮----
-export interface FuturesCoinMAccountBalance {
-  accountAlias: string;
-  asset: string;
-  balance: numberInString;
-  withdrawAvailable: numberInString;
-  crossWalletBalance: numberInString;
-  crossUnPnl: numberInString;
-  availableBalance: numberInString;
-  updateTime: number;
-}
-⋮----
-export interface FuturesAccountAsset {
-  asset: string;
-  walletBalance: numberInString;
-  unrealizedProfit: numberInString;
-  marginBalance: numberInString;
-  maintMargin: numberInString;
-  initialMargin: numberInString;
-  positionInitialMargin: numberInString;
-  openOrderInitialMargin: numberInString;
-  maxWithdrawAmount: numberInString;
-  crossWalletBalance: numberInString;
-  crossUnPnl: numberInString;
-  availableBalance: numberInString;
-  marginAvailable: boolean;
-  updateTime: number;
-}
-⋮----
-export interface FuturesAccountPosition {
-  symbol: string;
-  initialMargin: numberInString;
-  maintMargin: numberInString;
-  unrealizedProfit: numberInString;
-  positionInitialMargin: numberInString;
-  openOrderInitialMargin: numberInString;
-  leverage: numberInString;
-  isolated: boolean;
-  entryPrice: numberInString;
-  maxNotional: numberInString;
-  positionSide: PositionSide;
-  positionAmt: numberInString;
-  notional: numberInString;
-  isolatedWallet: numberInString;
-  updateTime: number;
-  bidNotional: numberInString;
-  askNotional: numberInString;
-}
-⋮----
-export interface FuturesCoinMAccountPosition {
-  symbol: string;
-  positionAmt: numberInString;
-  initialMargin: numberInString;
-  maintMargin: numberInString;
-  unrealizedProfit: numberInString;
-  positionInitialMargin: numberInString;
-  openOrderInitialMargin: numberInString;
-  leverage: numberInString;
-  isolated: boolean;
-  positionSide: PositionSide;
-  entryPrice: numberInString;
-  maxQty: numberInString;
-  updateTime: number;
-}
-⋮----
-export interface FuturesAccountInformation {
-  feeTier: numberInString;
-  canTrade: boolean;
-  canDeposit: boolean;
-  canWithdraw: boolean;
-  updateTime: numberInString;
-  multiAssetsMargin: boolean;
-  totalInitialMargin: numberInString;
-  totalMaintMargin: numberInString;
-  totalWalletBalance: numberInString;
-  totalUnrealizedProfit: numberInString;
-  totalMarginBalance: numberInString;
-  totalPositionInitialMargin: numberInString;
-  totalOpenOrderInitialMargin: numberInString;
-  totalCrossWalletBalance: numberInString;
-  totalCrossUnPnl: numberInString;
-  availableBalance: numberInString;
-  maxWithdrawAmount: numberInString;
-  assets: FuturesAccountAsset[];
-  positions: FuturesAccountPosition[];
-}
-⋮----
-export interface FuturesCoinMAccountInformation {
-  assets: Omit<FuturesAccountAsset, 'marginAvailable'>[];
-  positions: FuturesCoinMAccountPosition[];
-  canTrade: boolean;
-  canDeposit: boolean;
-  canWithdraw: boolean;
-  feeTier: number;
-  updateTime: number;
-}
-⋮----
-export interface FuturesPosition {
-  entryPrice: numberInString;
-  marginType: 'isolated' | 'cross';
-  isAutoAddMargin: 'false' | 'true';
-  isolatedMargin: numberInString;
-  leverage: numberInString;
-  liquidationPrice: numberInString;
-  markPrice: numberInString;
-  maxNotionalValue: numberInString;
-  positionAmt: numberInString;
-  notional: numberInString;
-  isolatedWallet: numberInString;
-  symbol: string;
-  unRealizedProfit: numberInString;
-  positionSide: PositionSide;
-  updateTime: number;
-}
-⋮----
-export interface FuturesPositionV3 {
-  symbol: string;
-  positionSide: PositionSide;
-  positionAmt: numberInString;
-  entryPrice: numberInString;
-  breakEvenPrice: numberInString;
-  markPrice: numberInString;
-  unRealizedProfit: numberInString;
-  liquidationPrice: numberInString;
-  isolatedMargin: numberInString;
-  notional: numberInString;
-  marginAsset: string;
-  isolatedWallet: numberInString;
-  initialMargin: numberInString;
-  maintMargin: numberInString;
-  positionInitialMargin: numberInString;
-  openOrderInitialMargin: numberInString;
-  adl: number;
-  bidNotional: numberInString;
-  askNotional: numberInString;
-  updateTime: number;
-}
-⋮----
-export interface FuturesPositionTrade {
-  buyer: boolean;
-  commission: numberInString;
-  commissionAsset: string;
-  id: number;
-  maker: boolean;
-  orderId: number;
-  price: numberInString;
-  qty: numberInString;
-  quoteQty: numberInString;
-  realizedPnl: numberInString;
-  side: OrderSide;
-  positionSide: PositionSide;
-  symbol: string;
-  time: number;
-}
-⋮----
-export interface ForceOrderResult {
-  orderId: number;
-  symbol: string;
-  status: OrderStatus;
-  clientOrderId: string;
-  price: numberInString;
-  avgPrice: numberInString;
-  origQty: numberInString;
-  executedQty: numberInString;
-  cumQuote: numberInString;
-  timeInForce: OrderTimeInForce;
-  type: FuturesOrderType;
-  reduceOnly: boolean;
-  closePosition: boolean;
-  side: OrderSide;
-  stopPrice: numberInString;
-  workingType: WorkingType;
-  origType: FuturesOrderType;
-  time: number;
-  updateTime: number;
-}
-⋮----
-export interface SymbolLeverageBracket {
-  bracket: number;
-  initialLeverage: number;
-  notionalCap: number;
-  notionalFloor: number;
-  maintMarginRatio: number;
-  cum: number;
-}
-⋮----
-export interface SymbolLeverageBracketsResult {
-  symbol: string;
-  brackets: SymbolLeverageBracket[];
-}
-⋮----
-export interface UserCommissionRate {
-  symbol: string;
-  makerCommissionRate: numberInString;
-  takerCommissionRate: numberInString;
-  rpiCommissionRate?: numberInString;
-}
-⋮----
-export interface FuturesAccountConfig {
-  feeTier: number;
-  canTrade: boolean;
-  canDeposit: boolean;
-  canWithdraw: boolean;
-  dualSidePosition: boolean;
-  updateTime: number;
-  multiAssetsMargin: boolean;
-  tradeGroupId: number;
-}
-⋮----
-export interface SymbolConfig {
-  symbol: string;
-  marginType: string;
-  isAutoAddMargin: string;
-  leverage: number;
-  maxNotionalValue: string;
-}
-⋮----
-export interface UserForceOrder {
-  rateLimitType: string;
-  interval: string;
-  intervalNum: number;
-  limit: number;
-}
-⋮----
-export interface RebateDataOverview {
-  brokerId: string;
-  newTraderRebateCommission: numberInString;
-  oldTraderRebateCommission: numberInString;
-  totalTradeUser: number;
-  unit: string;
-  totalTradeVol: numberInString;
-  totalRebateVol: numberInString;
-  time: number;
-}
-⋮----
-export interface SetCancelTimeoutResult {
-  symbol: string;
-  countdownTime: numberInString;
-}
-⋮----
-export interface ChangeStats24hr {
-  symbol: string;
-  priceChange: numberInString;
-  priceChangePercent: numberInString;
-  weightedAvgPrice: numberInString;
-  lastPrice: numberInString;
-  lastQty: numberInString;
-  openPrice: numberInString;
-  highPrice: numberInString;
-  lowPrice: numberInString;
-  volume: numberInString;
-  quoteVolume: numberInString;
-  openTime: number;
-  closeTime: number;
-  firstId: number; // First tradeId
-  lastId: number; // Last tradeId
-  count: number;
-}
-⋮----
-firstId: number; // First tradeId
-lastId: number; // Last tradeId
-⋮----
-export interface OrderAmendmentDetailPrice {
-  before: numberInString;
-  after: numberInString;
-}
-⋮----
-export interface OrderAmendmentDetailQty {
-  before: numberInString;
-  after: numberInString;
-}
-⋮----
-export interface OrderAmendmentDetail {
-  price: OrderAmendmentDetailPrice;
-  origQty: OrderAmendmentDetailQty;
-  count: number;
-}
-⋮----
-export interface OrderAmendment {
-  amendmentId: number;
-  symbol: string;
-  pair: string;
-  orderId: number;
-  clientOrderId: string;
-  time: number;
-  amendment: OrderAmendmentDetail;
-}
-⋮----
-export interface QuarterlyContractSettlementPrice {
-  deliveryTime: number;
-  deliveryPrice: number;
-}
-⋮----
-export interface BasisParams {
-  pair: string;
-  contractType: 'CURRENT_QUARTER' | 'NEXT_QUARTER' | 'PERPETUAL';
-  period: '5m' | '15m' | '30m' | '1h' | '2h' | '4h' | '6h' | '12h' | '1d';
-  limit: number;
-  startTime?: number;
-  endTime?: number;
-}
-⋮----
-export interface Basis {
-  indexPrice: string;
-  contractType: string;
-  basisRate: string;
-  futuresPrice: string;
-  annualizedBasisRate: string;
-  basis: string;
-  pair: string;
-  timestamp: number;
-}
-⋮----
-export interface IndexPriceConstituent {
-  exchange: string;
-  symbol: string;
-  price: numberInString;
-  weight: numberInString;
-}
-⋮----
-export interface IndexPriceConstituents {
-  symbol: string;
-  time: number;
-  constituents: IndexPriceConstituent[];
-}
-⋮----
-export interface InsuranceFundBalance {
-  symbols: string[];
-  assets: {
-    asset: string;
-    marginBalance: string;
-    updateTime: number;
-  }[];
-}
-⋮----
-export interface ModifyOrderParams {
-  orderId?: number;
-  origClientOrderId?: string;
-  symbol: string;
-  side: 'SELL' | 'BUY';
-  quantity: string;
-  price: string;
-  priceMatch?:
-    | 'OPPONENT'
-    | 'OPPONENT_5'
-    | 'OPPONENT_10'
-    | 'OPPONENT_20'
-    | 'QUEUE'
-    | 'QUEUE_5'
-    | 'QUEUE_10'
-    | 'QUEUE_20';
-  recvWindow?: number;
-  timestamp: number;
-}
-⋮----
-export interface GetFuturesOrderModifyHistoryParams {
-  symbol: string;
-  orderId?: number;
-  origClientOrderId?: string;
-  startTime?: number;
-  endTime?: number;
-  limit?: number;
-}
-⋮----
-export interface FuturesTradeHistoryDownloadId {
-  avgCostTimestampOfLast30d: number;
-  downloadId: string;
-}
-⋮----
-export interface FuturesTransactionDownloadLink {
-  downloadId: string;
-  status: 'completed' | 'processing';
-  url: string;
-  expirationTimestamp: number;
-  isExpired: boolean | null;
-}
-⋮----
-export interface PortfolioMarginProAccountInfo {
-  maxWithdrawAmountUSD: string;
-  asset: string;
-  maxWithdrawAmount: string; // This field will be ignored in the response
-}
-⋮----
-maxWithdrawAmount: string; // This field will be ignored in the response
-⋮----
-export interface FuturesConvertPair {
-  fromAsset: string;
-  toAsset: string;
-  fromAssetMinAmount: string;
-  fromAssetMaxAmount: string;
-  toAssetMinAmount: string;
-  toAssetMaxAmount: string;
-}
-⋮----
-export interface FuturesConvertQuoteRequest {
-  fromAsset: string;
-  toAsset: string;
-  fromAmount?: number;
-  toAmount?: number;
-  validTime?: '10s' | '30s' | '1m' | '2m';
-}
-⋮----
-export interface FuturesConvertQuote {
-  quoteId: string;
-  ratio: string;
-  inverseRatio: string;
-  validTimestamp: number;
-  toAmount: string;
-  fromAmount: string;
-}
-⋮----
-export interface FuturesConvertOrderStatus {
-  orderId: string;
-  orderStatus: 'PROCESS' | 'ACCEPT_SUCCESS' | 'SUCCESS' | 'FAIL';
-  fromAsset: string;
-  fromAmount: string;
-  toAsset: string;
-  toAmount: string;
-  ratio: string;
-  inverseRatio: string;
-  createTime: number;
-}
-⋮----
-/**
- * Algo Order Types (Effective 2025-12-02)
- * USDⓈ-M Futures conditional orders migrate to Algo Service
- */
-⋮----
-export type FuturesAlgoOrderType = 'CONDITIONAL';
-⋮----
-export type FuturesAlgoConditionalOrderTypes =
-  | 'STOP_MARKET'
-  | 'TAKE_PROFIT_MARKET'
-  | 'STOP'
-  | 'TAKE_PROFIT'
-  | 'TRAILING_STOP_MARKET';
-⋮----
-/**
- * Ref: https://developers.binance.com/docs/derivatives/usds-margined-futures/user-data-streams/Event-Algo-Order-Update
- */
-export type FuturesAlgoOrderStatus =
-  | 'NEW'
-  | 'CANCELED'
-  | 'TRIGGERING'
-  | 'TRIGGERED'
-  | 'FINISHED'
-  | 'REJECTED'
-  | 'EXPIRED';
-⋮----
-export interface FuturesNewAlgoOrderParams {
-  algoType: FuturesAlgoOrderType;
-  symbol: string;
-  side: OrderSide;
-  positionSide?: PositionSide;
-  type: FuturesAlgoConditionalOrderTypes;
-  timeInForce?: OrderTimeInForce;
-  quantity?: numberInString;
-  price?: numberInString;
-  triggerPrice?: numberInString;
-  workingType?: WorkingType;
-  priceMatch?: PriceMatchMode;
-  closePosition?: BooleanString;
-  priceProtect?: BooleanString;
-  reduceOnly?: BooleanString;
-  activatePrice?: numberInString;
-  callbackRate?: numberInString;
-  clientAlgoId?: string; // ^[\.A-Z\:/a-z0-9_-]{1,36}$
-  selfTradePreventionMode?: SelfTradePreventionMode;
-  goodTillDate?: number;
-}
-⋮----
-clientAlgoId?: string; // ^[\.A-Z\:/a-z0-9_-]{1,36}$
-⋮----
-export interface FuturesAlgoOrderResponse {
-  algoId: number;
-  clientAlgoId: string;
-  algoType: FuturesAlgoOrderType;
-  orderType: FuturesAlgoConditionalOrderTypes;
-  symbol: string;
-  side: OrderSide;
-  positionSide: PositionSide;
-  timeInForce: OrderTimeInForce;
-  quantity: numberInString;
-  algoStatus: FuturesAlgoOrderStatus;
-  triggerPrice?: numberInString;
-  price?: numberInString;
-  icebergQuantity: numberInString | null;
-  selfTradePreventionMode: SelfTradePreventionMode;
-  workingType: WorkingType;
-  priceMatch: PriceMatchMode;
-  closePosition: boolean;
-  priceProtect: boolean;
-  reduceOnly: boolean;
-  activatePrice?: numberInString;
-  callbackRate?: numberInString;
-  createTime: number;
-  updateTime: number;
-  triggerTime: number;
-  goodTillDate: number;
-}
-⋮----
-export interface FuturesCancelAlgoOrderParams {
-  algoId?: number;
-  clientAlgoId?: string;
-}
-⋮----
-export interface FuturesCancelAlgoOrderResponse {
-  algoId: number;
-  clientAlgoId: string;
-  code: string;
-  msg: string;
-}
-⋮----
-export interface FuturesCancelAllAlgoOpenOrdersResponse {
-  code: number;
-  msg: string;
-}
-⋮----
-export interface FuturesQueryAlgoOrderParams {
-  algoId?: number;
-  clientAlgoId?: string;
-}
-⋮----
-export interface FuturesQueryAlgoOrderResponse
-  extends FuturesAlgoOrderResponse {
-  actualOrderId: numberInString;
-  actualPrice: numberInString;
-  tpTriggerPrice?: numberInString;
-  tpPrice?: numberInString;
-  slTriggerPrice?: numberInString;
-  slPrice?: numberInString;
-  tpOrderType?: string;
-}
-⋮----
-export interface FuturesQueryOpenAlgoOrdersParams {
-  algoType?: FuturesAlgoOrderType;
-  symbol?: string;
-  algoId?: number;
-}
-⋮----
-export interface FuturesQueryAllAlgoOrdersParams {
-  symbol: string;
-  algoId?: number;
-  startTime?: number;
-  endTime?: number;
-  page?: number;
-  limit?: number; // Default 500; max 1000
-}
-⋮----
-limit?: number; // Default 500; max 1000
-⋮----
-export interface SymbolAdlRisk {
-  symbol: string;
-  adlRisk: 'low' | 'medium' | 'high';
-  updateTime: number;
-}
-⋮----
-export interface TradingSession {
-  startTime: number;
-  endTime: number;
-  type: 'PRE_MARKET' | 'REGULAR' | 'AFTER_MARKET' | 'OVERNIGHT' | 'NO_TRADING';
-}
-⋮----
-export interface MarketSchedule {
-  sessions: TradingSession[];
-}
-⋮----
-export interface TradingSchedule {
-  updateTime: number;
-  marketSchedules: {
-    EQUITY?: MarketSchedule;
-    COMMODITY?: MarketSchedule;
-  };
-}
-⋮----
-export interface RpiOrderBook {
-  lastUpdateId: number;
-  E: number; // Message output time
-  T: number; // Transaction time
-  bids: [numberInString, numberInString][];
-  asks: [numberInString, numberInString][];
-}
-⋮----
-E: number; // Message output time
-T: number; // Transaction time
+Found something difficult to implement? Contribute to these examples and help others!
 
-================
-File: src/index.ts
-================
+## Getting started
+
+- Clone the project (or download it as a zip, or install the module in your own project `npm install binance`).
+- Edit the sample as needed (some samples require edits, e.g API keys or import statements to import from npm, not src).
+- Execute the sample using tsx: `tsx examples/REST/rest-spot-public.ts`.
+
+Samples that refer to API credentials using `process.env.API_KEY_COM` can be spawned with environment variables. Unix/macOS example:
+```
+API_KEY_COM='apikeypastedhere' API_SECRET_COM='apisecretpastedhere' tsx "examples/WebSockets/Private(userdata)/ws-userdata-listenkey.ts"
+```
+
+Or edit the example directly to hardcode your API keys.
+
+### WebSockets
+
+All examples relating to WebSockets can be found in the [examples/WebSockets](./WebSockets/) folder. High level summary of available examples:
+
+#### Consumers
+
+These are purely for receiving data from Binance's WebSockets (market data, account updates, etc).
+
+##### Market Data
+
+These examples demonstrate subscribing to & receiving market data from Binance's WebSockets:
+
+- ws-public.ts
+  - Demonstration on general usage of the WebSocket client to subscribe to / unsubscribe from one or more market data topics.
+- ws-public-spot-orderbook.ts
+  - Subscribing to orderbook events for multiple symbols in spot markets.
+-	ws-public-spot-trades.ts
+  - Subscribing to raw trades for multiple symbols in spot markets.
+- ws-unsubscribe.ts
+  - Subscribing to a list of topics, and then unsubscribing from a few topics in that list.
+- ws-public-usdm-funding.ts
+  - Simple example subscribing to a general topic, and how to process incoming events to only extract funding rates from those events.
+
+##### Account Data
+
+These examples demonstrate receiving account update events from Binance's WebSockets:
+
+-	ws-userdata-listenkey.ts
+  - Demonstration on subscribing to various user data streams (spot, margin, futures),
+  - Handling incoming user data events
+  - Using provided type guards to determine which product group the user data event is for (spot, margin, futures, etc).
+- ws-userdata-listenKey-testnet.ts
+  - Similar to above, but on testnet.
+- ws-userdata-connection-safety.ts
+  - Demonstration on extra safety around the first user data stream connection.
+  - Note: this is overkill in most situations...
+
+##### WebSocket API
+
+These examples demonstrate how to send commands using Binance's WebSocket API (e.g. submitting orders). Very similar to the REST API, but using a persisted WebSocket connection instead of HTTP requests.
+
+- ws-api-client.ts
+  - Demonstration of using Binance's WebSocket API in Node.js/JavaScript/TypeScript, using the WebsocketAPIClient.
+  - This WebsocketAPIClient is very similar to a REST client, with one method per available command (endpoint) and fully typed requests & responses.
+  - Routing is automatically handled via the WebsocketClient, including authentication and connection persistence. Just call the functions you need - the SDK does the rest.
+  - From a usage perspective, it feels like a REST API - you can await responses just like a HTTP request.
+- ws-api-raw-promises.ts
+  - More verbose usage of the WebSocket API using the `sendWSAPIRequest()` method.
+  - The `WebsocketAPIClient` uses this method too, so in most cases it is simple to just use the `WebsocketAPIClient` instead.
+- ws-userdata-wsapi.ts
+  - The listenKey workflow for the user data stream is deprecated (in spot markets).
+  - This example demonstrates how to subscribe to the user data stream in spot markets, without a listen key, using the WebSocket API.
+
+##### Misc Workflows
+
+These are miscellaneous examples that cover one or more of the above categories:
+
+- ws-close.ts
+  - Closing the (old listen-key driven) user data stream.
+  - Unsubscribing from various topics.
+- ws-proxy-socks.ts
+  - Using WebSockets over a SOCKS proxy.
+- deprecated-ws-public.ts
 
 
-================
-File: webpack/webpack.config.js
-================
-function generateConfig(name)
-⋮----
-// Add '.ts' and '.tsx' as resolvable extensions.
-⋮----
-// Node.js core modules not available in browsers
-// The REST client's https.Agent (for keepAlive) is Node.js-only and won't work in browsers
-⋮----
-// All files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'.
-⋮----
-// All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
-⋮----
-// new webpack.DefinePlugin({
-//   'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
-// }),
+### REST APIs
 
-================
-File: .gitignore
-================
-.vscode/
-.idea/
-.nyc_output/
-node_modules/
-util/config.js
-coverage/
-yarn-error.log
-lib/*
-testfile.ts
-privaterepotracker
-restClientRegex.ts
-.DS_Store
-dist
-localtest.ts
-repomix.sh
-doc
-*.pem
+All examples relating to REST APIs can be found in the [examples/REST](./REST/) folder. Most examples are named around functionality & product group. Any examples with "private" involve API calls relating to your account (such as changing settings or submitting orders, etc),
 
-================
-File: .nvmrc
-================
-v24.14.1
+High level summary for some of the available examples, but check the folder for a complete list:
+
+#### REST USDM Examples
+
+- `rest-future-bracket-order.ts` Creates an entry order plus a passive reduce-only TP limit order and an SL Algo Service order.
+- `rest-usdm-order.ts` Creates a single entry order using `submitNewOrder`.
+- `rest-usdm-order-sl.ts` Modifies a Hedge Mode LONG stop-loss order using Algo Service orders.
 
 ================
 File: src/types/websockets/ws-events-formatted.ts
@@ -10920,894 +9024,3680 @@ private validateOrderId(
 ): void
 
 ================
-File: examples/WebSockets/Private(userdata)/ws-userdata-listenkey.ts
+File: .nvmrc
 ================
-// or
-// import {
-//   DefaultLogger,
-//   isWsFormattedFuturesUserDataEvent,
-//   isWsFormattedSpotUserDataEvent,
-//   isWsFormattedSpotUserDataExecutionReport,
-//   isWsFormattedUserDataEvent,
-//   WebsocketClient,
-//   WsUserDataEvents,
-// } from 'binance';
-⋮----
-import {
-  DefaultLogger,
-  isWsFormattedFuturesUserDataEvent,
-  isWsFormattedSpotUserDataEvent,
-  isWsFormattedSpotUserDataExecutionReport,
-  isWsFormattedUserDataEvent,
-  WebsocketClient,
-  WsConnectionStateEnum,
-  WsUserDataEvents,
-} from '../../../src/index';
-⋮----
-// Optional, hook and customise logging behavior
-⋮----
-// testnet: true,
-⋮----
-// wsClient.on('message', (data) => {
-//   console.log('raw message received ', JSON.stringify(data, null, 2));
-// });
-⋮----
-function onUserDataEvent(data: WsUserDataEvents)
-⋮----
-// the market denotes which API category it came from
-// if (data.wsMarket.includes('spot')) {
-⋮----
-// or use a type guard, if one exists (PRs welcome)
-⋮----
-// The wsKey can be parsed to determine the type of message (what websocket it came from)
-// if (!Array.isArray(data) && data.wsKey.includes('userData')) {
-//   return onUserDataEvent(data);
-// }
-⋮----
-// or use a type guard if available
-⋮----
-// response to command sent via WS stream (e.g LIST_SUBSCRIPTIONS)
-⋮----
-// This is a good place to check your own state is still in sync with the account state on the exchange, in case any events were missed while the library was reconnecting:
-// - fetch balances
-// - fetch positions
-// - fetch orders
-⋮----
-/**
-   * This example demonstrates subscribing to the user data stream via the
-   * listen key workflow.
-   *
-   * Note: the listen key workflow is deprecated for "spot" markets. Use the
-   * WebSocket API `userDataStream.subscribe` workflow instead (only available
-   * in spot right now). See `subscribeUserDataStream()` in the WebsocketAPIClient.
-   *
-   * Each method below opens a dedicated WS connection attached to an automatically
-   * fetched listen key (a session for your user data stream).
-   *
-   * Once subscribed, you don't need to do anything else. Listen-key keep-alive, refresh, reconnects, etc are all automatically handled by the SDK.
-   */
-⋮----
-/**
-   * Note: for spot markets, the listen key workflow is deprecated. Use the
-   * WebSocket API `userDataStream.subscribe` workflow instead (only available
-   * in spot right now). See `subscribeUserDataStream()` in the WebsocketAPIClient.
-   */
-// Deprecated, see above: wsClient.subscribeSpotUserDataStream();
-// Deprecated, see above: wsClient.subscribeSpotUserDataStream('main2');
-// Deprecated, see above: wsClient.subscribeCrossMarginUserDataStream();
-// Deprecated, see above: wsClient.subscribeIsolatedMarginUserDataStream('BTCUSDC');
-⋮----
-/**
-   * Futures
-   */
-⋮----
-// Example 5: usdm futures
-⋮----
-// Example 6: coinm futures
-⋮----
-// Example 7: portfolio margin
-⋮----
-// Example 8: portfolio margin pro
-⋮----
-// after 15 seconds, kill user data connections one by one (or all at once)
-⋮----
-// console.log('killing all connections at once');
-// wsClient.closeAll();
-⋮----
-// or:
-⋮----
-// console.log('killing all connections');
-// wsClient.closeAll();
-// Example 5: usdm futures
-⋮----
-// Example 6: coinm futures
-⋮----
-// // Example 7: portfolio margin
-// wsClient.unsubscribePortfolioMarginUserDataStream();
-// // Example 8: portfolio margin pro
-// wsClient.unsubscribePortfolioMarginUserDataStream(
-//   'portfolioMarginProUserData',
-// );
-⋮----
-// after 20 seconds, list the remaining open connections
+v24.14.1
 
 ================
-File: examples/WebSockets/Private(userdata)/ws-userdata-wsapi.ts
+File: docs/BINANCE_SDK_QUICKSTART_GUIDE.md
 ================
-/* eslint-disable @typescript-eslint/no-unused-vars */
-// or
-// import { WebsocketAPIClient, WebsocketClient, WS_KEY_MAP } from 'binance';
-// or
-// const { WebsocketAPIClient, WebsocketClient, WS_KEY_MAP } = require('binance');
-⋮----
-import {
-  DefaultLogger,
-  isWsFormattedFuturesUserDataEvent,
-  isWsFormattedSpotBalanceUpdate,
-  isWsFormattedSpotOutboundAccountPosition,
-  isWsFormattedSpotUserDataEvent,
-  isWsFormattedUserDataEvent,
-  WebsocketAPIClient,
-  WebsocketClient,
-  WS_KEY_MAP,
-} from '../../../src';
-⋮----
-/**
- * Note: the WebSocket API is fastest with Ed25519 keys. HMAC & RSA will
- * require each command to be individually signed.
- *
- * Check the rest-private-ed25519.md in this folder for more guidance
- * on preparing this Ed25519 API key.
- */
-⋮----
-// returned by binance, generated using the publicKey (above)
-// const key = 'BVv39ATnIme5TTZRcC3I04C3FqLVM7vCw3Hf7mMT7uu61nEZK8xV1V5dmhf9kifm';
-// Your Ed25519 private key is passed as the "secret"
-// const secret = privateKey;
-⋮----
-function attachEventHandlers<TWSClient extends WebsocketClient>(
-  wsClient: TWSClient,
-): void
-⋮----
-/**
-   * General event handlers for monitoring the WebsocketClient
-   */
-⋮----
-// Raw events received from binance, as is:
-⋮----
-// console.log('raw message received ', JSON.stringify(data));
-⋮----
-// Formatted events from the built-in beautifier, with fully readable property names and parsed floats:
-⋮----
-// We've included type guards for many events, especially on the user data stream, to help easily
-// identify events using simple `if` checks.
-//
-// Use `if` checks to narrow down specific events from the user data stream
-⋮----
-//// More general handlers, if you prefer:
-⋮----
-// Any user data event in spot:
-⋮----
-// Any user data event in futures:
-⋮----
-// Any user data event on any market (spot + futures)
-⋮----
-// Formatted user data events also have a dedicated event handler, but that's optional and no different to the above
-// wsClient.on('formattedUserDataMessage', (data) => {
-//   if (isWsFormattedSpotOutboundAccountPosition(data)) {
-//     return;
-//     // console.log(
-//     //   'formattedUserDataMessage->isWsFormattedSpotOutboundAccountPosition: ',
-//     //   data,
-//     // );
-//   }
-//   if (isWsFormattedSpotBalanceUpdate(data)) {
-//     return console.log(
-//       'formattedUserDataMessage->isWsFormattedSpotBalanceUpdate: ',
-//       data,
-//     );
-//   }
-//   console.log('formattedUserDataMessage: ', data);
-// });
-⋮----
-// console.log('ws response: ', JSON.stringify(data));
-⋮----
-async function main()
-⋮----
-// Optional, hook and customise logging behavior
-⋮----
-// Enforce testnet ws connections, regardless of supplied wsKey:
-// testnet: true,
-⋮----
-// Note: unless you set this to false, the SDK will automatically call
-// the `subscribeUserDataStream()` method again if reconnected (if you called it before):
-// resubscribeUserDataStreamAfterReconnect: true,
-⋮----
-keepMarginListenTokenRefreshed: false, // Optional, if you don't want the SDK to automatically refresh your margin listen token (if you use it for subscribing to margin user data stream)
-⋮----
-// If you want your own event handlers instead of the default ones with logs, disable this setting and see the `attachEventHandlers` example below:
-⋮----
-logger, // Optional: inject a custom logger, especially to see trace events
-⋮----
-// Attach your own event handlers to process incoming events
-// You may want to disable the default ones to avoid unnecessary logs (via attachEventListeners:false, above)
-⋮----
-// Optional, if you see RECV Window errors, you can use this to manage time issues.
-// ! However, make sure you sync your system clock first!
-// https://github.com/tiagosiebler/awesome-crypto-examples/wiki/Timestamp-for-this-request-is-outside-of-the-recvWindow
-// wsClient.setTimeOffsetMs(-5000);
-⋮----
-// Note: unless you set resubscribeUserDataStreamAfterReconnect to false, the SDK will
-// automatically call this method again if reconnected,
-⋮----
-WS_KEY_MAP.mainWSAPI, // The `mainWSAPI` wsKey will connect to the "spot" Websocket API on Binance.
-⋮----
-// Start executing the example workflow
+# Binance SDK Quickstart Guide
 
-================
-File: src/types/websockets/ws-api.ts
-================
-import { WS_KEY_MAP, WsKey } from '../../util/websockets/websocket-util';
-import { FuturesExchangeInfo } from '../futures';
-import {
-  ExchangeInfo,
-  SpotExecutionRulesResponse,
-  SpotReferencePriceCalculationResponse,
-  SpotReferencePriceResult,
-} from '../spot';
-import {
-  WSAPIAccountCommissionWSAPIRequest,
-  WSAPIAccountInformationRequest,
-  WSAPIAllOrderListsRequest,
-  WSAPIAllOrdersRequest,
-  WSAPIAvgPriceRequest,
-  WSAPIExchangeInfoRequest,
-  WSAPIExecutionRulesRequest,
-  WSAPIFuturesAlgoOrderCancelRequest,
-  WSAPIFuturesOrderBookRequest,
-  WSAPIFuturesOrderCancelRequest,
-  WSAPIFuturesOrderModifyRequest,
-  WSAPIFuturesOrderStatusRequest,
-  WSAPIFuturesTickerBookRequest,
-  WSAPIFuturesTickerPriceRequest,
-  WSAPIKlinesRequest,
-  WSAPIMyAllocationsRequest,
-  WSAPIMyPreventedMatchesRequest,
-  WSAPIMyTradesRequest,
-  WSAPINewFuturesAlgoOrderRequest,
-  WSAPINewFuturesOrderRequest,
-  WSAPINewSpotOrderRequest,
-  WSAPIOpenOrdersCancelAllRequest,
-  WSAPIOpenOrdersStatusRequest,
-  WSAPIOrderAmendKeepPriorityRequest,
-  WSAPIOrderBookRequest,
-  WSAPIOrderCancelReplaceRequest,
-  WSAPIOrderCancelRequest,
-  WSAPIOrderListCancelRequest,
-  WSAPIOrderListPlaceOCORequest,
-  WSAPIOrderListPlaceOPOCORequest,
-  WSAPIOrderListPlaceOPORequest,
-  WSAPIOrderListPlaceOTOCORequest,
-  WSAPIOrderListPlaceOTORequest,
-  WSAPIOrderListPlaceRequest,
-  WSAPIOrderListStatusRequest,
-  WSAPIOrderStatusRequest,
-  WSAPIOrderTestRequest,
-  WSAPIRecvWindowTimestamp,
-  WSAPIReferencePriceCalculationRequest,
-  WSAPIReferencePriceRequest,
-  WSAPISessionLogonRequest,
-  WSAPISOROrderPlaceRequest,
-  WSAPISOROrderTestRequest,
-  WSAPITicker24hrRequest,
-  WSAPITickerBookRequest,
-  WSAPITickerPriceRequest,
-  WSAPITickerRequest,
-  WSAPITickerTradingDayRequest,
-  WSAPITradesAggregateRequest,
-  WSAPITradesHistoricalRequest,
-  WSAPITradesRecentRequest,
-} from './ws-api-requests';
-import {
-  WSAPIAccountCommission,
-  WSAPIAccountInformation,
-  WSAPIAggregateTrade,
-  WSAPIAllocation,
-  WSAPIAvgPrice,
-  WSAPIBookTicker,
-  WSAPIFullTicker,
-  WSAPIFuturesAccountBalanceItem,
-  WSAPIFuturesAccountStatus,
-  WSAPIFuturesAlgoOrder,
-  WSAPIFuturesAlgoOrderCancelResponse,
-  WSAPIFuturesBookTicker,
-  WSAPIFuturesOrder,
-  WSAPIFuturesOrderBook,
-  WSAPIFuturesPosition,
-  WSAPIFuturesPositionV2,
-  WSAPIFuturesPriceTicker,
-  WSAPIKline,
-  WSAPIMiniTicker,
-  WSAPIOrder,
-  WSAPIOrderBook,
-  WSAPIOrderCancel,
-  WSAPIOrderCancelReplaceResponse,
-  WSAPIOrderListCancelResponse,
-  WSAPIOrderListPlaceResponse,
-  WSAPIOrderListStatusResponse,
-  WSAPIOrderTestResponse,
-  WSAPIOrderTestWithCommission,
-  WSAPIPreventedMatch,
-  WSAPIPriceTicker,
-  WSAPIRateLimit,
-  WSAPIServerTime,
-  WSAPISessionStatus,
-  WSAPISOROrderPlaceResponse,
-  WSAPISOROrderTestResponse,
-  WSAPISOROrderTestResponseWithCommission,
-  WSAPISpotOrderResponse,
-  WSAPITrade,
-} from './ws-api-responses';
-⋮----
-/**
- * Standard WS commands (for consumers)
- */
-export type WsOperation =
-  | 'SUBSCRIBE'
-  | 'UNSUBSCRIBE'
-  | 'LIST_SUBSCRIPTIONS'
-  | 'SET_PROPERTY'
-  | 'GET_PROPERTY';
-⋮----
-/**
- * WS API commands (for sending requests via WS)
- */
-⋮----
-//// General commands
-⋮----
-//// Market data commands
-⋮----
-//// Account commands
-// Spot
-⋮----
-// Futures
-⋮----
-//// Trading commands
-⋮----
-// Order list commands
-⋮----
-// SOR commands
-⋮----
-// user data stream
-⋮----
-export interface WSAPIUserDataListenKeyRequest {
-  apiKey: string;
-  listenKey: string;
+> [!TIP]
+> This guide can be read in tutorial format on the Siebly Website: [Binance JavaScript REST API & WebSocket Tutorial](https://siebly.io/sdk/binance/javascript/tutorial)
+
+This guide walks through key pieces of a Binance REST API, WebSocket & WebSocket API integration using [`binance`](https://www.npmjs.com/package/binance), the Binance JavaScript and TypeScript SDK by Siebly.io.
+
+The SDK handles request building and connectivity for you, including request signing, WebSocket management, healthchecks, heartbeats, listen-key refreshes, resubscribe behavior, and WebSocket API response mapping so your code can stay focused on the workflow you are automating. This guide will walk you through installation and client selection, then moves through public calls, private auth, REST API calls, streams, user data, and the WebSocket API.
+
+**Key links**
+
+- Binance JavaScript SDK by Siebly: [`binance`](https://www.npmjs.com/package/binance)
+- GitHub Repository: [`tiagosiebler/binance`](https://github.com/tiagosiebler/binance)
+- SDK function-endpoint map: [Binance JavaScript Endpoint Reference](./endpointFunctionList.md)
+- REST API examples: [Binance SDK REST API examples](../examples/Rest)
+- WebSocket examples: [Binance SDK WebSocket examples](../examples/WebSockets)
+- More SDKs: [Siebly.io](https://siebly.io)
+
+---
+
+## Why use the SDK
+
+A stable Binance integration is more than a handful of HTTP requests. Binance splits behavior across product groups, transports, key types, and environments:
+
+- Spot, Margin, Wallet, Convert, Earn, and Sub-Account APIs live behind the main REST API client, but not all of them share the same endpoint prefix or permission model.
+- Some of these product groups expect API calls to reach different subdomains.
+- USD-M Futures and COIN-M Futures have separate REST API clients, symbols, endpoint prefixes, and WebSocket endpoints.
+- Both have their own subdomains as well.
+- Portfolio Margin uses a dedicated REST API client and its own account model.
+- Public streams, private user data streams, and WebSocket API commands are different flows.
+- Private REST API and WebSocket API requests must be signed.
+- User data streams can involve listen keys, WebSocket API subscriptions, token refreshes, and reconnect handling.
+
+Most of that work is handled for you, while the grouping & naming stays close to Binance's API naming. The SDK gives you dedicated REST API clients for the major product groups, `WebsocketClient` for streaming, `WebsocketAPIClient` for awaitable WebSocket API requests. It also includes TypeScript definitions, ESM/CJS support, proxy support, and optional response beautification.
+
+---
+
+## Install and API keys
+
+If you do not have Node.js installed yet, install it first. The SDK is published to both [GitHub](https://github.com/tiagosiebler/binance) and [npm](https://www.npmjs.com/package/binance), and can therefore be installed with your favourite Node.js compatible package manager.
+
+Install the SDK with npm:
+
+```bash
+npm install binance
+```
+
+Or use another npm-compatible package manager:
+
+```bash
+pnpm install binance
+yarn add binance
+```
+
+Create API keys from the relevant Binance page:
+
+- Binance live API keys: [Binance API Management](https://www.binance.com/en/my/settings/api-management)
+- Binance Spot testnet: [Spot Test Network](https://testnet.binance.vision/)
+- Binance Futures testnet: [Futures Testnet](https://testnet.binancefuture.com/)
+- Binance demo trading: [Binance Demo Trading](https://demo.binance.com/)
+
+> Always use the minimum permissions needed for your scenario. Trading does not require withdrawal permissions. Analytics does not require trading permissions.
+> Always require strict IP whitelisting for any API keys that you create.
+
+The main auth and environment rules are:
+
+- Public market data does not require API keys.
+- Private REST APIs require `api_key` and `api_secret`.
+- Live, testnet, and demo trading credentials are separate, as they are separate environments.
+- API permissions must match the product and action your code is using.
+- HMAC keys are the common API key + secret flow. These are the "system generated" API keys, selected by default when creating new API keys for Binance.
+- RSA and Ed25519 keys use self-generated private keys.
+- Ed25519 is recommended for latency-sensitive integrations with the WebSocket API, as this enables session-based WebSocket API authentication, instead of having to authenticate every request.
+
+All supported key types use the same SDK constructor shape. The SDK will automatically detect your key type and adjust request building & sign automatically:
+
+```typescript
+const client = new MainClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+});
+```
+
+For HMAC, `api_secret` is your Binance API secret. For RSA or Ed25519, `api_secret` is your PEM private key.
+
+Typical environment variables:
+
+```bash
+export BINANCE_API_KEY='your-api-key'
+export BINANCE_API_SECRET='your-api-secret-or-private-key'
+```
+
+If you are only testing public endpoints, you do not need any keys at all.
+
+---
+
+## Products and clients
+
+Binance is not one single API. The SDK splits API clients around Binance's product groups:
+
+| Product group                                                              | API client           | Common usage                                                                                              |
+| -------------------------------------------------------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------- |
+| REST API: Spot, Margin, Wallet, Convert, Earn, Sub-accounts, Broker, Alpha | `MainClient`         | Spot trading, account data, wallet flows, margin trading, transfers, savings/earn, sub-account management |
+| REST API: USD-M Futures                                                    | `USDMClient`         | USDT/USDC margined futures market data, account data, positions, orders                                   |
+| REST API: COIN-M Futures                                                   | `CoinMClient`        | Coin-margined futures market data, account data, positions, orders                                        |
+| REST API: Portfolio Margin                                                 | `PortfolioClient`    | Portfolio Margin account, UM/CM/margin orders, balances, positions                                        |
+| WebSocket streams                                                          | `WebsocketClient`    | Public market data streams and private user data streams                                                  |
+| WebSocket API                                                              | `WebsocketAPIClient` | REST API-like Spot and Futures commands over persistent WebSocket API connections                         |
+
+As a rule of thumb:
+
+- Use `MainClient` when the Binance docs path starts with `api/` or `sapi/`, including Spot and many account/wallet APIs.
+- Use `USDMClient` when the Binance docs path starts with `fapi/`.
+- Use `CoinMClient` when the Binance docs path starts with `dapi/`.
+- Use `PortfolioClient` when the Binance docs path starts with `papi/`.
+- Use `WebsocketClient` when you want to subscribe to streams and receive events.
+- Use `WebsocketAPIClient` when you want to send commands over WebSocket and await responses like REST API calls.
+
+For a complete method map, see [docs/endpointFunctionList.md](./endpointFunctionList.md). If any endpoints or properties seem to be missing, please open an issue on GitHub and we'll look into it. Targeted PRs are also welcome.
+
+### REST API, streams, listen keys, and WebSocket API
+
+Binance uses several related but different integration patterns. It helps to keep them separate:
+
+| Flow                         | SDK surface                                                                                                      | Best for                                                                                                                                          | What the SDK handles                                                                                |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| REST API                     | `MainClient`, `USDMClient`, `CoinMClient`, `PortfolioClient`                                                     | Request/response calls, broad API coverage, occasional reads/writes, fallback reconciliation                                                      | Base URLs, request signing, timestamps, response parsing, errors                                    |
+| Public WebSocket streams     | `WebsocketClient.subscribe(...)`                                                                                 | Live market data such as trades, klines, tickers, order book updates                                                                              | Connection routing, subscribe requests, heartbeats, reconnects, resubscribe                         |
+| Listen-key user data streams | `WebsocketClient.subscribeUsdFuturesUserDataStream()`, `subscribeCoinFuturesUserDataStream()`, portfolio helpers | Private account events where Binance still uses listen keys, especially Futures and Portfolio Margin streams                                      | Listen-key creation, keepalive, refresh, reconnect, stream teardown                                 |
+| WebSocket API user data      | `WebsocketAPIClient.subscribeUserDataStream(...)`                                                                | Spot user data and some newer private stream flows without the old Spot listen-key workflow                                                       | WebSocket API auth, subscription command, reconnect/resubscribe behavior                            |
+| WebSocket API commands       | `WebsocketAPIClient` methods or `WebsocketClient.sendWSAPIRequest(...)`                                          | Lower-latency request/response commands over an already-open WebSocket, such as order tests, order placement, cancellation, status, account reads | WebSocket connection persistence, auth, request IDs, promise resolution, response/error correlation |
+
+The WebSocket API is not just another stream. It is a request/response API over WebSocket. Since much of the functionality is a better alternative to the REST API, we've introduced the promise-driven `WebsocketAPIClient`. Lets you write code that feels like working with a REST API. Call a function to send a command over WS and await the response, without any of the complexity of managing asynchronous messaging over WebSockets (as well as the life-cycle complexities that come with keeping WebSockets healthy).
+
+```typescript
+const result = await wsApi.testSpotOrder({
+  symbol: 'BTCUSDT',
+  side: 'BUY',
+  type: 'LIMIT',
+  quantity: '0.001',
+  price: '10000',
+  timeInForce: 'GTC',
+  timestamp: Date.now(),
+});
+```
+
+Use the REST API when you want maximum endpoint coverage, simple one-off calls, or reconciliation after reconnects. Use the WebSocket API when you want persistent connectivity, lower request overhead, WebSocket API-only features, or a promise-driven command path that can share the same event-driven architecture as your streams. With Ed25519 keys, authentication can happen once per WebSocket API connection, which can improve latency in mid-to-high frequency systems. One less thing to repeat every request, is cumulatively saved time.
+
+---
+
+## Start building: first calls
+
+If you only want the fastest path to a working integration, start here.
+
+### 1. First Spot REST API request
+
+```typescript
+import { MainClient } from 'binance';
+
+const client = new MainClient();
+
+async function main() {
+  const serverTime = await client.getServerTime();
+  const exchangeInfo = await client.getExchangeInfo({ symbol: 'BTCUSDT' });
+  const ticker = await client.getSymbolPriceTicker({ symbol: 'BTCUSDT' });
+  const orderBook = await client.getOrderBook({ symbol: 'BTCUSDT', limit: 10 });
+  const candles = await client.getKlines({
+    symbol: 'BTCUSDT',
+    interval: '1m',
+    limit: 5,
+  });
+
+  console.log({
+    serverTime,
+    symbol: exchangeInfo.symbols?.[0]?.symbol,
+    ticker,
+    orderBook,
+    candles,
+  });
 }
-⋮----
-export type WsAPIOperation = (typeof WS_API_Operations)[number];
-⋮----
-export interface WsRequestOperationBinance<
-  TWSTopic extends string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  TWSParams extends object = any,
-> {
-  method: WsOperation | WsAPIOperation;
-  params?: (TWSTopic | string | number)[] | TWSParams;
-  id: number;
+
+main().catch(console.error);
+```
+
+That confirms public Spot REST API access is wired correctly.
+
+See also: [Spot public REST API example](../examples/Rest/Spot/rest-spot-public.ts)
+
+### 2. First public Spot WebSocket stream
+
+```typescript
+import { WebsocketClient, WS_KEY_MAP } from 'binance';
+
+const ws = new WebsocketClient({
+  beautify: true,
+});
+
+ws.on('open', (data) => console.log('connected', data.wsKey, data.wsUrl));
+ws.on('message', (data) => console.log('raw message', JSON.stringify(data)));
+ws.on('formattedMessage', (data) => console.log('formatted', data));
+ws.on('response', (data) => console.log('response', JSON.stringify(data)));
+ws.on('reconnecting', (data) => console.log('reconnecting', data?.wsKey));
+ws.on('reconnected', (data) => console.log('reconnected', data?.wsKey));
+ws.on('exception', console.error);
+
+ws.subscribe(['btcusdt@trade', 'btcusdt@bookTicker'], WS_KEY_MAP.main);
+```
+
+That gives you a live public Spot stream without any API keys.
+
+See also: [Spot trades WebSocket example](../examples/WebSockets/Public/ws-public-spot-trades.ts)
+
+### 3. First private Spot user data stream
+
+For Spot user data streams, prefer the WebSocket API user data flow. It avoids the older Spot listen-key flow and keeps the stream on a managed WebSocket API connection.
+
+```typescript
+import { WebsocketAPIClient, WS_KEY_MAP } from 'binance';
+
+const wsApi = new WebsocketAPIClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+  beautify: true,
+});
+
+wsApi.getWSClient().on('open', (data) => {
+  console.log('ws api open', data.wsKey);
+});
+
+wsApi.getWSClient().on('formattedUserDataMessage', (data) => {
+  console.log('account event', data);
+});
+
+wsApi.getWSClient().on('exception', console.error);
+
+async function main() {
+  await wsApi.subscribeUserDataStream(WS_KEY_MAP.mainWSAPI);
 }
-⋮----
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-⋮----
-export interface WSAPIResponse<TResponseData extends object = object> {
-  /** Auto-generated */
-  id: string;
 
-  status: number;
-  result: TResponseData;
-  rateLimits: {
-    rateLimitType: 'REQUEST_WEIGHT';
-    interval: 'MINUTE';
-    intervalNum: number;
-    limit: number;
-    count: number;
-  }[];
+main().catch(console.error);
+```
 
-  wsKey: WsKey;
-  isWSAPIResponse: boolean;
+The SDK handles authentication and resubscribe behavior for the WebSocket API connection. With Ed25519 keys it can authenticate the WebSocket API session once. With HMAC or RSA keys it signs private WebSocket API commands individually, although that primarily matters in the context of sending regular commands (such as order submissions) via WebSocket API.
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  request?: any;
+See also: [Spot user data stream over WebSocket API](<../examples/WebSockets/Private(userdata)/ws-userdata-wsapi.ts>)
+
+### 4. First Spot order over REST API
+
+```typescript
+import { MainClient } from 'binance';
+
+const client = new MainClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+});
+
+async function placeOrder() {
+  const orderRequest = {
+    symbol: 'BTCUSDT',
+    side: 'BUY',
+    type: 'LIMIT',
+    quantity: 0.001,
+    price: 10000,
+    timeInForce: 'GTC',
+    newOrderRespType: 'FULL',
+  } as const;
+
+  // Validate the request without sending it to the matching engine.
+  await client.testNewOrder(orderRequest);
+
+  // Remove this comment when you are ready to place a real order.
+  // const result = await client.submitNewOrder(orderRequest);
+  // console.log(result);
 }
+
+placeOrder().catch(console.error);
+```
+
+Use `testNewOrder()` when you want to validate the request shape and signature without placing a live Spot order. Use `submitNewOrder()` only when you are ready to send the order.
+
+See also: [Spot private trading example](../examples/Rest/Spot/rest-spot-private-trade.ts)
+
+### 5. First USD-M Futures order
+
+For strategy testing, `demoTrading: true` is usually more realistic than testnet because demo trading uses live market data with simulated trading.
+
+```typescript
+import { USDMClient } from 'binance';
+
+const client = new USDMClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+  demoTrading: true,
+});
+
+async function placeFuturesOrder() {
+  const account = await client.getAccountInformation();
+  console.log('demo futures account can trade:', account.canTrade);
+
+  const result = await client.submitNewOrder({
+    symbol: 'BTCUSDT',
+    side: 'SELL',
+    type: 'MARKET',
+    quantity: 0.001,
+  });
+
+  console.log(result);
+}
+
+placeFuturesOrder().catch(console.error);
+```
+
+See also: [USD-M Futures demo trading example](../examples/Rest/Futures/rest-usdm-demo.ts)
+
+### 6. First WebSocket API request
+
+The WebSocket API lets you send requests over a persistent WebSocket connection and await responses, similar to REST API calls. This is useful for lower-latency workflows and for WebSocket API-only features.
+
+```typescript
+import { WebsocketAPIClient } from 'binance';
+
+const wsApi = new WebsocketAPIClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+});
+
+async function main() {
+  const time = await wsApi.getSpotServerTime();
+
+  const orderTest = await wsApi.testSpotOrder({
+    symbol: 'BTCUSDT',
+    side: 'BUY',
+    type: 'LIMIT',
+    quantity: '0.001',
+    price: '10000',
+    timeInForce: 'GTC',
+    timestamp: Date.now(),
+  });
+
+  console.log({ time, orderTest });
+}
+
+main()
+  .catch(console.error)
+  .finally(() => wsApi.disconnectAll());
+```
+
+See also: [WebSocket API client example](../examples/WebSockets/WS-API/ws-api-client.ts)
+
+---
+
+## Spot, Margin, and Wallet REST API
+
+Most Binance integrations start with `MainClient`. It covers Spot trading and many account APIs under Binance's main REST API families.
+
+### Create a public `MainClient`
+
+```typescript
+import { MainClient } from 'binance';
+
+const client = new MainClient();
+```
+
+Public calls do not require keys.
+
+### Create a private `MainClient`
+
+If you plan on making private API calls, include API keys when creating the client:
+
+```typescript
+import { MainClient } from 'binance';
+
+const client = new MainClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+  beautifyResponses: true,
+});
+```
+
+Private REST API methods are signed automatically. You do not need to manually add timestamps, signatures, or `X-MBX-APIKEY` headers.
+
+### Common public Spot market data calls
+
+```typescript
+const serverTime = await client.getServerTime();
+const ping = await client.testConnectivity();
+const exchangeInfo = await client.getExchangeInfo({ symbol: 'BTCUSDT' });
+const orderBook = await client.getOrderBook({ symbol: 'BTCUSDT', limit: 10 });
+const recentTrades = await client.getRecentTrades({
+  symbol: 'BTCUSDT',
+  limit: 10,
+});
+const aggregateTrades = await client.getAggregateTrades({
+  symbol: 'BTCUSDT',
+  limit: 10,
+});
+const candles = await client.getKlines({
+  symbol: 'BTCUSDT',
+  interval: '1m',
+  limit: 10,
+});
+const averagePrice = await client.getAvgPrice({ symbol: 'BTCUSDT' });
+const ticker = await client.getSymbolPriceTicker({ symbol: 'BTCUSDT' });
+const bookTicker = await client.getSymbolOrderBookTicker({
+  symbol: 'BTCUSDT',
+});
+```
+
+### Common private Spot account and order calls
+
+```typescript
+const account = await client.getAccountInformation();
+const balances = await client.getBalances();
+const accountInfo = await client.getAccountInfo();
+const openOrders = await client.getOpenOrders({ symbol: 'BTCUSDT' });
+const allOrders = await client.getAllOrders({ symbol: 'BTCUSDT', limit: 10 });
+const myTrades = await client.getAccountTradeList({
+  symbol: 'BTCUSDT',
+  limit: 10,
+});
+const tradeFee = await client.getTradeFee({ symbol: 'BTCUSDT' });
+const apiPermissions = await client.getApiKeyPermissions();
+```
+
+See also:
+
+- [Spot public REST API example](../examples/Rest/Spot/rest-spot-public.ts)
+- [Spot exchange info example](../examples/Rest/Spot/rest-spot-exchange-info.ts)
+- [Spot private trading example](../examples/Rest/Spot/rest-spot-private-trade.ts)
+- [Spot private miscellaneous account example](../examples/Rest/Spot/rest-spot-private-misc.ts)
+
+### Spot order examples
+
+Market order:
+
+```typescript
+await client.submitNewOrder({
+  symbol: 'BTCUSDT',
+  side: 'BUY',
+  type: 'MARKET',
+  quantity: 0.001,
+  newOrderRespType: 'FULL',
+});
+```
+
+Limit order:
+
+```typescript
+await client.submitNewOrder({
+  symbol: 'BTCUSDT',
+  side: 'BUY',
+  type: 'LIMIT',
+  quantity: 0.001,
+  price: 10000,
+  timeInForce: 'GTC',
+});
+```
+
+Limit maker order:
+
+```typescript
+await client.submitNewOrder({
+  symbol: 'BTCUSDT',
+  side: 'BUY',
+  type: 'LIMIT_MAKER',
+  quantity: 0.001,
+  price: 10000,
+});
+```
+
+Test an order without sending it:
+
+```typescript
+await client.testNewOrder({
+  symbol: 'BTCUSDT',
+  side: 'BUY',
+  type: 'LIMIT',
+  quantity: 0.001,
+  price: 10000,
+  timeInForce: 'GTC',
+});
+```
+
+Cancel an order:
+
+```typescript
+await client.cancelOrder({
+  symbol: 'BTCUSDT',
+  orderId: 123456789,
+});
+```
+
+**Custom client order IDs**
+
+You do not always need to set a custom client order ID. Most of the time, the cleanest option is to send the order without `newClientOrderId` and let the SDK handle the request normally:
+
+```typescript
+await client.submitNewOrder({
+  symbol: 'BTCUSDT',
+  side: 'SELL',
+  type: 'LIMIT',
+  quantity: 0.001,
+  price: 13000,
+  timeInForce: 'GTC',
+});
+```
+
+If your system needs to know the client order ID before the order is sent, but the ID does not need to carry any meaning, ask the REST API client to generate one:
+
+```typescript
+const newClientOrderId = client.generateNewOrderId();
+
+await client.submitNewOrder({
+  symbol: 'BTCUSDT',
+  side: 'SELL',
+  type: 'LIMIT',
+  quantity: 0.001,
+  price: 13000,
+  timeInForce: 'GTC',
+  newClientOrderId,
+});
+```
+
+`generateNewOrderId()` is available on every REST API client, including `MainClient`, `USDMClient`, `CoinMClient`, and `PortfolioClient`. The client already knows its product group, so the generated ID uses the right Binance-compatible prefix.
+
+If you want to include a small piece of your own context in the client order ID, such as a take-profit marker or strategy step, use the product prefix from the client and append your suffix:
+
+```typescript
+const prefix = client.getOrderIdPrefix();
+const suffix = `tp1_${Date.now()}`;
+const newClientOrderId = `${prefix}${suffix}`;
+const validBinanceClientOrderId = /^[.A-Z:/a-z0-9_-]{1,32}$/;
+
+if (!validBinanceClientOrderId.test(newClientOrderId)) {
+  throw new Error(`Invalid Binance client order ID: ${newClientOrderId}`);
+}
+
+await client.submitNewOrder({
+  symbol: 'BTCUSDT',
+  side: 'SELL',
+  type: 'LIMIT',
+  quantity: 0.001,
+  price: 13000,
+  timeInForce: 'GTC',
+  newClientOrderId,
+});
+```
+
+The prefix returned by `getOrderIdPrefix()` is 10 characters long. For endpoints with Binance's common 32-character client order ID limit, that leaves 22 characters for your own suffix. Some fields have a different documented limit, such as USD-M Futures Algo `clientAlgoId`, which currently allows up to 36 characters and therefore leaves 26 characters after the SDK prefix. Keep the suffix short and use only characters Binance allows for that field.
+
+If you need to track richer metadata than will comfortably fit in the client order ID, do not try to squeeze it into these custom order ID fields. Instead, generate an ID with `client.generateNewOrderId()` before placing the order, use that value as the key for your own metadata, and store the metadata locally or in an external store such as Redis. Later, when order updates arrive through REST API polling or user data events, you can look up the richer context using the seen `newClientOrderId` value like a primary key, while keeping the exchange-facing ID short and valid.
+
+Regular Spot/Futures/Portfolio orders usually use `newClientOrderId`; newer Futures algo or conditional flows may use `clientAlgoId` instead. The same rule applies: omit it unless you need it, use `generateNewOrderId()` when any unique ID is fine, and use `getOrderIdPrefix()` when building your own value.
+
+### Margin REST API examples
+
+Margin APIs also live on `MainClient`.
+
+```typescript
+const marginAssets = await client.getAllMarginAssets();
+const marginPairs = await client.getAllCrossMarginPairs();
+const priceIndex = await client.queryMarginPriceIndex({ symbol: 'BTCUSDT' });
+
+const crossMarginAccount = await client.queryCrossMarginAccountDetails();
+const isolatedMarginAccount = await client.getIsolatedMarginAccountInfo({
+  symbols: 'BTCUSDT',
+});
+const openMarginOrders = await client.queryMarginAccountOpenOrders({
+  symbol: 'BTCUSDT',
+});
+```
+
+Margin order:
+
+```typescript
+await client.marginAccountNewOrder({
+  symbol: 'BTCUSDT',
+  side: 'BUY',
+  type: 'LIMIT',
+  quantity: 0.001,
+  price: 10000,
+  timeInForce: 'GTC',
+  isIsolated: 'FALSE',
+  sideEffectType: 'NO_SIDE_EFFECT',
+});
+```
+
+Borrow or repay:
+
+```typescript
+await client.submitMarginAccountBorrowRepay({
+  asset: 'USDT',
+  symbol: 'BTCUSDT',
+  amount: 25,
+  type: 'BORROW',
+  isIsolated: 'FALSE',
+});
+```
+
+Margin permissions, collateral, interest, and liquidation behavior are account-specific. Keep margin trading code separate from ordinary Spot trading code even though both use `MainClient`.
+
+### Wallet and transfer examples
+
+Wallet and transfer APIs also live on `MainClient`.
+
+```typescript
+const balances = await client.getBalances();
+const depositAddress = await client.getDepositAddress({
+  coin: 'USDT',
+  network: 'ETH',
+});
+const depositHistory = await client.getDepositHistory({ coin: 'USDT' });
+const withdrawHistory = await client.getWithdrawHistory({ coin: 'USDT' });
+
+const transferHistory = await client.getUniversalTransferHistory({
+  type: 'MAIN_UMFUTURE',
+});
+```
+
+Withdrawal calls are intentionally not shown as a quickstart. Use withdrawal permissions only when your system truly needs them, and isolate those keys from trading keys.
+
+---
+
+## Futures REST API
+
+Binance Futures are split into USD-M and COIN-M product groups. Use the dedicated client for the product you are integrating.
+
+### Create public Futures clients
+
+```typescript
+import { CoinMClient, USDMClient } from 'binance';
+
+const usdm = new USDMClient();
+const coinm = new CoinMClient();
+```
+
+Public futures market data does not require keys.
+
+### Create private Futures clients
+
+```typescript
+import { CoinMClient, USDMClient } from 'binance';
+
+const usdm = new USDMClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+});
+
+const coinm = new CoinMClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+});
+```
+
+Use `demoTrading: true` for Binance demo trading or `testnet: true` for testnet where supported:
+
+```typescript
+const demoUsdm = new USDMClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+  demoTrading: true,
+});
+
+const testnetUsdm = new USDMClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+  testnet: true,
+});
+```
+
+Do not enable both `demoTrading` and `testnet` on the same client.
+
+### Common public USD-M Futures market data calls
+
+```typescript
+const serverTime = await usdm.getServerTime();
+const exchangeInfo = await usdm.getExchangeInfo();
+const orderBook = await usdm.getOrderBook({ symbol: 'BTCUSDT', limit: 10 });
+const recentTrades = await usdm.getRecentTrades({
+  symbol: 'BTCUSDT',
+  limit: 10,
+});
+const candles = await usdm.getKlines({
+  symbol: 'BTCUSDT',
+  interval: '1m',
+  limit: 10,
+});
+const markPrice = await usdm.getMarkPrice({ symbol: 'BTCUSDT' });
+const fundingHistory = await usdm.getFundingRateHistory({
+  symbol: 'BTCUSDT',
+  limit: 10,
+});
+const ticker = await usdm.getSymbolPriceTicker({ symbol: 'BTCUSDT' });
+```
+
+### Common public COIN-M Futures market data calls
+
+```typescript
+const serverTime = await coinm.getServerTime();
+const exchangeInfo = await coinm.getExchangeInfo();
+const orderBook = await coinm.getOrderBook({
+  symbol: 'BTCUSD_PERP',
+  limit: 10,
+});
+const candles = await coinm.getKlines({
+  symbol: 'BTCUSD_PERP',
+  interval: '1m',
+  limit: 10,
+});
+const markPrice = await coinm.getMarkPrice({ symbol: 'BTCUSD_PERP' });
+const ticker = await coinm.getSymbolPriceTicker({ symbol: 'BTCUSD_PERP' });
+```
+
+See also:
+
+- [USD-M public REST API example](../examples/Rest/Futures/rest-usdm-public.ts)
+- [USD-M demo trading example](../examples/Rest/Futures/rest-usdm-demo.ts)
+- [USD-M testnet example](../examples/Rest/Futures/rest-usdm-testnet.ts)
+
+### Common private Futures account calls
+
+```typescript
+const balance = await usdm.getBalance();
+const account = await usdm.getAccountInformation();
+const positions = await usdm.getPositions({ symbol: 'BTCUSDT' });
+const openOrders = await usdm.getAllOpenOrders({ symbol: 'BTCUSDT' });
+const tradeHistory = await usdm.getAccountTrades({
+  symbol: 'BTCUSDT',
+  limit: 10,
+});
+const income = await usdm.getIncomeHistory({
+  symbol: 'BTCUSDT',
+  limit: 10,
+});
+```
+
+### Futures order examples
+
+Market order:
+
+```typescript
+await usdm.submitNewOrder({
+  symbol: 'BTCUSDT',
+  side: 'SELL',
+  type: 'MARKET',
+  quantity: 0.001,
+});
+```
+
+Limit order:
+
+```typescript
+await usdm.submitNewOrder({
+  symbol: 'BTCUSDT',
+  side: 'BUY',
+  type: 'LIMIT',
+  quantity: 0.001,
+  price: 10000,
+  timeInForce: 'GTC',
+});
+```
+
+Reduce-only limit order:
+
+```typescript
+await usdm.submitNewOrder({
+  symbol: 'BTCUSDT',
+  side: 'BUY',
+  type: 'LIMIT',
+  quantity: 0.001,
+  price: 10000,
+  timeInForce: 'GTC',
+  reduceOnly: 'true',
+});
+```
+
+Batch order management:
+
+```typescript
+await usdm.submitMultipleOrders([
+  {
+    symbol: 'BTCUSDT',
+    side: 'BUY',
+    type: 'LIMIT',
+    quantity: 0.001,
+    price: 10000,
+    timeInForce: 'GTC',
+  },
+  {
+    symbol: 'BTCUSDT',
+    side: 'SELL',
+    type: 'LIMIT',
+    quantity: 0.001,
+    price: 13000,
+    timeInForce: 'GTC',
+  },
+]);
+```
+
+See also:
+
+- [USD-M order example](../examples/Rest/Futures/rest-usdm-order.ts)
+- [USD-M stop-loss order example](../examples/Rest/Futures/rest-usdm-order-sl.ts)
+- [USD-M bracket order example](../examples/Rest/Futures/rest-future-bracket-order.ts)
+
+---
+
+## Portfolio Margin REST API
+
+Portfolio Margin has its own account model and a dedicated `PortfolioClient`.
+
+### Create a Portfolio Margin client
+
+```typescript
+import { PortfolioClient } from 'binance';
+
+const portfolio = new PortfolioClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+});
+```
+
+### Common Portfolio Margin calls
+
+```typescript
+const ping = await portfolio.testConnectivity();
+const serverTime = await portfolio.getServerTime();
+const balance = await portfolio.getBalance();
+const account = await portfolio.getAccountInfo();
+const umPositions = await portfolio.getUMPosition({ symbol: 'BTCUSDT' });
+const cmPositions = await portfolio.getCMPosition({ pair: 'BTCUSD' });
+const umOpenOrders = await portfolio.getAllUMOpenOrders({
+  symbol: 'BTCUSDT',
+});
+const marginOpenOrders = await portfolio.getMarginOpenOrders({
+  symbol: 'BTCUSDT',
+});
+```
+
+Portfolio Margin order examples:
+
+```typescript
+await portfolio.submitNewUMOrder({
+  symbol: 'BTCUSDT',
+  side: 'BUY',
+  type: 'LIMIT',
+  quantity: '0.001',
+  price: '10000',
+  timeInForce: 'GTC',
+});
+
+await portfolio.submitNewCMOrder({
+  symbol: 'BTCUSD_PERP',
+  side: 'SELL',
+  type: 'MARKET',
+  quantity: '1',
+});
+
+await portfolio.submitNewMarginOrder({
+  symbol: 'BTCUSDT',
+  side: 'BUY',
+  type: 'MARKET',
+  quantity: '0.001',
+  sideEffectType: 'NO_SIDE_EFFECT',
+});
+```
+
+See also:
+
+- [Portfolio Margin public REST API example](../examples/Rest/Portfolio%20Margin/rest-portfoliomargin-public.ts)
+- [Portfolio Margin private REST API example](../examples/Rest/Portfolio%20Margin/rest-portfoliomargin-private.ts)
+
+---
+
+## WebSocket Streams
+
+Use `WebsocketClient` when you want event-driven updates instead of polling the REST API. It is the shared client for public market streams and the older listen-key style user data streams.
+
+The workflow is simple: create a client, add event handlers, provide API keys if you need private user data, and subscribe to the streams you want. The SDK opens the correct Binance endpoint, applies proxy settings if configured, fetches and refreshes listen keys where required, monitors heartbeats, reconnects stale sockets, and resubscribes cached topics after reconnect.
+
+### Common `WebsocketClient` events
+
+| Event                      | Meaning                                                         |
+| -------------------------- | --------------------------------------------------------------- |
+| `open`                     | Connection established                                          |
+| `message`                  | Raw streaming data received                                     |
+| `formattedMessage`         | Beautified public stream data when `beautify: true`             |
+| `formattedUserDataMessage` | Beautified private user data stream event when `beautify: true` |
+| `response`                 | Subscribe, unsubscribe, auth, or WebSocket API acknowledgement  |
+| `reconnecting`             | Connection dropped and retrying                                 |
+| `reconnected`              | Connection restored and subscriptions resynced                  |
+| `close`                    | Socket closed                                                   |
+| `authenticated`            | WebSocket API session authentication succeeded                  |
+| `exception`                | Errors and unexpected conditions                                |
+
+### Understanding `WS_KEY_MAP`
+
+`WS_KEY_MAP` tells the SDK which Binance WebSocket endpoint family to use. This matters because Spot, USD-M Futures, COIN-M Futures, Options, Portfolio Margin, and WebSocket API traffic do not all live on the same endpoint.
+
+Common `WS_KEY_MAP` entries:
+
+| Key                          | Use                                                                     |
+| ---------------------------- | ----------------------------------------------------------------------- |
+| `main`                       | Spot, margin, and isolated margin market data streams                   |
+| `main2`                      | Alternate Spot stream port                                              |
+| `main3`                      | Spot market-data-only stream endpoint                                   |
+| `mainWSAPI`                  | Spot and margin WebSocket API                                           |
+| `mainWSAPITestnet`           | Spot WebSocket API testnet                                              |
+| `marginUserData`             | Margin user data over WebSocket API listen-token flow                   |
+| `marginRiskUserData`         | Cross-margin risk data stream                                           |
+| `usdmPublic`                 | USD-M high-frequency public market data, such as book and depth streams |
+| `usdmMarket`                 | USD-M regular market data, such as trades, klines, tickers, mark price  |
+| `usdmPrivate`                | USD-M private user data stream endpoint                                 |
+| `usdmWSAPI`                  | USD-M Futures WebSocket API                                             |
+| `coinm`                      | COIN-M market data and user data stream endpoint                        |
+| `coinmWSAPI`                 | COIN-M Futures WebSocket API                                            |
+| `eoptions`                   | European Options WebSocket streams                                      |
+| `portfolioMarginUserData`    | Portfolio Margin user data stream                                       |
+| `portfolioMarginProUserData` | Portfolio Margin Pro user data stream                                   |
+| `alpha`                      | Alpha market data streams                                               |
+
+These keys act like connection IDs. The SDK uses them to track connection state, cached subscriptions, reconnect behavior, and endpoint-specific routing.
+
+### Public Spot WebSocket topics
+
+```typescript
+import { WebsocketClient, WS_KEY_MAP } from 'binance';
+
+const ws = new WebsocketClient({ beautify: true });
+
+ws.on('formattedMessage', (data) => console.log(data));
+ws.on('exception', console.error);
+
+ws.subscribe(
+  [
+    'btcusdt@trade',
+    'btcusdt@aggTrade',
+    'btcusdt@kline_1m',
+    'btcusdt@bookTicker',
+    'btcusdt@depth10@100ms',
+  ],
+  WS_KEY_MAP.main,
+);
+```
+
+See also:
+
+- [General public WebSocket example](../examples/WebSockets/Public/ws-public.ts)
+- [Spot order book WebSocket example](../examples/WebSockets/Public/ws-public-spot-orderbook.ts)
+- [Spot trades WebSocket example](../examples/WebSockets/Public/ws-public-spot-trades.ts)
+
+### Public USD-M Futures WebSocket topics
+
+USD-M Futures WebSockets have dedicated endpoint families for high-frequency public data and regular market data.
+
+```typescript
+import { WebsocketClient, WS_KEY_MAP } from 'binance';
+
+const ws = new WebsocketClient({ beautify: true });
+
+ws.on('formattedMessage', (data) => console.log(data));
+ws.on('exception', console.error);
+
+// High-frequency public data: book ticker and order book depth.
+ws.subscribe(
+  ['btcusdt@bookTicker', 'btcusdt@depth10@100ms', 'btcusdt@depth@100ms'],
+  WS_KEY_MAP.usdmPublic,
+);
+
+// Regular market data: trades, mark price, klines, mini tickers, liquidations.
+ws.subscribe(
+  ['btcusdt@aggTrade', 'btcusdt@markPrice', 'btcusdt@kline_1m'],
+  WS_KEY_MAP.usdmMarket,
+);
+```
+
+See also:
+
+- [USD-M public WebSocket example](../examples/WebSockets/Public/ws-usdm-public.ts)
+- [USD-M funding stream example](../examples/WebSockets/Public/ws-public-usdm-funding.ts)
+
+### Public COIN-M Futures WebSocket topics
+
+```typescript
+import { WebsocketClient, WS_KEY_MAP } from 'binance';
+
+const ws = new WebsocketClient({ beautify: true });
+
+ws.on('message', (data) => console.log(JSON.stringify(data)));
+ws.on('exception', console.error);
+
+ws.subscribe(
+  ['btcusd_perp@aggTrade', 'btcusd_perp@markPrice', 'btcusd_perp@kline_1m'],
+  WS_KEY_MAP.coinm,
+);
+```
+
+COIN-M symbols and stream names are not the same as Spot or USD-M symbols. Treat symbols as product-specific strings.
+
+---
+
+## User Data Streams
+
+User data streams are how Binance pushes private account events: order updates, execution updates, balance changes, position changes, margin events, and listen-key or subscription expiry events.
+
+Binance uses two patterns for these streams: WebSocket API user data subscriptions and listen-key user data streams. The SDK supports both; the product group determines which path you should use.
+
+For either pattern, listen for the WebSocket lifecycle events as well as account events. The event names are `reconnecting` and `reconnected`. `reconnecting` fires when the SDK starts replacing a dropped connection; `reconnected` fires after the replacement connection is open. Both include the `wsKey`, which tells you which connection was affected. For user data streams, `reconnected` is the right place to reconcile private state through the REST API in case account events were missed while the socket was down.
+
+With `WebsocketAPIClient`, attach those handlers to `wsApi.getWSClient()`. With `WebsocketClient`, attach them directly to the client.
+
+### Preferred Spot user data stream with `WebsocketAPIClient`
+
+```typescript
+import { WebsocketAPIClient, WS_KEY_MAP } from 'binance';
+
+const wsApi = new WebsocketAPIClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+  beautify: true,
+});
+
+const wsClient = wsApi.getWSClient();
+
+wsClient.on('formattedUserDataMessage', (data) => {
+  console.log('spot account event', data);
+});
+
+wsClient.on('reconnecting', ({ wsKey }) => {
+  console.log('spot user data reconnecting', wsKey);
+});
+
+wsClient.on('reconnected', ({ wsKey }) => {
+  console.log('spot user data reconnected', wsKey);
+  // Fetch account state, open orders, or recent fills here if needed.
+});
+
+wsClient.on('exception', console.error);
+
+await wsApi.subscribeUserDataStream(WS_KEY_MAP.mainWSAPI);
+```
+
+This is the recommended path for Spot user data in this SDK version.
+
+### Margin user data stream with `WebsocketAPIClient`
+
+```typescript
+import { WebsocketAPIClient, WS_KEY_MAP } from 'binance';
+
+const wsApi = new WebsocketAPIClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+  beautify: true,
+});
+
+const wsClient = wsApi.getWSClient();
+
+wsClient.on('formattedUserDataMessage', (data) => {
+  console.log('margin account event', data);
+});
+
+wsClient.on('reconnecting', ({ wsKey }) => {
+  console.log('margin user data reconnecting', wsKey);
+});
+
+wsClient.on('reconnected', ({ wsKey }) => {
+  console.log('margin user data reconnected', wsKey);
+});
+
+await wsApi.subscribeUserDataStream(WS_KEY_MAP.marginUserData);
+```
+
+For margin, the SDK handles the listen-token workflow used by Binance's margin WebSocket API user data endpoint.
+
+### Futures user data streams with `WebsocketClient`
+
+For Futures user data streams, the SDK can manage listen keys for you through convenience methods.
+
+```typescript
+import { WebsocketClient } from 'binance';
+
+const ws = new WebsocketClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+  beautify: true,
+});
+
+ws.on('formattedUserDataMessage', (data) => {
+  console.log('futures account event', data);
+});
+
+ws.on('reconnecting', ({ wsKey }) => {
+  console.log('futures user data reconnecting', wsKey);
+});
+
+ws.on('reconnected', ({ wsKey }) => {
+  console.log('futures user data reconnected', wsKey);
+  // Fetch positions, balances, open orders, or fills here if needed.
+});
+
+ws.on('exception', console.error);
+
+await ws.subscribeUsdFuturesUserDataStream();
+// await ws.subscribeCoinFuturesUserDataStream();
+```
+
+The SDK will fetch the listen key, keep it alive, refresh it when needed, reconnect after network issues, and resubscribe where possible.
+
+### Portfolio Margin user data stream
+
+```typescript
+import { WebsocketClient, WS_KEY_MAP } from 'binance';
+
+const ws = new WebsocketClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+  beautify: true,
+});
+
+ws.on('formattedUserDataMessage', (data) => {
+  console.log('portfolio margin event', data);
+});
+
+ws.on('reconnecting', ({ wsKey }) => {
+  console.log('portfolio margin user data reconnecting', wsKey);
+});
+
+ws.on('reconnected', ({ wsKey }) => {
+  console.log('portfolio margin user data reconnected', wsKey);
+});
+
+ws.on('exception', console.error);
+
+await ws.subscribePortfolioMarginUserDataStream(
+  WS_KEY_MAP.portfolioMarginUserData,
+);
+```
+
+See also:
+
+- [User data stream overview](<../examples/WebSockets/Private(userdata)/ws-userdata-README.MD>)
+- [Listen-key user data example](<../examples/WebSockets/Private(userdata)/ws-userdata-listenkey.ts>)
+- [WebSocket API user data example](<../examples/WebSockets/Private(userdata)/ws-userdata-wsapi.ts>)
+- [User data connection safety example](<../examples/WebSockets/Private(userdata)/ws-userdata-connection-safety.ts>)
+
+---
+
+## WebSocket API
+
+Binance's WebSocket API is a request/response API over a persistent WebSocket connection. It is useful when you want lower request overhead than REST API calls, or when a Binance feature is exposed through the WebSocket API flow.
+
+`WebsocketAPIClient` wraps that in a promise-driven interface: call a method, await a promise, receive the response, and let the SDK manage the underlying WebSocket connection.
+
+### Authentication
+
+The SDK supports HMAC, RSA, and Ed25519 keys:
+
+- HMAC: supported for REST API and WebSocket API, but WebSocket API private commands are signed individually.
+- RSA: supported for REST API and WebSocket API, but WebSocket API private commands are signed individually.
+- Ed25519: recommended for WebSocket API because the SDK can authenticate the WebSocket API session once and then send private commands without signing every command.
+
+If your `api_secret` contains a PEM private key, the SDK automatically detects whether it should use RSA or Ed25519 signing.
+
+See also:
+
+- [Ed25519 auth example](../examples/auth/rest-private-ed25519.md)
+- [RSA auth example](../examples/auth/rest-private-rsa.md)
+
+### Spot examples
+
+```typescript
+import { WebsocketAPIClient } from 'binance';
+
+const wsApi = new WebsocketAPIClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+});
+
+const exchangeInfo = await wsApi.getSpotExchangeInfo({
+  symbol: 'BTCUSDT',
+});
+
+const orderBook = await wsApi.getSpotOrderBook({
+  symbol: 'BTCUSDT',
+  limit: 10,
+});
+
+const account = await wsApi.getSpotAccountInformation({
+  timestamp: Date.now(),
+});
+
+await wsApi.testSpotOrder({
+  symbol: 'BTCUSDT',
+  side: 'BUY',
+  type: 'LIMIT',
+  quantity: '0.001',
+  price: '10000',
+  timeInForce: 'GTC',
+  timestamp: Date.now(),
+});
+```
+
+Submit a Spot order over the WebSocket API:
+
+```typescript
+await wsApi.submitNewSpotOrder({
+  symbol: 'BTCUSDT',
+  side: 'BUY',
+  type: 'LIMIT',
+  quantity: '0.001',
+  price: '10000',
+  timeInForce: 'GTC',
+});
+```
+
+### Futures examples
+
+```typescript
+import { WebsocketAPIClient } from 'binance';
+
+const wsApi = new WebsocketAPIClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+});
+
+const book = await wsApi.getFuturesOrderBook({
+  symbol: 'BTCUSDT',
+  limit: 10,
+});
+
+const balance = await wsApi.getFuturesAccountBalance('usdm', {
+  timestamp: Date.now(),
+});
+
+await wsApi.submitNewFuturesOrder('usdm', {
+  symbol: 'BTCUSDT',
+  side: 'SELL',
+  type: 'MARKET',
+  quantity: '0.001',
+  timestamp: Date.now(),
+});
+```
+
+See also:
+
+- [WebSocket API client example](../examples/WebSockets/WS-API/ws-api-client.ts)
+- [Raw WebSocket API promises example](../examples/WebSockets/WS-API/ws-api-raw-promises.ts)
+
+---
+
+## Environments and Special Endpoints
+
+### Demo trading
+
+Demo trading uses real market data with simulated trading. For strategy testing, this is usually more useful than testnet.
+
+```typescript
+const client = new USDMClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+  demoTrading: true,
+});
+```
+
+Demo trading is supported by SDK options for REST API and WebSocket clients where Binance provides demo endpoints.
+
+### Testnet
+
+Testnet uses separate credentials and simulated market conditions.
+
+```typescript
+const client = new USDMClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+  testnet: true,
+});
+```
+
+Use testnet for endpoint wiring and permission checks. Do not use testnet market behavior as evidence that a live strategy is profitable or safe.
+
+### Market maker endpoints
+
+Binance provides market maker endpoints for eligible futures users. If you qualify and need those endpoints, enable them with `useMMSubdomain: true`.
+
+```typescript
+const usdm = new USDMClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+  useMMSubdomain: true,
+});
+
+const ws = new WebsocketClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+  useMMSubdomain: true,
+});
+```
+
+Market maker endpoints are for supported futures products. They are not a general Spot endpoint override and are not available on testnet.
+
+---
+
+## Production Notes
+
+Before a Binance integration trades unattended, these are the parts worth making explicit.
+
+### 1. Roll out in layers
+
+Move from public reads to private actions one layer at a time:
+
+1. Public REST APIs
+2. Public WebSockets
+3. Private REST API account reads
+4. Private account/user data streams
+5. Order validation
+6. Tiny demo or live trading tests
+
+For Futures, prefer demo trading before live trading if it fits your setup.
+
+### 2. Reconnect, then backfill
+
+Listen for `reconnecting` and `reconnected`. A dropped WebSocket connection is a normal production condition, especially during volatility or scheduled exchange disconnects.
+
+If your system uses WebSockets for account or market state, a reconnect should usually trigger a REST API backfill:
+
+1. Pause risky order actions when `reconnecting` fires.
+2. On `reconnected`, query the REST API for account state, orders, fills, positions, and any market state you depend on.
+3. Reconcile internal state.
+4. React to any discrepancies in internal vs exchange state, as needed.
+5. Resume normal processing.
+
+### 3. Keep credentials scoped
+
+Live, demo trading, Spot testnet, and Futures testnet credentials are different. Keep them separate in your secrets manager and deployment configuration.
+
+Use the minimum permissions needed for each key. A market-data key should not be able to trade. A trading key should not have withdrawal permissions. Do not put live secrets in frontend code. Make use of IP whitelisting for any API keys. These must be protected, treat them like passwords.
+
+### 4. Keep streams and commands separate
+
+Use `WebsocketClient` for streams. Use `WebsocketAPIClient` for commands you want to await. They share WebSocket infrastructure, but they solve different problems.
+
+### 5. Treat symbols and order IDs as product-specific state
+
+Spot, USD-M Futures, COIN-M Futures, Options, and Portfolio Margin do not all use the same symbol conventions:
+
+- Spot: `BTCUSDT`
+- USD-M Futures: `BTCUSDT`
+- COIN-M Futures: `BTCUSD_PERP`
+- Stream names are usually lowercase, such as `btcusdt@trade`. Refer to the examples and/or exchange API docs for exact stream names.
+
+Client order IDs deserve the same care. If you do not need a custom client order ID, omit it. If your strategy relies on idempotency, retries, or reconciliation, generate an ID before sending the order and persist it using the restClient.generateNewOrderId() method. If you build your own value, keep the SDK's product prefix in place (query it using restClient.getOrderIdPrefix()) and stay within Binance's length and character constraints.
+
+### 6. Watch clocks and rate limits
+
+Private Binance requests are timestamp-sensitive. Keep your system clock synced and set `recvWindow` intentionally:
+
+```typescript
+const client = new MainClient({
+  api_key: process.env.BINANCE_API_KEY!,
+  api_secret: process.env.BINANCE_API_SECRET!,
+  recvWindow: 5000,
+});
+
+await client.fetchLatencySummary();
+
+// For WebSocket API clients:
+wsApi.setTimeOffsetMs(-500);
+```
+
+The REST API client also tracks Binance rate-limit headers it sees:
+
+```typescript
+const ticker = await client.getSymbolPriceTicker({ symbol: 'BTCUSDT' });
+console.log(ticker);
+
+console.log(client.getRateLimitStates());
+```
+
+If you see timestamp errors, fix system clock sync first. If you see rate-limit pressure, reduce polling, batch where the API allows it, and design around Binance's documented request weights.
+
+For more guidance on resolving timestamp & recvWindow issues, refer to the following guidance:
+https://github.com/sieblyio/awesome-crypto-examples/wiki/Timestamp-for-this-request-is-outside-of-the-recvWindow
+
+### 7. Logging and large integers
+
+If you want SDK logs in your own monitoring stack, pass a logger:
+
+```typescript
+import { DefaultLogger, WebsocketClient } from 'binance';
+
+const customLogger: typeof DefaultLogger = {
+  ...DefaultLogger,
+  trace: () => {},
+  info: (...params) => console.info(new Date(), ...params),
+  error: (...params) => console.error(new Date(), ...params),
+};
+
+const ws = new WebsocketClient(
+  {
+    api_key: process.env.BINANCE_API_KEY!,
+    api_secret: process.env.BINANCE_API_SECRET!,
+    beautify: true,
+  },
+  customLogger,
+);
+```
+
+JavaScript cannot precisely represent integers above `Number.MAX_SAFE_INTEGER`. If you need to preserve very large order IDs from WebSocket messages, provide a custom parser:
+
+```typescript
+import { WebsocketClient } from 'binance';
+
+const ws = new WebsocketClient({
+  customParseJSONFn: (rawEvent) => {
+    return JSON.parse(
+      rawEvent.replace(/"orderId":\s*(\d+)/g, '"orderId":"$1"'),
+    );
+  },
+});
+```
+
+See also: [custom parser example](../examples/WebSockets/Misc/ws-custom-parser.ts)
+
+---
+
+## FAQ
+
+**Which REST API client should I use?**
+
+Use `MainClient` for Spot, margin, wallet, Convert, Earn, sub-account, and many account APIs. Use `USDMClient` for USD-M Futures. Use `CoinMClient` for COIN-M Futures. Use `PortfolioClient` for Portfolio Margin.
+
+**Do I need API keys for public market data?**
+
+No. Public REST API market data and public WebSocket market data do not require API keys.
+
+**Can I use one Binance API key for every product group?**
+
+Sometimes, but only when the key belongs to the right environment and has the required product permissions enabled. Keep live, demo, and testnet credentials separate. Also keep high-risk permissions, especially withdrawals, separate from ordinary trading keys.
+
+**What is the difference between HMAC, RSA, and Ed25519?**
+
+HMAC is the standard API key + secret flow. RSA and Ed25519 use self-generated private keys. The SDK detects PEM private keys automatically when they are passed as `api_secret`. Ed25519 is recommended for latency-sensitive WebSocket API usage because it supports WebSocket API session authentication.
+
+**Why both `WebsocketClient` and `WebsocketAPIClient`?**
+
+- `WebsocketClient` is for subscriptions and streaming topics.
+- `WebsocketAPIClient` is for commands over Binance's WebSocket API. Think "REST API" but over persistent WebSockets.
+
+**Should I use listen keys for Spot user data?**
+
+Prefer `WebsocketAPIClient.subscribeUserDataStream(WS_KEY_MAP.mainWSAPI)` for Spot user data in this SDK version. The older Spot listen-key workflow is still present in places for compatibility, but Binance has marked the Spot listen-key workflow as deprecated.
+
+**What happens if a WebSocket connection drops?**
+
+The SDK supports reconnect and resubscribe flows. Listen for `reconnecting` and `reconnected`. Use `reconnected` as a trigger to reconcile state through the REST API before resuming risky trading actions.
+
+**Should I use demo trading or testnet?**
+
+Use demo trading when you want simulated trading with real market data. Use testnet for API wiring, endpoint behavior, and permission checks. Do not treat testnet market behavior as representative of live market behavior.
+
+**Can I use this Binance API SDK in TypeScript projects?**
+
+Yes. The package is TypeScript-first and publishes type declarations.
+
+**Do I need TypeScript to use this JavaScript Binance SDK?**
+
+No. Pure JavaScript projects can use this SDK too. Type declarations are included and will help your IDE, but TypeScript is not required.
+
+**Can I use this package in both ESM and CommonJS projects?**
+
+Yes. The package supports both ESM-style imports and CommonJS `require()`.
+
+**Does this guide cover every SDK method?**
+
+No. This guide covers the common first steps and production concerns. For full method coverage, see:
+
+- [Binance JavaScript endpoint reference](./endpointFunctionList.md)
+- [Binance SDK examples](../examples)
+- [TSDoc documentation](https://tsdocs.dev/docs/binance)
+
+---
+
+## Next steps
+
+If you want to learn more about integrating with Binance APIs and WebSockets:
+
+- Explore the [Binance JavaScript examples on GitHub](../examples)
+- Review the full endpoint list: [Binance JavaScript endpoint reference](./endpointFunctionList.md)
+- Check the Binance JavaScript SDK on npm: [`binance`](https://www.npmjs.com/package/binance)
+- Browse the source code of the Binance JavaScript SDK on GitHub: [`tiagosiebler/binance`](https://github.com/tiagosiebler/binance)
+- Review auth examples: [Ed25519](../examples/auth/rest-private-ed25519.md) and [RSA](../examples/auth/rest-private-rsa.md)
+- Explore the wider SDK ecosystem: [Siebly.io](https://siebly.io)
+
+================
+File: src/types/websockets/ws-api-requests.ts
+================
+import {
+  FuturesAlgoConditionalOrderTypes,
+  FuturesAlgoOrderType,
+  FuturesOrderType,
+  PositionSide,
+  PriceMatchMode,
+  WorkingType,
+} from '../futures';
+import {
+  BooleanString,
+  KlineInterval,
+  numberInString,
+  OrderResponseType,
+  OrderSide,
+  OrderTimeInForce,
+  OrderType,
+  SelfTradePreventionMode,
+} from '../shared';
 ⋮----
-/** Auto-generated */
-⋮----
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-⋮----
-export type Exact<T> = {
-  // This part says: if there's any key that's not in T, it's an error
-  // This conflicts sometimes for some reason...
-  // [K: string]: never;
-} & {
-  [K in keyof T]: T[K];
+/**
+ * Simple request params with timestamp (required) & recv window (optional)
+ */
+export type WSAPIRecvWindowTimestamp = {
+  recvWindow?: number;
+  timestamp: number;
 };
 ⋮----
-// This part says: if there's any key that's not in T, it's an error
-// This conflicts sometimes for some reason...
-// [K: string]: never;
-⋮----
 /**
- * List of operations supported for this WsKey (connection)
+ *
+ * Authentication request types
+ *
  */
-export interface WsAPIWsKeyTopicMap {
-  [WS_KEY_MAP.main]: WsOperation;
-  [WS_KEY_MAP.main2]: WsOperation;
-  [WS_KEY_MAP.main3]: WsOperation;
-
-  [WS_KEY_MAP.mainTestnetPublic]: WsOperation;
-  [WS_KEY_MAP.mainTestnetUserData]: WsOperation;
-
-  [WS_KEY_MAP.marginRiskUserData]: WsOperation;
-  [WS_KEY_MAP.marginUserData]: WsAPIOperation;
-  [WS_KEY_MAP.usdm]: WsOperation;
-  [WS_KEY_MAP.usdmTestnet]: WsOperation;
-
-  [WS_KEY_MAP.coinm]: WsOperation;
-  [WS_KEY_MAP.coinm2]: WsOperation;
-  [WS_KEY_MAP.coinmTestnet]: WsOperation;
-  [WS_KEY_MAP.eoptions]: WsOperation;
-  [WS_KEY_MAP.portfolioMarginUserData]: WsOperation;
-  [WS_KEY_MAP.portfolioMarginProUserData]: WsOperation;
-
-  [WS_KEY_MAP.alpha]: WsOperation;
-
-  [WS_KEY_MAP.mainWSAPI]: WsAPIOperation;
-  [WS_KEY_MAP.mainWSAPI2]: WsAPIOperation;
-  [WS_KEY_MAP.mainWSAPITestnet]: WsAPIOperation;
-
-  [WS_KEY_MAP.usdmWSAPI]: WsAPIOperation;
-  [WS_KEY_MAP.usdmWSAPITestnet]: WsAPIOperation;
-
-  [WS_KEY_MAP.coinmWSAPI]: WsAPIOperation;
-  [WS_KEY_MAP.coinmWSAPITestnet]: WsAPIOperation;
+export interface WSAPISessionLogonRequest {
+  timestamp: number;
 }
 ⋮----
-export type WsAPIFuturesWsKey =
-  | typeof WS_KEY_MAP.usdmWSAPI
-  | typeof WS_KEY_MAP.usdmWSAPITestnet;
+/**
+ *
+ * General request types
+ *
+ */
+export interface WSAPIExchangeInfoRequest {
+  symbol?: string;
+  symbols?: string[];
+  permissions?: string[];
+  showPermissionSets?: boolean;
+  symbolStatus?: string;
+}
 ⋮----
 /**
- * Request parameters expected per operation.
  *
- * - Each "key" here is the name of the command/operation.
- * - Each "value" here has the parameters required for the command.
+ * Market data request types
  *
- * Make sure to add new topics to WS_API_Operations and the response param map too.
  */
-export interface WsAPITopicRequestParamMap<TWSKey = WsKey> {
-  SUBSCRIBE: never;
-  UNSUBSCRIBE: never;
-  LIST_SUBSCRIPTIONS: never;
-  SET_PROPERTY: never;
-  GET_PROPERTY: never;
+⋮----
+export interface WSAPIOrderBookRequest {
+  symbol: string;
+  limit?: number;
+  symbolStatus?: string;
+}
+⋮----
+export interface WSAPITradesRecentRequest {
+  symbol: string;
+  limit?: number;
+}
+⋮----
+export interface WSAPITradesHistoricalRequest {
+  symbol: string;
+  fromId?: number;
+  limit?: number;
+}
+⋮----
+export interface WSAPIBlockTradesHistoricalRequest {
+  symbol: string;
+  fromId: number;
+  limit?: number;
+}
+⋮----
+export interface WSAPITradesAggregateRequest {
+  symbol: string;
+  fromId?: number;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+}
+⋮----
+export interface WSAPIKlinesRequest {
+  symbol: string;
+  interval: KlineInterval;
+  startTime?: number;
+  endTime?: number;
+  timeZone?: string;
+  limit?: number;
+}
+⋮----
+export interface WSAPIAvgPriceRequest {
+  symbol: string;
+}
+⋮----
+/**
+ * Query execution rules (e.g. PRICE_RANGE). Only one of symbol, symbols, or symbolStatus per request.
+ */
+export interface WSAPIExecutionRulesRequest {
+  symbol?: string;
+  symbols?: string[];
+  symbolStatus?: 'TRADING' | 'HALT' | 'BREAK';
+}
+⋮----
+export interface WSAPIReferencePriceRequest {
+  symbol: string;
+}
+⋮----
+export interface WSAPIReferencePriceCalculationRequest {
+  symbol: string;
+  symbolStatus?: 'TRADING' | 'HALT' | 'BREAK';
+}
+⋮----
+/**
+ * Symbol for single symbol, or symbols for multiple symbols
+ */
+export interface WSAPITicker24hrRequest {
+  symbol?: string;
+  symbols?: string[];
+  type?: 'FULL' | 'MINI';
+  symbolStatus?: string;
+}
+⋮----
+/**
+ * Symbol for single symbol, or symbols for multiple symbols
+ */
+export interface WSAPITickerTradingDayRequest {
+  symbol?: string;
+  symbols?: string[];
+  timeZone?: string;
+  type?: 'FULL' | 'MINI';
+  symbolStatus?: string;
+}
+⋮----
+/**
+ * Symbol for single symbol, or symbols for multiple symbols
+ */
+export interface WSAPITickerRequest {
+  symbol?: string;
+  symbols?: string[];
+  windowSize?: string; // '1m', '2m' ... '59m', '1h', '2h' ... '23h', '1d', '2d' ... '7d'
+  type?: 'FULL' | 'MINI';
+  symbolStatus?: string;
+}
+⋮----
+windowSize?: string; // '1m', '2m' ... '59m', '1h', '2h' ... '23h', '1d', '2d' ... '7d'
+⋮----
+/**
+ * Symbol for single symbol, or symbols for multiple symbols
+ */
+export interface WSAPITickerPriceRequest {
+  symbol?: string;
+  symbols?: string[];
+  symbolStatus?: string;
+}
+⋮----
+/**
+ * Symbol for single symbol, or symbols for multiple symbols
+ */
+export interface WSAPITickerBookRequest {
+  symbol?: string;
+  symbols?: string[];
+  symbolStatus?: string;
+}
+⋮----
+/**
+ *
+ * Account request types - Spot
+ *
+ */
+⋮----
+export interface WSAPIAllOrdersRequest {
+  symbol: string;
+  orderId?: number;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+}
+⋮----
+export interface WSAPIAllOrderListsRequest {
+  fromId?: number;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+}
+⋮----
+export interface WSAPIMyTradesRequest {
+  symbol: string;
+  orderId?: number;
+  startTime?: number;
+  endTime?: number;
+  fromId?: number;
+  limit?: number;
+}
+⋮----
+export interface WSAPIMyPreventedMatchesRequest {
+  symbol: string;
+  preventedMatchId?: number;
+  orderId?: number;
+  fromPreventedMatchId?: number;
+  limit?: number;
+}
+⋮----
+export interface WSAPIMyAllocationsRequest {
+  symbol: string;
+  startTime?: number;
+  endTime?: number;
+  fromAllocationId?: number;
+  limit?: number;
+  orderId?: number;
+}
+⋮----
+/**
+ * Trading request types
+ */
+⋮----
+export interface WSAPINewSpotOrderRequest {
+  symbol: string;
+  side: OrderSide;
+  type: OrderType;
+  timeInForce?: OrderTimeInForce;
+  price?: numberInString;
+  quantity?: numberInString;
+  quoteOrderQty?: numberInString;
+  newClientOrderId?: string;
+  newOrderRespType?: 'ACK' | 'RESULT' | 'FULL';
+  stopPrice?: numberInString;
+  trailingDelta?: number;
+  icebergQty?: numberInString;
+  strategyId?: number;
+  strategyType?: number;
+  selfTradePreventionMode?: string;
+}
+⋮----
+export interface WSAPIOrderTestRequest {
+  symbol: string;
+  side: 'BUY' | 'SELL';
+  type: string;
+  timeInForce?: string;
+  price?: numberInString;
+  quantity?: numberInString;
+  quoteOrderQty?: numberInString;
+  newClientOrderId?: string;
+  stopPrice?: numberInString;
+  trailingDelta?: number;
+  icebergQty?: numberInString;
+  strategyId?: number;
+  strategyType?: number;
+  selfTradePreventionMode?: string;
+  computeCommissionRates?: boolean;
+  timestamp: number;
+  recvWindow?: number;
+}
+⋮----
+export interface WSAPIOrderStatusRequest {
+  symbol: string;
+  orderId?: number;
+  origClientOrderId?: string;
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+export interface WSAPIOrderCancelRequest {
+  symbol: string;
+  orderId?: number;
+  origClientOrderId?: string;
+  newClientOrderId?: string;
+  cancelRestrictions?: 'ONLY_NEW' | 'ONLY_PARTIALLY_FILLED';
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+export interface WSAPIOrderCancelReplaceRequest {
+  symbol: string;
+  cancelReplaceMode: 'STOP_ON_FAILURE' | 'ALLOW_FAILURE';
+  cancelOrderId?: number;
+  cancelOrigClientOrderId?: string;
+  cancelNewClientOrderId?: string;
+  side: 'BUY' | 'SELL';
+  type: string;
+  timeInForce?: string;
+  price?: numberInString;
+  quantity?: numberInString;
+  quoteOrderQty?: numberInString;
+  newClientOrderId?: string;
+  newOrderRespType?: 'ACK' | 'RESULT' | 'FULL';
+  stopPrice?: numberInString;
+  trailingDelta?: number;
+  icebergQty?: numberInString;
+  strategyId?: number;
+  strategyType?: number;
+  selfTradePreventionMode?: string;
+  cancelRestrictions?: 'ONLY_NEW' | 'ONLY_PARTIALLY_FILLED';
+  orderRateLimitExceededMode?: 'DO_NOTHING' | 'CANCEL_ONLY';
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+export interface WSAPIOrderAmendKeepPriorityRequest {
+  symbol: string;
+  orderId?: number | string;
+  origClientOrderId?: string;
+  newClientOrderId?: string;
+  newQty?: string;
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+export interface WSAPIOpenOrdersStatusRequest {
+  symbol?: string;
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+export interface WSAPIOpenOrdersCancelAllRequest {
+  symbol: string;
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+/**
+ * Order list request types
+ */
+export interface WSAPIOrderListPlaceRequest {
+  symbol: string;
+  side: 'BUY' | 'SELL';
+  price: numberInString;
+  quantity: numberInString;
+  listClientOrderId?: string;
+  limitClientOrderId?: string;
+  limitIcebergQty?: numberInString;
+  limitStrategyId?: number;
+  limitStrategyType?: number;
+  stopPrice?: numberInString;
+  trailingDelta?: number;
+  stopClientOrderId?: string;
+  stopLimitPrice?: numberInString;
+  stopLimitTimeInForce?: string;
+  stopIcebergQty?: numberInString;
+  stopStrategyId?: number;
+  stopStrategyType?: number;
+  newOrderRespType?: 'ACK' | 'RESULT' | 'FULL';
+  selfTradePreventionMode?: string;
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+export interface WSAPIOrderListPlaceOCORequest {
+  symbol: string;
+  side: 'BUY' | 'SELL';
+  quantity: numberInString;
+  listClientOrderId?: string;
+  aboveType:
+    | 'STOP_LOSS_LIMIT'
+    | 'STOP_LOSS'
+    | 'LIMIT_MAKER'
+    | 'TAKE_PROFIT'
+    | 'TAKE_PROFIT_LIMIT';
+  aboveClientOrderId?: string;
+  aboveIcebergQty?: numberInString;
+  abovePrice?: numberInString;
+  aboveStopPrice?: numberInString;
+  aboveTrailingDelta?: number;
+  aboveTimeInForce?: string;
+  aboveStrategyId?: number;
+  aboveStrategyType?: number;
+  belowType:
+    | 'STOP_LOSS'
+    | 'STOP_LOSS_LIMIT'
+    | 'TAKE_PROFIT'
+    | 'TAKE_PROFIT_LIMIT'
+    | 'LIMIT_MAKER';
+  belowClientOrderId?: string;
+  belowIcebergQty?: numberInString;
+  belowPrice?: numberInString;
+  belowStopPrice?: numberInString;
+  belowTrailingDelta?: number;
+  belowTimeInForce?: string;
+  belowStrategyId?: number;
+  belowStrategyType?: number;
+  newOrderRespType?: 'ACK' | 'RESULT' | 'FULL';
+  selfTradePreventionMode?: string;
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+export interface WSAPIOrderListPlaceOTORequest {
+  symbol: string;
+  listClientOrderId?: string;
+  newOrderRespType?: 'ACK' | 'RESULT' | 'FULL';
+  selfTradePreventionMode?: string;
+  workingType: 'LIMIT' | 'LIMIT_MAKER';
+  workingSide: 'BUY' | 'SELL';
+  workingClientOrderId?: string;
+  workingPrice: numberInString;
+  workingQuantity: numberInString;
+  workingIcebergQty?: numberInString;
+  workingTimeInForce?: string;
+  workingStrategyId?: number;
+  workingStrategyType?: number;
+  pendingType: string;
+  pendingSide: 'BUY' | 'SELL';
+  pendingClientOrderId?: string;
+  pendingPrice?: numberInString;
+  pendingStopPrice?: numberInString;
+  pendingTrailingDelta?: numberInString;
+  pendingQuantity: numberInString;
+  pendingIcebergQty?: numberInString;
+  pendingTimeInForce?: string;
+  pendingStrategyId?: number;
+  pendingStrategyType?: number;
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+export interface WSAPIOrderListPlaceOTOCORequest {
+  symbol: string;
+  listClientOrderId?: string;
+  newOrderRespType?: 'ACK' | 'RESULT' | 'FULL';
+  selfTradePreventionMode?: string;
+  workingType: 'LIMIT' | 'LIMIT_MAKER';
+  workingSide: 'BUY' | 'SELL';
+  workingClientOrderId?: string;
+  workingPrice: numberInString;
+  workingQuantity: numberInString;
+  workingIcebergQty?: numberInString;
+  workingTimeInForce?: string;
+  workingStrategyId?: number;
+  workingStrategyType?: number;
+  pendingSide: 'BUY' | 'SELL';
+  pendingQuantity: number | string;
+  pendingAboveType:
+    | 'STOP_LOSS_LIMIT'
+    | 'STOP_LOSS'
+    | 'LIMIT_MAKER'
+    | 'TAKE_PROFIT'
+    | 'TAKE_PROFIT_LIMIT';
+  pendingAboveClientOrderId?: string;
+  pendingAbovePrice?: numberInString;
+  pendingAboveStopPrice?: numberInString;
+  pendingAboveTrailingDelta?: numberInString;
+  pendingAboveIcebergQty?: numberInString;
+  pendingAboveTimeInForce?: string;
+  pendingAboveStrategyId?: number;
+  pendingAboveStrategyType?: number;
+  pendingBelowType:
+    | 'STOP_LOSS'
+    | 'STOP_LOSS_LIMIT'
+    | 'TAKE_PROFIT'
+    | 'TAKE_PROFIT_LIMIT'
+    | 'LIMIT_MAKER';
+  pendingBelowClientOrderId?: string;
+  pendingBelowPrice?: numberInString;
+  pendingBelowStopPrice?: numberInString;
+  pendingBelowTrailingDelta?: numberInString;
+  pendingBelowIcebergQty?: numberInString;
+  pendingBelowTimeInForce?: string;
+  pendingBelowStrategyId?: number;
+  pendingBelowStrategyType?: number;
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+export interface WSAPIOrderListPlaceOPORequest {
+  symbol: string;
+  listClientOrderId?: string;
+  newOrderRespType?: 'ACK' | 'RESULT' | 'FULL';
+  selfTradePreventionMode?: string;
+  workingType: 'LIMIT' | 'LIMIT_MAKER';
+  workingSide: 'BUY' | 'SELL';
+  workingClientOrderId?: string;
+  workingPrice: numberInString;
+  workingQuantity: numberInString;
+  workingIcebergQty?: numberInString;
+  workingTimeInForce?: string;
+  workingStrategyId?: number;
+  workingStrategyType?: number;
+  workingPegPriceType?: string;
+  workingPegOffsetType?: string;
+  workingPegOffsetValue?: number;
+  pendingType: string;
+  pendingSide: 'BUY' | 'SELL';
+  pendingClientOrderId?: string;
+  pendingPrice?: numberInString;
+  pendingStopPrice?: numberInString;
+  pendingTrailingDelta?: numberInString;
+  pendingIcebergQty?: numberInString;
+  pendingTimeInForce?: string;
+  pendingStrategyId?: number;
+  pendingStrategyType?: number;
+  pendingPegPriceType?: string;
+  pendingPegOffsetType?: string;
+  pendingPegOffsetValue?: number;
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+export interface WSAPIOrderListPlaceOPOCORequest {
+  symbol: string;
+  listClientOrderId?: string;
+  newOrderRespType?: 'ACK' | 'RESULT' | 'FULL';
+  selfTradePreventionMode?: string;
+  workingType: 'LIMIT' | 'LIMIT_MAKER';
+  workingSide: 'BUY' | 'SELL';
+  workingClientOrderId?: string;
+  workingPrice: numberInString;
+  workingQuantity: numberInString;
+  workingIcebergQty?: numberInString;
+  workingTimeInForce?: string;
+  workingStrategyId?: number;
+  workingStrategyType?: number;
+  workingPegPriceType?: string;
+  workingPegOffsetType?: string;
+  workingPegOffsetValue?: number;
+  pendingSide: 'BUY' | 'SELL';
+  pendingAboveType:
+    | 'STOP_LOSS_LIMIT'
+    | 'STOP_LOSS'
+    | 'LIMIT_MAKER'
+    | 'TAKE_PROFIT'
+    | 'TAKE_PROFIT_LIMIT';
+  pendingAboveClientOrderId?: string;
+  pendingAbovePrice?: numberInString;
+  pendingAboveStopPrice?: numberInString;
+  pendingAboveTrailingDelta?: numberInString;
+  pendingAboveIcebergQty?: numberInString;
+  pendingAboveTimeInForce?: string;
+  pendingAboveStrategyId?: number;
+  pendingAboveStrategyType?: number;
+  pendingAbovePegPriceType?: string;
+  pendingAbovePegOffsetType?: string;
+  pendingAbovePegOffsetValue?: number;
+  pendingBelowType?:
+    | 'STOP_LOSS'
+    | 'STOP_LOSS_LIMIT'
+    | 'TAKE_PROFIT'
+    | 'TAKE_PROFIT_LIMIT';
+  pendingBelowClientOrderId?: string;
+  pendingBelowPrice?: numberInString;
+  pendingBelowStopPrice?: numberInString;
+  pendingBelowTrailingDelta?: numberInString;
+  pendingBelowIcebergQty?: numberInString;
+  pendingBelowTimeInForce?: string;
+  pendingBelowStrategyId?: number;
+  pendingBelowStrategyType?: number;
+  pendingBelowPegPriceType?: string;
+  pendingBelowPegOffsetType?: string;
+  pendingBelowPegOffsetValue?: number;
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+export interface WSAPIOrderListStatusRequest {
+  origClientOrderId?: string;
+  orderListId?: number;
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+export interface WSAPIOrderListCancelRequest {
+  symbol: string;
+  orderListId?: number;
+  listClientOrderId?: string;
+  newClientOrderId?: string;
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+/**
+ * SOR request types
+ */
+export interface WSAPISOROrderPlaceRequest {
+  symbol: string;
+  side: 'BUY' | 'SELL';
+  type: 'LIMIT' | 'MARKET';
+  timeInForce?: string;
+  price?: numberInString;
+  quantity: numberInString;
+  newClientOrderId?: string;
+  newOrderRespType?: 'ACK' | 'RESULT' | 'FULL';
+  icebergQty?: numberInString;
+  strategyId?: number;
+  strategyType?: number;
+  selfTradePreventionMode?: string;
+  timestamp: number;
+  recvWindow?: number;
+}
+⋮----
+export type WSAPISOROrderTestRequest = WSAPISOROrderPlaceRequest & {
+  computeCommissionRates?: boolean;
+};
+⋮----
+/**
+ * Futures market data request types
+ */
+⋮----
+export interface WSAPIFuturesOrderBookRequest {
+  symbol: string;
+  limit?: number;
+}
+⋮----
+export interface WSAPIFuturesTickerPriceRequest {
+  symbol?: string;
+}
+⋮----
+export interface WSAPIFuturesTickerBookRequest {
+  symbol?: string;
+}
+⋮----
+/**
+ * Futures trading request types
+ */
+⋮----
+export interface WSAPINewFuturesOrderRequest<numberType = numberInString> {
+  symbol: string;
+  side: OrderSide;
+  positionSide?: PositionSide;
+  type: FuturesOrderType;
+  timeInForce?: OrderTimeInForce;
+  quantity?: numberType;
+  reduceOnly?: BooleanString;
+  price?: numberType;
+  newClientOrderId?: string;
+  stopPrice?: numberType;
+  closePosition?: BooleanString;
+  activationPrice?: numberType;
+  callbackRate?: numberType;
+  workingType?: WorkingType;
+  priceProtect?: BooleanString;
+  newOrderRespType?: 'ACK' | 'RESULT';
+  selfTradePreventionMode?: SelfTradePreventionMode;
+  priceMatch?: PriceMatchMode;
+  goodTillDate?: number; // Mandatory when timeInForce is GTD
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+goodTillDate?: number; // Mandatory when timeInForce is GTD
+⋮----
+export interface WSAPIFuturesOrderModifyRequest {
+  symbol: string;
+  orderId?: number;
+  origClientOrderId?: string;
+  side: 'BUY' | 'SELL';
+  quantity: numberInString;
+  price: numberInString;
+  priceMatch?:
+    | 'NONE'
+    | 'OPPONENT'
+    | 'OPPONENT_5'
+    | 'OPPONENT_10'
+    | 'OPPONENT_20'
+    | 'QUEUE'
+    | 'QUEUE_5'
+    | 'QUEUE_10'
+    | 'QUEUE_20';
+  origType?: string;
+  positionSide?: 'BOTH' | 'LONG' | 'SHORT';
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+export interface WSAPIFuturesOrderCancelRequest {
+  symbol: string;
+  orderId?: number;
+  origClientOrderId?: string;
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+export interface WSAPIFuturesOrderStatusRequest {
+  symbol: string;
+  orderId?: number;
+  origClientOrderId?: string;
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+export interface WSAPIFuturesPositionRequest {
+  symbol?: string;
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+export interface WSAPIFuturesPositionV2Request {
+  symbol?: string;
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+export interface WSAPIAccountInformationRequest {
+  omitZeroBalances?: boolean;
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+export interface WSAPIAccountCommissionWSAPIRequest {
+  symbol: string;
+}
+⋮----
+/**
+ * Ref: https://developers.binance.com/docs/derivatives/usds-margined-futures/trade/websocket-api
+ */
+export interface WSAPINewFuturesAlgoOrderRequest<numberType = numberInString> {
+  algoType: FuturesAlgoOrderType;
+  symbol: string;
+  side: OrderSide;
+  positionSide?: PositionSide;
+  type: FuturesAlgoConditionalOrderTypes;
+  timeInForce?: OrderTimeInForce;
+  quantity?: numberType;
+  reduceOnly?: BooleanString;
+  price?: numberInString;
+  clientAlgoId?: string;
+  triggerPrice?: numberInString;
+  closePosition?: BooleanString;
+  activatePrice?: numberInString;
+  callbackRate?: numberInString;
+  workingType?: WorkingType;
+  priceProtect?: BooleanString;
+  newOrderRespType?: OrderResponseType;
+  priceMatch?: PriceMatchMode;
+  selfTradePreventionMode?: SelfTradePreventionMode;
+  goodTillDate?: number; // Mandatory when timeInForce is GTD
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+goodTillDate?: number; // Mandatory when timeInForce is GTD
+⋮----
+/**
+ * Ref: https://developers.binance.com/docs/derivatives/usds-margined-futures/trade/websocket-api/Cancel-Algo-Order
+ */
+export interface WSAPIFuturesAlgoOrderCancelRequest {
+  algoid?: number;
+  clientalgoid?: string;
+  recvWindow?: number;
+  timestamp: number;
+}
 
-  /**
-   * Authentication commands & parameters:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/authentication-requests
-   */
-  'session.logon': WSAPISessionLogonRequest;
-  'session.status': void;
-  'session.logout': void;
-
-  /**
-   * General requests & parameters:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/general-requests
-   */
-  ping: void;
-  time: void;
-
-  exchangeInfo: void | WSAPIExchangeInfoRequest;
-
-  /**
-   * Market data requests & parameters:
-   * - Spot:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/market-data-requests
-   * - Futures:
-   * https://developers.binance.com/docs/derivatives/usds-margined-futures/market-data/websocket-api
-   */
-  depth: TWSKey extends WsAPIFuturesWsKey
-    ? WSAPIFuturesOrderBookRequest
-    : WSAPIOrderBookRequest;
-  'trades.recent': WSAPITradesRecentRequest;
-  'trades.historical': WSAPITradesHistoricalRequest;
-  'trades.aggregate': WSAPITradesAggregateRequest;
-  klines: WSAPIKlinesRequest;
-  uiKlines: WSAPIKlinesRequest;
-  avgPrice: WSAPIAvgPriceRequest;
-  executionRules: void | WSAPIExecutionRulesRequest;
-  referencePrice: WSAPIReferencePriceRequest;
-  'referencePrice.calculation': WSAPIReferencePriceCalculationRequest;
-  'ticker.24hr': void | WSAPITicker24hrRequest;
-  'ticker.tradingDay': WSAPITickerTradingDayRequest;
-  ticker: WSAPITickerRequest;
-  'ticker.price': void | TWSKey extends WsAPIFuturesWsKey
-    ? WSAPIFuturesTickerPriceRequest | undefined
-    : WSAPITickerPriceRequest | undefined;
-  'ticker.book': void | TWSKey extends WsAPIFuturesWsKey
-    ? WSAPIFuturesTickerBookRequest | undefined
-    : WSAPITickerBookRequest | undefined;
-
-  /**
-   * Account requests & parameters:
-   * - Spot:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/account-requests
-   * - Futures:
-   * https://developers.binance.com/docs/derivatives/usds-margined-futures/account/websocket-api
-   */
-
-  'account.status':
-    | void
-    | (TWSKey extends WsAPIFuturesWsKey
-        ? WSAPIRecvWindowTimestamp
-        : WSAPIAccountInformationRequest);
-
-  'account.rateLimits.orders': void | WSAPIRecvWindowTimestamp;
-
-  allOrders: WSAPIAllOrdersRequest;
-
-  allOrderLists: void | WSAPIAllOrderListsRequest;
-
-  myTrades: WSAPIMyTradesRequest;
-
-  myPreventedMatches: WSAPIMyPreventedMatchesRequest;
-
-  myAllocations: WSAPIMyAllocationsRequest;
-
-  'account.commission': WSAPIAccountCommissionWSAPIRequest;
-
-  /**
-   * Futures account requests & parameters:
-   * https://developers.binance.com/docs/derivatives/usds-margined-futures/account/websocket-api
-   */
-  'account.position': WSAPIRecvWindowTimestamp;
-
-  'v2/account.position': WSAPIRecvWindowTimestamp;
-
-  'account.balance': WSAPIRecvWindowTimestamp;
-
-  'v2/account.balance': WSAPIRecvWindowTimestamp;
-
-  'v2/account.status': WSAPIRecvWindowTimestamp;
-
-  /**
-   * Trading requests & parameters:
-   * - Spot:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/trading-requests
-   * - Futures:
-   * https://developers.binance.com/docs/derivatives/usds-margined-futures/trading/websocket-api
-   */
-  'order.place': (TWSKey extends WsAPIFuturesWsKey
-    ? WSAPINewFuturesOrderRequest
-    : WSAPINewSpotOrderRequest) & {
-    timestamp?: number;
+================
+File: src/types/websockets/ws-general.ts
+================
+import { AxiosRequestConfig } from 'axios';
+import type { ClientRequestArgs } from 'http';
+import WebSocket from 'isomorphic-ws';
+⋮----
+import { RestClientOptions } from '../../util/requestUtils';
+import { WsKey } from '../../util/websockets/websocket-util';
+⋮----
+export interface MessageEventLike {
+  target: WebSocket;
+  type: 'message';
+  data: string;
+}
+⋮----
+export function isMessageEvent(msg: unknown): msg is MessageEventLike
+⋮----
+export type WsMarket =
+  | 'spot'
+  | 'spotTestnet'
+  | 'crossMargin'
+  | 'isolatedMargin'
+  | 'riskDataMargin'
+  | 'usdm'
+  | 'usdmTestnet'
+  | 'coinm'
+  | 'coinmTestnet'
+  | 'options'
+  | 'optionsTestnet'
+  | 'portfoliom'
+  | 'alpha';
+⋮----
+export interface WsSharedBase {
+  wsMarket: WsMarket;
+  wsKey: WsKey;
+  streamName: string;
+}
+⋮----
+export interface WsResponse {
+  type: 'message';
+  data: {
+    result: boolean | string[] | null;
+    id: number;
+    isWSAPIResponse: boolean;
+    wsKey: WsKey;
   };
-  'order.test': WSAPIOrderTestRequest;
-  'order.status': TWSKey extends WsAPIFuturesWsKey
-    ? WSAPIFuturesOrderStatusRequest
-    : WSAPIOrderStatusRequest;
-  'order.cancel': TWSKey extends WsAPIFuturesWsKey
-    ? WSAPIFuturesOrderCancelRequest
-    : WSAPIOrderCancelRequest;
-  'order.modify': WSAPIFuturesOrderModifyRequest; // order.modify only futures
-  'order.cancelReplace': WSAPIOrderCancelReplaceRequest;
-  'order.amend.keepPriority': WSAPIOrderAmendKeepPriorityRequest;
-  'openOrders.status': WSAPIOpenOrdersStatusRequest;
-  'openOrders.cancelAll': WSAPIOpenOrdersCancelAllRequest;
-
-  'algoOrder.place': WSAPINewFuturesAlgoOrderRequest;
-  'algoOrder.cancel': WSAPIFuturesAlgoOrderCancelRequest;
-
-  /**
-   * Order list requests & parameters:
-   */
-  'orderList.place': WSAPIOrderListPlaceRequest;
-  'orderList.place.oco': WSAPIOrderListPlaceOCORequest;
-  'orderList.place.oto': WSAPIOrderListPlaceOTORequest;
-  'orderList.place.otoco': WSAPIOrderListPlaceOTOCORequest;
-  'orderList.place.opo': WSAPIOrderListPlaceOPORequest;
-  'orderList.place.opoco': WSAPIOrderListPlaceOPOCORequest;
-  'orderList.status': WSAPIOrderListStatusRequest;
-  'orderList.cancel': WSAPIOrderListCancelRequest;
-
-  'openOrderLists.status': WSAPIRecvWindowTimestamp;
-
-  /**
-   * SOR requests & parameters:
-   */
-  'sor.order.place': WSAPISOROrderPlaceRequest;
-  'sor.order.test': WSAPISOROrderTestRequest;
-
-  /**
-   * User data stream:
-   *
-   * - Spot:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/user-data-stream-requests
-   *
-   * - Futures:
-   * https://developers.binance.com/docs/derivatives/usds-margined-futures/account/websocket-api
-   *
-   * Note: for the user data stream, use the subscribe*UserDataStream() methods from the WS Client.
-   */
-  'userDataStream.start': { apiKey: string };
-  'userDataStream.ping': WSAPIUserDataListenKeyRequest;
-  'userDataStream.stop': WSAPIUserDataListenKeyRequest;
-  'userDataStream.subscribe': void;
-  'userDataStream.subscribe.signature': { timestamp: number };
-  'userDataStream.unsubscribe': void;
-
-  /**
-   * User data streams, margin:
-   */
-  'userDataStream.subscribe.listenToken': { listenToken: string };
 }
 ⋮----
-/**
-   * Authentication commands & parameters:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/authentication-requests
+// Same as inverse futures
+export type WsPublicInverseTopic =
+  | 'orderBookL2_25'
+  | 'orderBookL2_200'
+  | 'trade'
+  | 'insurance'
+  | 'instrument_info'
+  | 'klineV2';
+⋮----
+export type WsPublicUSDTPerpTopic =
+  | 'orderBookL2_25'
+  | 'orderBookL2_200'
+  | 'trade'
+  | 'insurance'
+  | 'instrument_info'
+  | 'kline';
+⋮----
+export type WsPublicSpotV1Topic =
+  | 'trade'
+  | 'realtimes'
+  | 'kline'
+  | 'mergedDepth'
+  | 'diffDepth';
+⋮----
+export type WsPublicSpotV2Topic = 'depth' | 'kline' | 'trade' | 'realtimes';
+⋮----
+// https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Important-WebSocket-Change-Notice#public-high-frequency-public-data
+export type WsPublicUSDMTopic = 'bookTicker' | 'depth';
+⋮----
+// https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Important-WebSocket-Change-Notice#market-regular-market-data
+export type WsMarketUSDMTopic =
+  | 'aggTrade'
+  | 'markPrice'
+  | 'kline'
+  | 'continuousKline'
+  | 'miniTicker'
+  | 'ticker'
+  | 'forceOrder'
+  | 'compositeIndex'
+  | 'contractInfo'
+  | 'assetIndex';
+⋮----
+export type WsPublicTopics =
+  | WsPublicInverseTopic
+  | WsPublicUSDTPerpTopic
+  | WsPublicSpotV1Topic
+  | WsPublicSpotV2Topic
+  | WsMarketUSDMTopic
+  | WsPublicUSDMTopic
+  | string;
+⋮----
+// Same as inverse futures
+export type WsPrivateInverseTopic =
+  | 'position'
+  | 'execution'
+  | 'order'
+  | 'stop_order';
+⋮----
+export type WsPrivateUSDTPerpTopic =
+  | 'position'
+  | 'execution'
+  | 'order'
+  | 'stop_order'
+  | 'wallet';
+⋮----
+export type WsPrivateSpotTopic =
+  | 'outboundAccountInfo'
+  | 'executionReport'
+  | 'ticketInfo';
+⋮----
+export type WsPrivateTopic =
+  | WsPrivateInverseTopic
+  | WsPrivateUSDTPerpTopic
+  | WsPrivateSpotTopic
+  | string;
+⋮----
+export type WsTopic = WsPublicTopics | WsPrivateTopic;
+⋮----
+export interface WSClientConfigurableOptions {
+  /** Your API key */
+  api_key?: string;
+
+  /** Your API secret */
+  api_secret?: string;
+
+  beautify?: boolean;
+
+  /**
+   * If true, log a warning if the beautifier is missing anything for an event
    */
-⋮----
-/**
-   * General requests & parameters:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/general-requests
-   */
-⋮----
-/**
-   * Market data requests & parameters:
-   * - Spot:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/market-data-requests
-   * - Futures:
-   * https://developers.binance.com/docs/derivatives/usds-margined-futures/market-data/websocket-api
-   */
-⋮----
-/**
-   * Account requests & parameters:
-   * - Spot:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/account-requests
-   * - Futures:
-   * https://developers.binance.com/docs/derivatives/usds-margined-futures/account/websocket-api
-   */
-⋮----
-/**
-   * Futures account requests & parameters:
-   * https://developers.binance.com/docs/derivatives/usds-margined-futures/account/websocket-api
-   */
-⋮----
-/**
-   * Trading requests & parameters:
-   * - Spot:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/trading-requests
-   * - Futures:
-   * https://developers.binance.com/docs/derivatives/usds-margined-futures/trading/websocket-api
-   */
-⋮----
-'order.modify': WSAPIFuturesOrderModifyRequest; // order.modify only futures
-⋮----
-/**
-   * Order list requests & parameters:
-   */
-⋮----
-/**
-   * SOR requests & parameters:
-   */
-⋮----
-/**
-   * User data stream:
+  beautifyWarnIfMissing?: boolean;
+
+  /**
+   * Set to `true` to connect to Binance's testnet environment.
    *
-   * - Spot:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/user-data-stream-requests
+   * Notes:
+   * - Not all WebSocket categories support testnet.
+   * - If testing a strategy, this is not recommended. Testnet market data is very different from real market conditions. More guidance here: https://github.com/tiagosiebler/awesome-crypto-examples/wiki/CEX-Testnets
+   */
+  testnet?: boolean;
+
+  /**
+   * Set to `true` to use Binance's demo trading WebSocket endpoints.
+   * Demo trading uses real market data but simulated trading.
+   * More info: https://demo.binance.com/
    *
-   * - Futures:
-   * https://developers.binance.com/docs/derivatives/usds-margined-futures/account/websocket-api
+   * Notes:
+   * - If demo trading, `testnet` should be set to false!
+   * - If testing a strategy, use demo trading instead. Testnet market data is very different from real market conditions.
+   */
+  demoTrading?: boolean;
+
+  /**
+   * Default: false. If true, use market maker endpoints when available.
+   * Eligible for high-frequency trading users who have enrolled and qualified
+   * in at least one of the Futures Liquidity Provider Programs.
+   * More info: https://www.binance.com/en/support/faq/detail/7df7f3838c3b49e692d175374c3a3283
+   */
+  useMMSubdomain?: boolean;
+
+  /** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
+  recvWindow?: number;
+
+  // Disable ping/pong ws heartbeat mechanism (not recommended)
+  disableHeartbeat?: boolean;
+
+  /** How often to check if the connection is alive */
+  pingInterval?: number;
+
+  /** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
+  pongTimeout?: number;
+
+  /** Delay in milliseconds before respawning the connection */
+  reconnectTimeout?: number;
+
+  restOptions?: RestClientOptions;
+
+  requestOptions?: AxiosRequestConfig;
+
+  wsOptions?: {
+    protocols?: string[];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    agent?: any;
+  } & Partial<WebSocket.ClientOptions | ClientRequestArgs>;
+
+  wsUrl?: string;
+
+  /**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
    *
-   * Note: for the user data stream, use the subscribe*UserDataStream() methods from the WS Client.
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
+
+  /**
+   * Optional custom JSON parser used for incoming WS messages.
+   * Defaults to JSON.parse.
+   */
+  customParseJSONFn?: (raw: string) => object;
+}
+⋮----
+/** Your API key */
+⋮----
+/** Your API secret */
+⋮----
+/**
+   * If true, log a warning if the beautifier is missing anything for an event
    */
 ⋮----
 /**
-   * User data streams, margin:
+   * Set to `true` to connect to Binance's testnet environment.
+   *
+   * Notes:
+   * - Not all WebSocket categories support testnet.
+   * - If testing a strategy, this is not recommended. Testnet market data is very different from real market conditions. More guidance here: https://github.com/tiagosiebler/awesome-crypto-examples/wiki/CEX-Testnets
    */
 ⋮----
 /**
- * Response structure expected for each operation
- *
- * - Each "key" here is a command/request supported by the WS API
- * - Each "value" here is the response schema for that command.
+   * Set to `true` to use Binance's demo trading WebSocket endpoints.
+   * Demo trading uses real market data but simulated trading.
+   * More info: https://demo.binance.com/
+   *
+   * Notes:
+   * - If demo trading, `testnet` should be set to false!
+   * - If testing a strategy, use demo trading instead. Testnet market data is very different from real market conditions.
+   */
+⋮----
+/**
+   * Default: false. If true, use market maker endpoints when available.
+   * Eligible for high-frequency trading users who have enrolled and qualified
+   * in at least one of the Futures Liquidity Provider Programs.
+   * More info: https://www.binance.com/en/support/faq/detail/7df7f3838c3b49e692d175374c3a3283
+   */
+⋮----
+/** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
+⋮----
+// Disable ping/pong ws heartbeat mechanism (not recommended)
+⋮----
+/** How often to check if the connection is alive */
+⋮----
+/** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
+⋮----
+/** Delay in milliseconds before respawning the connection */
+⋮----
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+⋮----
+/**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
+   *
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+⋮----
+/**
+   * Optional custom JSON parser used for incoming WS messages.
+   * Defaults to JSON.parse.
+   */
+⋮----
+/**
+ * WS configuration that's always defined, regardless of user configuration
+ * (usually comes from defaults if there's no user-provided values)
  */
-export interface WsAPIOperationResponseMap {
-  [key: string]: unknown;
+export interface WebsocketClientOptions extends WSClientConfigurableOptions {
+  pongTimeout: number;
+  pingInterval: number;
+  reconnectTimeout: number;
+  recvWindow: number;
+  authPrivateConnectionsOnConnect: boolean;
+  authPrivateRequestsIndividually: boolean;
+}
 
-  SUBSCRIBE: never;
-  UNSUBSCRIBE: never;
-  LIST_SUBSCRIPTIONS: never;
-  SET_PROPERTY: never;
-  GET_PROPERTY: never;
-
-  /**
-   * Session authentication responses:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/session-authentication
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/authentication-requests
-   */
-  'session.login': WSAPIResponse<WSAPISessionStatus>;
-  'session.status': WSAPIResponse<WSAPISessionStatus>;
-  'session.logout': WSAPIResponse<WSAPISessionStatus>;
-
-  /**
-   * General responses:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/general-requests
-   */
-
-  ping: unknown;
-  time: WSAPIResponse<WSAPIServerTime>;
-  exchangeInfo: WSAPIResponse<FuturesExchangeInfo | ExchangeInfo>;
-
-  /**
-   * Market data responses
-   * - Spot:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/market-data-requests
-   * - Futures:
-   * https://developers.binance.com/docs/derivatives/usds-margined-futures/market-data/websocket-api
-   */
-  depth: WSAPIResponse<WSAPIOrderBook | WSAPIFuturesOrderBook>;
-  'trades.recent': WSAPIResponse<WSAPITrade[]>;
-  'trades.historical': WSAPIResponse<WSAPITrade[]>;
-  'trades.aggregate': WSAPIResponse<WSAPIAggregateTrade[]>;
-  klines: WSAPIResponse<WSAPIKline[]>;
-  uiKlines: WSAPIResponse<WSAPIKline[]>;
-  avgPrice: WSAPIResponse<WSAPIAvgPrice>;
-  executionRules: WSAPIResponse<SpotExecutionRulesResponse>;
-  referencePrice: WSAPIResponse<SpotReferencePriceResult>;
-  'referencePrice.calculation': WSAPIResponse<SpotReferencePriceCalculationResponse>;
-  'ticker.24hr': WSAPIResponse<
-    WSAPIFullTicker | WSAPIMiniTicker | WSAPIFullTicker[] | WSAPIMiniTicker[]
-  >;
-  'ticker.tradingDay': WSAPIResponse<
-    WSAPIFullTicker | WSAPIMiniTicker | WSAPIFullTicker[] | WSAPIMiniTicker[]
-  >;
-  ticker: WSAPIResponse<
-    WSAPIFullTicker | WSAPIMiniTicker | WSAPIFullTicker[] | WSAPIMiniTicker[]
-  >;
-  'ticker.price': WSAPIResponse<
-    | WSAPIPriceTicker
-    | WSAPIPriceTicker[]
-    | WSAPIFuturesPriceTicker
-    | WSAPIFuturesPriceTicker[]
-  >;
-  'ticker.book': WSAPIResponse<
-    | WSAPIBookTicker
-    | WSAPIBookTicker[]
-    | WSAPIFuturesBookTicker
-    | WSAPIFuturesBookTicker[]
-  >;
-
-  /**
-   * Account responses:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/account-requests
-   */
-
-  'account.status': WSAPIResponse<
-    WSAPIAccountInformation | WSAPIFuturesAccountStatus
-  >;
-  'account.commission': WSAPIResponse<WSAPIAccountCommission>;
-  'account.rateLimits.orders': WSAPIResponse<WSAPIRateLimit[]>;
-  allOrders: WSAPIResponse<WSAPIOrder[]>;
-  allOrderLists: WSAPIResponse<WSAPIOrderListStatusResponse[]>;
-  myTrades: WSAPIResponse<WSAPITrade[]>;
-  myPreventedMatches: WSAPIResponse<WSAPIPreventedMatch[]>;
-  myAllocations: WSAPIResponse<WSAPIAllocation[]>;
-
-  /**
-   * Futures account responses:
-   * https://developers.binance.com/docs/derivatives/usds-margined-futures/account/websocket-api
-   */
-  'account.position': WSAPIResponse<WSAPIFuturesPosition[]>;
-  'v2/account.position': WSAPIResponse<WSAPIFuturesPositionV2[]>;
-  'account.balance': WSAPIResponse<WSAPIFuturesAccountBalanceItem[]>;
-  'v2/account.balance': WSAPIResponse<WSAPIFuturesAccountBalanceItem[]>;
-  'v2/account.status': WSAPIResponse<WSAPIFuturesAccountStatus>;
-
-  /**
-   * Trading responses
-   * - Spot:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/trading-requests
-   * - Futures:
-   * https://developers.binance.com/docs/derivatives/usds-margined-futures/trading/websocket-api
-   */
-  'order.place': WSAPIResponse<WSAPISpotOrderResponse | WSAPIFuturesOrder>;
-  'order.test': WSAPIResponse<
-    WSAPIOrderTestResponse | WSAPIOrderTestWithCommission
-  >;
-  'order.status': WSAPIResponse<WSAPIOrder | WSAPIFuturesOrder>;
-  'order.cancel': WSAPIResponse<WSAPIOrderCancel | WSAPIFuturesOrder>;
-  'order.modify': WSAPIResponse<WSAPIFuturesOrder>;
-  'order.cancelReplace': WSAPIResponse<WSAPIOrderCancelReplaceResponse>;
-  'openOrders.status': WSAPIResponse<WSAPIOrder[] | WSAPIFuturesOrder[]>;
-  'openOrders.cancelAll': WSAPIResponse<
-    (WSAPIOrderCancel | WSAPIOrderListCancelResponse)[]
-  >;
-  'algoOrder.place': WSAPIResponse<WSAPIFuturesAlgoOrder>;
-  'algoOrder.cancel': WSAPIResponse<WSAPIFuturesAlgoOrderCancelResponse>;
-  /**
-   * Order list responses
-   */
-  'orderList.place': WSAPIResponse<WSAPIOrderListPlaceResponse>;
-  'orderList.place.oco': WSAPIResponse<WSAPIOrderListPlaceResponse>;
-  'orderList.place.oto': WSAPIResponse<WSAPIOrderListPlaceResponse>;
-  'orderList.place.otoco': WSAPIResponse<WSAPIOrderListPlaceResponse>;
-  'orderList.place.opo': WSAPIResponse<WSAPIOrderListPlaceResponse>;
-  'orderList.place.opoco': WSAPIResponse<WSAPIOrderListPlaceResponse>;
-  'orderList.status': WSAPIResponse<WSAPIOrderListStatusResponse>;
-  'orderList.cancel': WSAPIResponse<WSAPIOrderListCancelResponse>;
-  'openOrderLists.status': WSAPIResponse<WSAPIOrderListStatusResponse[]>;
-
-  /**
-   * SOR responses
-   */
-  'sor.order.place': WSAPIResponse<WSAPISOROrderPlaceResponse>;
-  'sor.order.test': WSAPIResponse<
-    WSAPISOROrderTestResponse | WSAPISOROrderTestResponseWithCommission
-  >;
-
-  'userDataStream.start': WSAPIResponse<{ listenKey: string }>;
-  'userDataStream.ping': WSAPIResponse<object>;
-  'userDataStream.stop': WSAPIResponse<object>;
-  'userDataStream.subscribe': WSAPIResponse<object>;
-  'userDataStream.subscribe.signature': WSAPIResponse<object>;
-  'userDataStream.unsubscribe': WSAPIResponse<object>;
+================
+File: src/types/futures.ts
+================
+import {
+  BooleanString,
+  ExchangeFilter,
+  KlineInterval,
+  numberInString,
+  OrderBookRow,
+  OrderSide,
+  OrderStatus,
+  OrderTimeInForce,
+  OrderType,
+  RateLimiter,
+  SelfTradePreventionMode,
+  SymbolIcebergPartsFilter,
+  SymbolLotSizeFilter,
+  SymbolMarketLotSizeFilter,
+  SymbolMaxIcebergOrdersFilter,
+  SymbolMaxPositionFilter,
+  SymbolPriceFilter,
+} from './shared';
+⋮----
+export type FuturesContractType =
+  | 'PERPETUAL'
+  | 'CURRENT_MONTH'
+  | 'NEXT_MONTH'
+  | 'CURRENT_QUARTER'
+  | 'NEXT_QUARTER';
+⋮----
+export interface ContinuousContractKlinesParams {
+  pair: string;
+  contractType: FuturesContractType;
+  interval: KlineInterval;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+}
+⋮----
+export interface IndexPriceKlinesParams {
+  pair: string;
+  interval: KlineInterval;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+}
+⋮----
+export interface SymbolKlinePaginatedParams {
+  symbol: string;
+  interval: KlineInterval;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+}
+⋮----
+export interface FuturesDataPaginatedParams {
+  symbol: string;
+  contractType?: string;
+  period: '5m' | '15m' | '30m' | '1h' | '2h' | '4h' | '6h' | '12h' | '1d';
+  limit?: number;
+  startTime?: number;
+  endTime?: number;
+}
+⋮----
+export interface FuturesCoinMTakerBuySellVolumeParams {
+  pair: string;
+  contractType: 'ALL' | 'CURRENT_QUARTER' | 'NEXT_QUARTER' | 'PERPETUAL';
+  period: '5m' | '15m' | '30m' | '1h' | '2h' | '4h' | '6h' | '12h' | '1d';
+  limit?: number;
+  startTime?: number;
+  endTime?: number;
+}
+⋮----
+export interface FuturesCoinMBasisParams {
+  pair: string;
+  contractType: 'CURRENT_QUARTER' | 'NEXT_QUARTER' | 'PERPETUAL';
+  period: '5m' | '15m' | '30m' | '1h' | '2h' | '4h' | '6h' | '12h' | '1d';
+  limit?: number;
+  startTime?: number;
+  endTime?: number;
+}
+⋮----
+export enum EnumDualSideMode {
+  HedgeMode = 'true',
+  OneWayMode = 'false',
+}
+⋮----
+export type DualSideMode = `${EnumDualSideMode}`;
+⋮----
+export enum EnumMultiAssetMode {
+  MultiAssetsMode = 'true',
+  SingleAssetsMode = 'false',
+}
+⋮----
+export type MultiAssetsMode = `${EnumMultiAssetMode}`;
+⋮----
+export type PositionSide = 'BOTH' | 'LONG' | 'SHORT';
+⋮----
+export type MarginType = 'ISOLATED' | 'CROSSED';
+⋮----
+export type WorkingType = 'MARK_PRICE' | 'CONTRACT_PRICE';
+⋮----
+export type FuturesOrderType =
+  | 'LIMIT'
+  | 'MARKET'
+  | 'STOP'
+  | 'STOP_MARKET'
+  | 'TAKE_PROFIT'
+  | 'TAKE_PROFIT_MARKET'
+  | 'TRAILING_STOP_MARKET';
+⋮----
+export type PriceMatchMode =
+  | 'NONE'
+  | 'OPPONENT'
+  | 'OPPONENT_5'
+  | 'OPPONENT_10'
+  | 'OPPONENT_20'
+  | 'QUEUE'
+  | 'QUEUE_5'
+  | 'QUEUE_10'
+  | 'QUEUE_20';
+⋮----
+// When using the submitMultipleOrders() endpoint, it seems to expect strings instead of numbers. All other endpoints use numbers.
+export interface NewFuturesOrderParams<numberType = number> {
+  symbol: string;
+  side: OrderSide;
+  positionSide?: PositionSide;
+  type: FuturesOrderType;
+  timeInForce?: OrderTimeInForce;
+  quantity?: numberType;
+  reduceOnly?: BooleanString;
+  price?: numberType;
+  newClientOrderId?: string;
+  stopPrice?: numberType;
+  closePosition?: BooleanString;
+  activationPrice?: numberType;
+  callbackRate?: numberType;
+  workingType?: WorkingType;
+  priceProtect?: BooleanString;
+  newOrderRespType?: 'ACK' | 'RESULT';
+  selfTradePreventionMode?: SelfTradePreventionMode;
+  priceMatch?: PriceMatchMode;
+  goodTillDate?: number; // Mandatory when timeInForce is GTD
+}
+⋮----
+goodTillDate?: number; // Mandatory when timeInForce is GTD
+⋮----
+export interface ModifyFuturesOrderParams<numberType = number> {
+  orderId?: number;
+  origClientOrderId?: string;
+  symbol: string;
+  side: OrderSide;
+  quantity?: numberType;
+  price?: numberType;
+  priceMatch?: PriceMatchMode;
+}
+⋮----
+export enum EnumPositionMarginChangeType {
+  AddPositionMargin = 1,
+  ReducePositionMargin = 0,
+}
+⋮----
+export type PositionMarginChangeType = `${EnumPositionMarginChangeType}`;
+⋮----
+export type IncomeType =
+  | 'TRANSFER'
+  | 'WELCOME_BONUS'
+  | 'REALIZED_PNL'
+  | 'FUNDING_FEE'
+  | 'COMMISSION'
+  | 'INSURANCE_CLEAR';
+⋮----
+export interface CancelMultipleOrdersParams {
+  symbol: string;
+  orderIdList?: number[];
+  origClientOrderIdList?: string[];
+}
+⋮----
+export interface CancelOrdersTimeoutParams {
+  symbol: string;
+  countdownTime?: 0 | number;
+}
+⋮----
+export interface SetLeverageParams {
+  symbol: string;
+  leverage: number;
+}
+⋮----
+export interface SetLeverageResult {
+  leverage: number;
+  maxNotionalValue: numberInString;
+  symbol: string;
+}
+⋮----
+export interface SetMarginTypeParams {
+  symbol: string;
+  marginType: MarginType;
+}
+⋮----
+export interface SetIsolatedMarginParams {
+  symbol: string;
+  positionSide?: PositionSide;
+  amount: number;
+  type: PositionMarginChangeType;
+}
+⋮----
+export interface SetIsolatedMarginResult {
+  amount: numberInString;
+  code: 200 | number;
+  msg: string;
+  type: 1 | 2;
+}
+⋮----
+export interface GetPositionMarginChangeHistoryParams {
+  symbol: string;
+  type?: PositionMarginChangeType;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+}
+⋮----
+export interface GetIncomeHistoryParams {
+  symbol?: string;
+  incomeType?: IncomeType;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+  page?: number;
+}
+⋮----
+export interface IncomeHistory {
+  symbol?: string;
+  incomeType: IncomeType;
+  income: string;
+  asset: string;
+  time: number;
+  info: string;
+  tranId: number;
+  tradeId: string;
+}
+⋮----
+export type ForceOrderCloseType = 'LIQUIDATION' | 'ADL';
+⋮----
+export interface GetForceOrdersParams {
+  symbol?: string;
+  autoCloseType?: ForceOrderCloseType;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+}
+⋮----
+export type ContactType =
+  | 'PERPETUAL'
+  | 'CURRENT_MONTH'
+  | 'NEXT_MONTH'
+  | 'CURRENT_QUARTER'
+  | 'NEXT_QUARTER';
+⋮----
+export type ContractStatus =
+  | 'PENDING_TRADING'
+  | 'TRADING'
+  | 'PRE_DELIVERING'
+  | 'DELIVERING'
+  | 'DELIVERED'
+  | 'CANCELLED'
+  | 'PRE_SETTLE'
+  | 'SETTLING'
+  | 'CLOSE';
+⋮----
+export interface FuturesSymbolPercentPriceFilter {
+  filterType: 'PERCENT_PRICE';
+  multiplierUp: numberInString;
+  multiplierDown: numberInString;
+  multiplierDecimal: numberInString;
+}
+⋮----
+export interface FuturesSymbolMaxOrdersFilter {
+  filterType: 'MAX_NUM_ORDERS';
+  limit: number;
+}
+⋮----
+export interface FuturesSymbolMaxAlgoOrdersFilter {
+  filterType: 'MAX_NUM_ALGO_ORDERS';
+  limit: number;
+}
+⋮----
+export interface FuturesSymbolMinNotionalFilter {
+  filterType: 'MIN_NOTIONAL';
+  notional: numberInString;
+}
+⋮----
+export type FuturesSymbolFilter =
+  | SymbolPriceFilter
+  | FuturesSymbolPercentPriceFilter
+  | SymbolLotSizeFilter
+  | FuturesSymbolMinNotionalFilter
+  | SymbolIcebergPartsFilter
+  | SymbolMarketLotSizeFilter
+  | FuturesSymbolMaxOrdersFilter
+  | FuturesSymbolMaxAlgoOrdersFilter
+  | SymbolMaxIcebergOrdersFilter
+  | SymbolMaxPositionFilter;
+⋮----
+export interface FuturesSymbolExchangeInfo {
+  symbol: string;
+  pair: string;
+  contractType: ContactType;
+  deliveryDate: number;
+  onboardDate: number;
+  status: ContractStatus;
+  maintMarginPercent: numberInString;
+  requiredMarginPercent: numberInString;
+  baseAsset: string;
+  quoteAsset: string;
+  marginAsset: string;
+  pricePrecision: number;
+  quantityPrecision: number;
+  baseAssetPrecision: number;
+  quotePrecision: number;
+  underlyingType: 'COIN' | 'INDEX'; // No other known values
+  underlyingSubType: string[]; // DEFI / NFT / BSC / HOT / etc
+  settlePlan: number;
+  triggerProtect: numberInString;
+  filters: FuturesSymbolFilter[];
+  OrderType: OrderType[];
+  timeInForce: OrderTimeInForce[];
+  liquidationFee: numberInString;
+  marketTakeBound: numberInString;
+  contractSize?: number;
+}
+⋮----
+underlyingType: 'COIN' | 'INDEX'; // No other known values
+underlyingSubType: string[]; // DEFI / NFT / BSC / HOT / etc
+⋮----
+export interface FuturesExchangeInfo {
+  exchangeFilters: ExchangeFilter[];
+  rateLimits: RateLimiter[];
+  serverTime: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  assets: any[];
+  symbols: FuturesSymbolExchangeInfo[];
+  timezone: string;
+}
+⋮----
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+⋮----
+export interface FuturesOrderBook {
+  lastUpdateId: number;
+  E: number;
+  T: number;
+  bids: OrderBookRow[];
+  asks: OrderBookRow[];
+}
+⋮----
+export interface RawFuturesTrade {
+  id: number;
+  price: numberInString;
+  qty: numberInString;
+  quoteQty: numberInString;
+  time: number;
+  isBuyerMaker: boolean;
+}
+⋮----
+export interface AggregateFuturesTrade {
+  a: number;
+  p: numberInString;
+  q: numberInString;
+  f: number;
+  l: number;
+  T: number;
+  m: boolean;
+}
+⋮----
+export interface MarkPrice {
+  symbol: string;
+  markPrice: numberInString;
+  indexPrice: numberInString;
+  estimatedSettlePrice: numberInString;
+  lastFundingRate: numberInString;
+  interestRate: numberInString;
+  nextFundingTime: number;
+  time: number;
+}
+⋮----
+export interface FundingRateHistory {
+  symbol: string;
+  fundingRate: numberInString;
+  fundingTime: number;
+  markPrice: numberInString;
+}
+⋮----
+export interface FuturesSymbolOrderBookTicker {
+  symbol: string;
+  bidPrice: numberInString;
+  bidQty: numberInString;
+  askPrice: numberInString;
+  askQty: numberInString;
+  time: number;
+}
+⋮----
+export interface OpenInterest {
+  openInterest: numberInString;
+  symbol: string;
+  time: number;
+}
+⋮----
+export interface HistoricOpenInterest {
+  symbol: string;
+  sumOpenInterest: string;
+  sumOpenInterestValue: string;
+  CMCCirculatingSupply: string;
+  timestamp: number;
+}
+⋮----
+export interface PositionModeParams {
+  dualSidePosition: DualSideMode;
+}
+⋮----
+export interface ModeChangeResult {
+  code: 200 | number;
+  msg: 'success' | string;
+}
+⋮----
+export interface PositionModeResponse {
+  dualSidePosition: boolean;
+}
+⋮----
+export interface MultiAssetModeResponse {
+  multiAssetsMargin: boolean;
+}
+⋮----
+export interface NewOrderResult {
+  clientOrderId: string;
+  cumQty: numberInString;
+  cumQuote: numberInString;
+  executedQty: numberInString;
+  orderId: number;
+  avgPrice: numberInString;
+  origQty: numberInString;
+  price: numberInString;
+  reduceOnly: boolean;
+  side: OrderSide;
+  positionSide: PositionSide;
+  status: OrderStatus;
+  stopPrice: numberInString;
+  closePosition: boolean;
+  symbol: string;
+  timeInForce: OrderTimeInForce;
+  type: FuturesOrderType;
+  origType: FuturesOrderType;
+  activatePrice: numberInString;
+  priceRate: numberInString;
+  updateTime: number;
+  workingType: WorkingType;
+  priceProtect: boolean;
+  selfTradePreventionMode: SelfTradePreventionMode;
+  priceMatch: PriceMatchMode;
+}
+⋮----
+export interface NewOrderError {
+  code: number;
+  msg: string;
+}
+⋮----
+export interface OrderResult {
+  avgPrice: numberInString;
+  clientOrderId: string;
+  cumQuote: numberInString;
+  executedQty: numberInString;
+  orderId: number;
+  origQty: numberInString;
+  origType: FuturesOrderType;
+  price: numberInString;
+  reduceOnly: boolean;
+  side: OrderSide;
+  positionSide: PositionSide;
+  status: OrderStatus;
+  stopPrice: numberInString;
+  closePosition: boolean;
+  symbol: string;
+  time: number;
+  timeInForce: OrderTimeInForce;
+  type: FuturesOrderType;
+  activatePrice: numberInString;
+  priceRate: numberInString;
+  updateTime: number;
+  workingType: WorkingType;
+  priceProtect: boolean;
+  selfTradePreventionMode: SelfTradePreventionMode;
+  priceMatch: PriceMatchMode;
+  goodTillDate: number;
+}
+⋮----
+export interface ModifyFuturesOrderResult {
+  orderId: number;
+  symbol: string;
+  pair: string;
+  status: OrderStatus;
+  clientOrderId: string;
+  price: numberInString;
+  avgPrice: numberInString;
+  origQty: numberInString;
+  executedQty: numberInString;
+  cumQty: numberInString;
+  cumBase: numberInString;
+  timeInForce: OrderTimeInForce;
+  type: FuturesOrderType;
+  reduceOnly: boolean;
+  closePosition: boolean;
+  side: OrderSide;
+  positionSide: PositionSide;
+  stopPrice: numberInString;
+  workingType: WorkingType;
+  priceProtect: boolean;
+  origType: FuturesOrderType;
+  updateTime: number;
+  selfTradePreventionMode: SelfTradePreventionMode;
+  priceMatch: PriceMatchMode;
+}
+⋮----
+export interface CancelFuturesOrderResult {
+  clientOrderId: string;
+  cumQty: numberInString;
+  cumQuote: numberInString;
+  executedQty: numberInString;
+  orderId: number;
+  origQty: numberInString;
+  origType: FuturesOrderType;
+  price: numberInString;
+  reduceOnly: boolean;
+  side: OrderSide;
+  positionSide: PositionSide;
+  status: OrderStatus;
+  stopPrice: numberInString;
+  closePosition: boolean;
+  symbol: string;
+  timeInForce: OrderTimeInForce;
+  type: FuturesOrderType;
+  activatePrice: numberInString;
+  priceRate: numberInString;
+  updateTime: number;
+  workingType: WorkingType;
+  priceProtect: boolean;
+  selfTradePreventionMode: SelfTradePreventionMode;
+  priceMatch: PriceMatchMode;
+}
+⋮----
+export interface CancelAllOpenOrdersResult {
+  code: 200 | numberInString;
+  msg: string;
+}
+⋮----
+export interface FuturesAccountBalance {
+  accountAlias: string;
+  asset: string;
+  balance: numberInString;
+  crossWalletBalance: numberInString;
+  crossUnPnl: numberInString;
+  availableBalance: numberInString;
+  maxWithdrawAmount: numberInString;
+  marginAvailable: boolean;
+  updateTime: numberInString;
+}
+⋮----
+export interface FuturesCoinMAccountBalance {
+  accountAlias: string;
+  asset: string;
+  balance: numberInString;
+  withdrawAvailable: numberInString;
+  crossWalletBalance: numberInString;
+  crossUnPnl: numberInString;
+  availableBalance: numberInString;
+  updateTime: number;
+}
+⋮----
+export interface FuturesAccountAsset {
+  asset: string;
+  walletBalance: numberInString;
+  unrealizedProfit: numberInString;
+  marginBalance: numberInString;
+  maintMargin: numberInString;
+  initialMargin: numberInString;
+  positionInitialMargin: numberInString;
+  openOrderInitialMargin: numberInString;
+  maxWithdrawAmount: numberInString;
+  crossWalletBalance: numberInString;
+  crossUnPnl: numberInString;
+  availableBalance: numberInString;
+  marginAvailable: boolean;
+  updateTime: number;
+}
+⋮----
+export interface FuturesAccountPosition {
+  symbol: string;
+  initialMargin: numberInString;
+  maintMargin: numberInString;
+  unrealizedProfit: numberInString;
+  positionInitialMargin: numberInString;
+  openOrderInitialMargin: numberInString;
+  leverage: numberInString;
+  isolated: boolean;
+  entryPrice: numberInString;
+  maxNotional: numberInString;
+  positionSide: PositionSide;
+  positionAmt: numberInString;
+  notional: numberInString;
+  isolatedWallet: numberInString;
+  updateTime: number;
+  bidNotional: numberInString;
+  askNotional: numberInString;
+}
+⋮----
+export interface FuturesCoinMAccountPosition {
+  symbol: string;
+  positionAmt: numberInString;
+  initialMargin: numberInString;
+  maintMargin: numberInString;
+  unrealizedProfit: numberInString;
+  positionInitialMargin: numberInString;
+  openOrderInitialMargin: numberInString;
+  leverage: numberInString;
+  isolated: boolean;
+  positionSide: PositionSide;
+  entryPrice: numberInString;
+  maxQty: numberInString;
+  updateTime: number;
+}
+⋮----
+export interface FuturesAccountInformation {
+  feeTier: numberInString;
+  canTrade: boolean;
+  canDeposit: boolean;
+  canWithdraw: boolean;
+  updateTime: numberInString;
+  multiAssetsMargin: boolean;
+  totalInitialMargin: numberInString;
+  totalMaintMargin: numberInString;
+  totalWalletBalance: numberInString;
+  totalUnrealizedProfit: numberInString;
+  totalMarginBalance: numberInString;
+  totalPositionInitialMargin: numberInString;
+  totalOpenOrderInitialMargin: numberInString;
+  totalCrossWalletBalance: numberInString;
+  totalCrossUnPnl: numberInString;
+  availableBalance: numberInString;
+  maxWithdrawAmount: numberInString;
+  assets: FuturesAccountAsset[];
+  positions: FuturesAccountPosition[];
+}
+⋮----
+export interface FuturesCoinMAccountInformation {
+  assets: Omit<FuturesAccountAsset, 'marginAvailable'>[];
+  positions: FuturesCoinMAccountPosition[];
+  canTrade: boolean;
+  canDeposit: boolean;
+  canWithdraw: boolean;
+  feeTier: number;
+  updateTime: number;
+}
+⋮----
+export interface FuturesPosition {
+  entryPrice: numberInString;
+  marginType: 'isolated' | 'cross';
+  isAutoAddMargin: 'false' | 'true';
+  isolatedMargin: numberInString;
+  leverage: numberInString;
+  liquidationPrice: numberInString;
+  markPrice: numberInString;
+  maxNotionalValue: numberInString;
+  positionAmt: numberInString;
+  notional: numberInString;
+  isolatedWallet: numberInString;
+  symbol: string;
+  unRealizedProfit: numberInString;
+  positionSide: PositionSide;
+  updateTime: number;
+}
+⋮----
+export interface FuturesPositionV3 {
+  symbol: string;
+  positionSide: PositionSide;
+  positionAmt: numberInString;
+  entryPrice: numberInString;
+  breakEvenPrice: numberInString;
+  markPrice: numberInString;
+  unRealizedProfit: numberInString;
+  liquidationPrice: numberInString;
+  isolatedMargin: numberInString;
+  notional: numberInString;
+  marginAsset: string;
+  isolatedWallet: numberInString;
+  initialMargin: numberInString;
+  maintMargin: numberInString;
+  positionInitialMargin: numberInString;
+  openOrderInitialMargin: numberInString;
+  adl: number;
+  bidNotional: numberInString;
+  askNotional: numberInString;
+  updateTime: number;
+}
+⋮----
+export interface FuturesPositionTrade {
+  buyer: boolean;
+  commission: numberInString;
+  commissionAsset: string;
+  id: number;
+  maker: boolean;
+  orderId: number;
+  price: numberInString;
+  qty: numberInString;
+  quoteQty: numberInString;
+  realizedPnl: numberInString;
+  side: OrderSide;
+  positionSide: PositionSide;
+  symbol: string;
+  time: number;
+}
+⋮----
+export interface ForceOrderResult {
+  orderId: number;
+  symbol: string;
+  status: OrderStatus;
+  clientOrderId: string;
+  price: numberInString;
+  avgPrice: numberInString;
+  origQty: numberInString;
+  executedQty: numberInString;
+  cumQuote: numberInString;
+  timeInForce: OrderTimeInForce;
+  type: FuturesOrderType;
+  reduceOnly: boolean;
+  closePosition: boolean;
+  side: OrderSide;
+  stopPrice: numberInString;
+  workingType: WorkingType;
+  origType: FuturesOrderType;
+  time: number;
+  updateTime: number;
+}
+⋮----
+export interface SymbolLeverageBracket {
+  bracket: number;
+  initialLeverage: number;
+  notionalCap: number;
+  notionalFloor: number;
+  maintMarginRatio: number;
+  cum: number;
+}
+⋮----
+export interface SymbolLeverageBracketsResult {
+  symbol: string;
+  brackets: SymbolLeverageBracket[];
+}
+⋮----
+export interface UserCommissionRate {
+  symbol: string;
+  makerCommissionRate: numberInString;
+  takerCommissionRate: numberInString;
+  rpiCommissionRate?: numberInString;
+}
+⋮----
+export interface FuturesAccountConfig {
+  feeTier: number;
+  canTrade: boolean;
+  canDeposit: boolean;
+  canWithdraw: boolean;
+  dualSidePosition: boolean;
+  updateTime: number;
+  multiAssetsMargin: boolean;
+  tradeGroupId: number;
+}
+⋮----
+export interface SymbolConfig {
+  symbol: string;
+  marginType: string;
+  isAutoAddMargin: string;
+  leverage: number;
+  maxNotionalValue: string;
+}
+⋮----
+export interface UserForceOrder {
+  rateLimitType: string;
+  interval: string;
+  intervalNum: number;
+  limit: number;
+}
+⋮----
+export interface RebateDataOverview {
+  brokerId: string;
+  newTraderRebateCommission: numberInString;
+  oldTraderRebateCommission: numberInString;
+  totalTradeUser: number;
+  unit: string;
+  totalTradeVol: numberInString;
+  totalRebateVol: numberInString;
+  time: number;
+}
+⋮----
+export interface SetCancelTimeoutResult {
+  symbol: string;
+  countdownTime: numberInString;
+}
+⋮----
+export interface ChangeStats24hr {
+  symbol: string;
+  priceChange: numberInString;
+  priceChangePercent: numberInString;
+  weightedAvgPrice: numberInString;
+  lastPrice: numberInString;
+  lastQty: numberInString;
+  openPrice: numberInString;
+  highPrice: numberInString;
+  lowPrice: numberInString;
+  volume: numberInString;
+  quoteVolume: numberInString;
+  openTime: number;
+  closeTime: number;
+  firstId: number; // First tradeId
+  lastId: number; // Last tradeId
+  count: number;
+}
+⋮----
+firstId: number; // First tradeId
+lastId: number; // Last tradeId
+⋮----
+export interface OrderAmendmentDetailPrice {
+  before: numberInString;
+  after: numberInString;
+}
+⋮----
+export interface OrderAmendmentDetailQty {
+  before: numberInString;
+  after: numberInString;
+}
+⋮----
+export interface OrderAmendmentDetail {
+  price: OrderAmendmentDetailPrice;
+  origQty: OrderAmendmentDetailQty;
+  count: number;
+}
+⋮----
+export interface OrderAmendment {
+  amendmentId: number;
+  symbol: string;
+  pair: string;
+  orderId: number;
+  clientOrderId: string;
+  time: number;
+  amendment: OrderAmendmentDetail;
+}
+⋮----
+export interface QuarterlyContractSettlementPrice {
+  deliveryTime: number;
+  deliveryPrice: number;
+}
+⋮----
+export interface BasisParams {
+  pair: string;
+  contractType: 'CURRENT_QUARTER' | 'NEXT_QUARTER' | 'PERPETUAL';
+  period: '5m' | '15m' | '30m' | '1h' | '2h' | '4h' | '6h' | '12h' | '1d';
+  limit: number;
+  startTime?: number;
+  endTime?: number;
+}
+⋮----
+export interface Basis {
+  indexPrice: string;
+  contractType: string;
+  basisRate: string;
+  futuresPrice: string;
+  annualizedBasisRate: string;
+  basis: string;
+  pair: string;
+  timestamp: number;
+}
+⋮----
+export interface IndexPriceConstituent {
+  exchange: string;
+  symbol: string;
+  price: numberInString;
+  weight: numberInString;
+}
+⋮----
+export interface IndexPriceConstituents {
+  symbol: string;
+  time: number;
+  constituents: IndexPriceConstituent[];
+}
+⋮----
+export interface InsuranceFundBalance {
+  symbols: string[];
+  assets: {
+    asset: string;
+    marginBalance: string;
+    updateTime: number;
+  }[];
+}
+⋮----
+export interface ModifyOrderParams {
+  orderId?: number;
+  origClientOrderId?: string;
+  symbol: string;
+  side: 'SELL' | 'BUY';
+  quantity: string;
+  price: string;
+  priceMatch?:
+    | 'OPPONENT'
+    | 'OPPONENT_5'
+    | 'OPPONENT_10'
+    | 'OPPONENT_20'
+    | 'QUEUE'
+    | 'QUEUE_5'
+    | 'QUEUE_10'
+    | 'QUEUE_20';
+  recvWindow?: number;
+  timestamp: number;
+}
+⋮----
+export interface GetFuturesOrderModifyHistoryParams {
+  symbol: string;
+  orderId?: number;
+  origClientOrderId?: string;
+  startTime?: number;
+  endTime?: number;
+  limit?: number;
+}
+⋮----
+export interface FuturesTradeHistoryDownloadId {
+  avgCostTimestampOfLast30d: number;
+  downloadId: string;
+}
+⋮----
+export interface FuturesTransactionDownloadLink {
+  downloadId: string;
+  status: 'completed' | 'processing';
+  url: string;
+  expirationTimestamp: number;
+  isExpired: boolean | null;
+}
+⋮----
+export interface PortfolioMarginProAccountInfo {
+  maxWithdrawAmountUSD: string;
+  asset: string;
+  maxWithdrawAmount: string; // This field will be ignored in the response
+}
+⋮----
+maxWithdrawAmount: string; // This field will be ignored in the response
+⋮----
+export interface FuturesConvertPair {
+  fromAsset: string;
+  toAsset: string;
+  fromAssetMinAmount: string;
+  fromAssetMaxAmount: string;
+  toAssetMinAmount: string;
+  toAssetMaxAmount: string;
+}
+⋮----
+export interface FuturesConvertQuoteRequest {
+  fromAsset: string;
+  toAsset: string;
+  fromAmount?: number;
+  toAmount?: number;
+  validTime?: '10s' | '30s' | '1m' | '2m';
+}
+⋮----
+export interface FuturesConvertQuote {
+  quoteId: string;
+  ratio: string;
+  inverseRatio: string;
+  validTimestamp: number;
+  toAmount: string;
+  fromAmount: string;
+}
+⋮----
+export interface FuturesConvertOrderStatus {
+  orderId: string;
+  orderStatus: 'PROCESS' | 'ACCEPT_SUCCESS' | 'SUCCESS' | 'FAIL';
+  fromAsset: string;
+  fromAmount: string;
+  toAsset: string;
+  toAmount: string;
+  ratio: string;
+  inverseRatio: string;
+  createTime: number;
 }
 ⋮----
 /**
-   * Session authentication responses:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/session-authentication
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/authentication-requests
-   */
+ * Algo Order Types (Effective 2025-12-02)
+ * USDⓈ-M Futures conditional orders migrate to Algo Service
+ */
+⋮----
+export type FuturesAlgoOrderType = 'CONDITIONAL';
+⋮----
+export type FuturesAlgoConditionalOrderTypes =
+  | 'STOP_MARKET'
+  | 'TAKE_PROFIT_MARKET'
+  | 'STOP'
+  | 'TAKE_PROFIT'
+  | 'TRAILING_STOP_MARKET';
 ⋮----
 /**
-   * General responses:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/general-requests
-   */
+ * Ref: https://developers.binance.com/docs/derivatives/usds-margined-futures/user-data-streams/Event-Algo-Order-Update
+ */
+export type FuturesAlgoOrderStatus =
+  | 'NEW'
+  | 'CANCELED'
+  | 'TRIGGERING'
+  | 'TRIGGERED'
+  | 'FINISHED'
+  | 'REJECTED'
+  | 'EXPIRED';
 ⋮----
-/**
-   * Market data responses
-   * - Spot:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/market-data-requests
-   * - Futures:
-   * https://developers.binance.com/docs/derivatives/usds-margined-futures/market-data/websocket-api
-   */
+export interface FuturesNewAlgoOrderParams {
+  algoType: FuturesAlgoOrderType;
+  symbol: string;
+  side: OrderSide;
+  positionSide?: PositionSide;
+  type: FuturesAlgoConditionalOrderTypes;
+  timeInForce?: OrderTimeInForce;
+  quantity?: numberInString;
+  price?: numberInString;
+  triggerPrice?: numberInString;
+  workingType?: WorkingType;
+  priceMatch?: PriceMatchMode;
+  closePosition?: BooleanString;
+  priceProtect?: BooleanString;
+  reduceOnly?: BooleanString;
+  activatePrice?: numberInString;
+  callbackRate?: numberInString;
+  clientAlgoId?: string; // ^[\.A-Z\:/a-z0-9_-]{1,36}$
+  selfTradePreventionMode?: SelfTradePreventionMode;
+  goodTillDate?: number;
+}
 ⋮----
-/**
-   * Account responses:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/account-requests
-   */
+clientAlgoId?: string; // ^[\.A-Z\:/a-z0-9_-]{1,36}$
 ⋮----
-/**
-   * Futures account responses:
-   * https://developers.binance.com/docs/derivatives/usds-margined-futures/account/websocket-api
-   */
+export interface FuturesAlgoOrderResponse {
+  algoId: number;
+  clientAlgoId: string;
+  algoType: FuturesAlgoOrderType;
+  orderType: FuturesAlgoConditionalOrderTypes;
+  symbol: string;
+  side: OrderSide;
+  positionSide: PositionSide;
+  timeInForce: OrderTimeInForce;
+  quantity: numberInString;
+  algoStatus: FuturesAlgoOrderStatus;
+  triggerPrice?: numberInString;
+  price?: numberInString;
+  icebergQuantity: numberInString | null;
+  selfTradePreventionMode: SelfTradePreventionMode;
+  workingType: WorkingType;
+  priceMatch: PriceMatchMode;
+  closePosition: boolean;
+  priceProtect: boolean;
+  reduceOnly: boolean;
+  activatePrice?: numberInString;
+  callbackRate?: numberInString;
+  createTime: number;
+  updateTime: number;
+  triggerTime: number;
+  goodTillDate: number;
+}
 ⋮----
-/**
-   * Trading responses
-   * - Spot:
-   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/trading-requests
-   * - Futures:
-   * https://developers.binance.com/docs/derivatives/usds-margined-futures/trading/websocket-api
-   */
+export interface FuturesCancelAlgoOrderParams {
+  algoId?: number;
+  clientAlgoId?: string;
+}
 ⋮----
-/**
-   * Order list responses
-   */
+export interface FuturesCancelAlgoOrderResponse {
+  algoId: number;
+  clientAlgoId: string;
+  code: string;
+  msg: string;
+}
 ⋮----
-/**
-   * SOR responses
-   */
+export interface FuturesCancelAllAlgoOpenOrdersResponse {
+  code: number;
+  msg: string;
+}
+⋮----
+export interface FuturesQueryAlgoOrderParams {
+  algoId?: number;
+  clientAlgoId?: string;
+}
+⋮----
+export interface FuturesQueryAlgoOrderResponse
+  extends FuturesAlgoOrderResponse {
+  actualOrderId: numberInString;
+  actualPrice: numberInString;
+  tpTriggerPrice?: numberInString;
+  tpPrice?: numberInString;
+  slTriggerPrice?: numberInString;
+  slPrice?: numberInString;
+  tpOrderType?: string;
+}
+⋮----
+export interface FuturesQueryOpenAlgoOrdersParams {
+  algoType?: FuturesAlgoOrderType;
+  symbol?: string;
+  algoId?: number;
+}
+⋮----
+export interface FuturesQueryAllAlgoOrdersParams {
+  symbol: string;
+  algoId?: number;
+  startTime?: number;
+  endTime?: number;
+  page?: number;
+  limit?: number; // Default 500; max 1000
+}
+⋮----
+limit?: number; // Default 500; max 1000
+⋮----
+export interface SymbolAdlRisk {
+  symbol: string;
+  adlRisk: 'low' | 'medium' | 'high';
+  updateTime: number;
+}
+⋮----
+export interface TradingSession {
+  startTime: number;
+  endTime: number;
+  type: 'PRE_MARKET' | 'REGULAR' | 'AFTER_MARKET' | 'OVERNIGHT' | 'NO_TRADING';
+}
+⋮----
+export interface MarketSchedule {
+  sessions: TradingSession[];
+}
+⋮----
+export interface TradingSchedule {
+  updateTime: number;
+  marketSchedules: {
+    EQUITY?: MarketSchedule;
+    COMMODITY?: MarketSchedule;
+  };
+}
+⋮----
+export interface RpiOrderBook {
+  lastUpdateId: number;
+  E: number; // Message output time
+  T: number; // Transaction time
+  bids: [numberInString, numberInString][];
+  asks: [numberInString, numberInString][];
+}
+⋮----
+E: number; // Message output time
+T: number; // Transaction time
 
 ================
 File: src/websocket-client-legacy.ts
@@ -12522,6 +13412,900 @@ public async subscribeCoinFuturesUserDataStream(
 // Start & store timer to keep alive listen key (and handle expiration)
 
 ================
+File: examples/WebSockets/Private(userdata)/ws-userdata-listenkey.ts
+================
+// or
+// import {
+//   DefaultLogger,
+//   isWsFormattedFuturesUserDataEvent,
+//   isWsFormattedSpotUserDataEvent,
+//   isWsFormattedSpotUserDataExecutionReport,
+//   isWsFormattedUserDataEvent,
+//   WebsocketClient,
+//   WsUserDataEvents,
+// } from 'binance';
+⋮----
+import {
+  DefaultLogger,
+  isWsFormattedFuturesUserDataEvent,
+  isWsFormattedSpotUserDataEvent,
+  isWsFormattedSpotUserDataExecutionReport,
+  isWsFormattedUserDataEvent,
+  WebsocketClient,
+  WsConnectionStateEnum,
+  WsUserDataEvents,
+} from '../../../src/index';
+⋮----
+// Optional, hook and customise logging behavior
+⋮----
+// testnet: true,
+⋮----
+// wsClient.on('message', (data) => {
+//   console.log('raw message received ', JSON.stringify(data, null, 2));
+// });
+⋮----
+function onUserDataEvent(data: WsUserDataEvents)
+⋮----
+// the market denotes which API category it came from
+// if (data.wsMarket.includes('spot')) {
+⋮----
+// or use a type guard, if one exists (PRs welcome)
+⋮----
+// The wsKey can be parsed to determine the type of message (what websocket it came from)
+// if (!Array.isArray(data) && data.wsKey.includes('userData')) {
+//   return onUserDataEvent(data);
+// }
+⋮----
+// or use a type guard if available
+⋮----
+// response to command sent via WS stream (e.g LIST_SUBSCRIPTIONS)
+⋮----
+// This is a good place to check your own state is still in sync with the account state on the exchange, in case any events were missed while the library was reconnecting:
+// - fetch balances
+// - fetch positions
+// - fetch orders
+⋮----
+/**
+   * This example demonstrates subscribing to the user data stream via the
+   * listen key workflow.
+   *
+   * Note: the listen key workflow is deprecated for "spot" markets. Use the
+   * WebSocket API `userDataStream.subscribe` workflow instead (only available
+   * in spot right now). See `subscribeUserDataStream()` in the WebsocketAPIClient.
+   *
+   * Each method below opens a dedicated WS connection attached to an automatically
+   * fetched listen key (a session for your user data stream).
+   *
+   * Once subscribed, you don't need to do anything else. Listen-key keep-alive, refresh, reconnects, etc are all automatically handled by the SDK.
+   */
+⋮----
+/**
+   * Note: for spot markets, the listen key workflow is deprecated. Use the
+   * WebSocket API `userDataStream.subscribe` workflow instead (only available
+   * in spot right now). See `subscribeUserDataStream()` in the WebsocketAPIClient.
+   */
+// Deprecated, see above: wsClient.subscribeSpotUserDataStream();
+// Deprecated, see above: wsClient.subscribeSpotUserDataStream('main2');
+// Deprecated, see above: wsClient.subscribeCrossMarginUserDataStream();
+// Deprecated, see above: wsClient.subscribeIsolatedMarginUserDataStream('BTCUSDC');
+⋮----
+/**
+   * Futures
+   */
+⋮----
+// Example 5: usdm futures
+⋮----
+// Example 6: coinm futures
+⋮----
+// Example 7: portfolio margin
+⋮----
+// Example 8: portfolio margin pro
+⋮----
+// after 15 seconds, kill user data connections one by one (or all at once)
+⋮----
+// console.log('killing all connections at once');
+// wsClient.closeAll();
+⋮----
+// or:
+⋮----
+// console.log('killing all connections');
+// wsClient.closeAll();
+// Example 5: usdm futures
+⋮----
+// Example 6: coinm futures
+⋮----
+// // Example 7: portfolio margin
+// wsClient.unsubscribePortfolioMarginUserDataStream();
+// // Example 8: portfolio margin pro
+// wsClient.unsubscribePortfolioMarginUserDataStream(
+//   'portfolioMarginProUserData',
+// );
+⋮----
+// after 20 seconds, list the remaining open connections
+
+================
+File: examples/WebSockets/Private(userdata)/ws-userdata-wsapi.ts
+================
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// or
+// import { WebsocketAPIClient, WebsocketClient, WS_KEY_MAP } from 'binance';
+// or
+// const { WebsocketAPIClient, WebsocketClient, WS_KEY_MAP } = require('binance');
+⋮----
+import {
+  DefaultLogger,
+  isWsFormattedFuturesUserDataEvent,
+  isWsFormattedSpotBalanceUpdate,
+  isWsFormattedSpotOutboundAccountPosition,
+  isWsFormattedSpotUserDataEvent,
+  isWsFormattedUserDataEvent,
+  WebsocketAPIClient,
+  WebsocketClient,
+  WS_KEY_MAP,
+} from '../../../src';
+⋮----
+/**
+ * Note: the WebSocket API is fastest with Ed25519 keys. HMAC & RSA will
+ * require each command to be individually signed.
+ *
+ * Check the rest-private-ed25519.md in this folder for more guidance
+ * on preparing this Ed25519 API key.
+ */
+⋮----
+// returned by binance, generated using the publicKey (above)
+// const key = 'BVv39ATnIme5TTZRcC3I04C3FqLVM7vCw3Hf7mMT7uu61nEZK8xV1V5dmhf9kifm';
+// Your Ed25519 private key is passed as the "secret"
+// const secret = privateKey;
+⋮----
+function attachEventHandlers<TWSClient extends WebsocketClient>(
+  wsClient: TWSClient,
+): void
+⋮----
+/**
+   * General event handlers for monitoring the WebsocketClient
+   */
+⋮----
+// Raw events received from binance, as is:
+⋮----
+// console.log('raw message received ', JSON.stringify(data));
+⋮----
+// Formatted events from the built-in beautifier, with fully readable property names and parsed floats:
+⋮----
+// We've included type guards for many events, especially on the user data stream, to help easily
+// identify events using simple `if` checks.
+//
+// Use `if` checks to narrow down specific events from the user data stream
+⋮----
+//// More general handlers, if you prefer:
+⋮----
+// Any user data event in spot:
+⋮----
+// Any user data event in futures:
+⋮----
+// Any user data event on any market (spot + futures)
+⋮----
+// Formatted user data events also have a dedicated event handler, but that's optional and no different to the above
+// wsClient.on('formattedUserDataMessage', (data) => {
+//   if (isWsFormattedSpotOutboundAccountPosition(data)) {
+//     return;
+//     // console.log(
+//     //   'formattedUserDataMessage->isWsFormattedSpotOutboundAccountPosition: ',
+//     //   data,
+//     // );
+//   }
+//   if (isWsFormattedSpotBalanceUpdate(data)) {
+//     return console.log(
+//       'formattedUserDataMessage->isWsFormattedSpotBalanceUpdate: ',
+//       data,
+//     );
+//   }
+//   console.log('formattedUserDataMessage: ', data);
+// });
+⋮----
+// console.log('ws response: ', JSON.stringify(data));
+⋮----
+async function main()
+⋮----
+// Optional, hook and customise logging behavior
+⋮----
+// Enforce testnet ws connections, regardless of supplied wsKey:
+// testnet: true,
+⋮----
+// Note: unless you set this to false, the SDK will automatically call
+// the `subscribeUserDataStream()` method again if reconnected (if you called it before):
+// resubscribeUserDataStreamAfterReconnect: true,
+⋮----
+keepMarginListenTokenRefreshed: false, // Optional, if you don't want the SDK to automatically refresh your margin listen token (if you use it for subscribing to margin user data stream)
+⋮----
+// If you want your own event handlers instead of the default ones with logs, disable this setting and see the `attachEventHandlers` example below:
+⋮----
+logger, // Optional: inject a custom logger, especially to see trace events
+⋮----
+// Attach your own event handlers to process incoming events
+// You may want to disable the default ones to avoid unnecessary logs (via attachEventListeners:false, above)
+⋮----
+// Optional, if you see RECV Window errors, you can use this to manage time issues.
+// ! However, make sure you sync your system clock first!
+// https://github.com/tiagosiebler/awesome-crypto-examples/wiki/Timestamp-for-this-request-is-outside-of-the-recvWindow
+// wsClient.setTimeOffsetMs(-5000);
+⋮----
+// Note: unless you set resubscribeUserDataStreamAfterReconnect to false, the SDK will
+// automatically call this method again if reconnected,
+⋮----
+WS_KEY_MAP.mainWSAPI, // The `mainWSAPI` wsKey will connect to the "spot" Websocket API on Binance.
+⋮----
+// Start executing the example workflow
+
+================
+File: src/types/websockets/ws-api.ts
+================
+import { WS_KEY_MAP, WsKey } from '../../util/websockets/websocket-util';
+import { FuturesExchangeInfo } from '../futures';
+import {
+  ExchangeInfo,
+  SpotExecutionRulesResponse,
+  SpotReferencePriceCalculationResponse,
+  SpotReferencePriceResult,
+} from '../spot';
+import {
+  WSAPIAccountCommissionWSAPIRequest,
+  WSAPIAccountInformationRequest,
+  WSAPIAllOrderListsRequest,
+  WSAPIAllOrdersRequest,
+  WSAPIAvgPriceRequest,
+  WSAPIBlockTradesHistoricalRequest,
+  WSAPIExchangeInfoRequest,
+  WSAPIExecutionRulesRequest,
+  WSAPIFuturesAlgoOrderCancelRequest,
+  WSAPIFuturesOrderBookRequest,
+  WSAPIFuturesOrderCancelRequest,
+  WSAPIFuturesOrderModifyRequest,
+  WSAPIFuturesOrderStatusRequest,
+  WSAPIFuturesTickerBookRequest,
+  WSAPIFuturesTickerPriceRequest,
+  WSAPIKlinesRequest,
+  WSAPIMyAllocationsRequest,
+  WSAPIMyPreventedMatchesRequest,
+  WSAPIMyTradesRequest,
+  WSAPINewFuturesAlgoOrderRequest,
+  WSAPINewFuturesOrderRequest,
+  WSAPINewSpotOrderRequest,
+  WSAPIOpenOrdersCancelAllRequest,
+  WSAPIOpenOrdersStatusRequest,
+  WSAPIOrderAmendKeepPriorityRequest,
+  WSAPIOrderBookRequest,
+  WSAPIOrderCancelReplaceRequest,
+  WSAPIOrderCancelRequest,
+  WSAPIOrderListCancelRequest,
+  WSAPIOrderListPlaceOCORequest,
+  WSAPIOrderListPlaceOPOCORequest,
+  WSAPIOrderListPlaceOPORequest,
+  WSAPIOrderListPlaceOTOCORequest,
+  WSAPIOrderListPlaceOTORequest,
+  WSAPIOrderListPlaceRequest,
+  WSAPIOrderListStatusRequest,
+  WSAPIOrderStatusRequest,
+  WSAPIOrderTestRequest,
+  WSAPIRecvWindowTimestamp,
+  WSAPIReferencePriceCalculationRequest,
+  WSAPIReferencePriceRequest,
+  WSAPISessionLogonRequest,
+  WSAPISOROrderPlaceRequest,
+  WSAPISOROrderTestRequest,
+  WSAPITicker24hrRequest,
+  WSAPITickerBookRequest,
+  WSAPITickerPriceRequest,
+  WSAPITickerRequest,
+  WSAPITickerTradingDayRequest,
+  WSAPITradesAggregateRequest,
+  WSAPITradesHistoricalRequest,
+  WSAPITradesRecentRequest,
+} from './ws-api-requests';
+import {
+  WSAPIAccountCommission,
+  WSAPIAccountInformation,
+  WSAPIAggregateTrade,
+  WSAPIAllocation,
+  WSAPIAvgPrice,
+  WSAPIBlockTrade,
+  WSAPIBookTicker,
+  WSAPIFullTicker,
+  WSAPIFuturesAccountBalanceItem,
+  WSAPIFuturesAccountStatus,
+  WSAPIFuturesAlgoOrder,
+  WSAPIFuturesAlgoOrderCancelResponse,
+  WSAPIFuturesBookTicker,
+  WSAPIFuturesOrder,
+  WSAPIFuturesOrderBook,
+  WSAPIFuturesPosition,
+  WSAPIFuturesPositionV2,
+  WSAPIFuturesPriceTicker,
+  WSAPIKline,
+  WSAPIMiniTicker,
+  WSAPIOrder,
+  WSAPIOrderBook,
+  WSAPIOrderCancel,
+  WSAPIOrderCancelReplaceResponse,
+  WSAPIOrderListCancelResponse,
+  WSAPIOrderListPlaceResponse,
+  WSAPIOrderListStatusResponse,
+  WSAPIOrderTestResponse,
+  WSAPIOrderTestWithCommission,
+  WSAPIPreventedMatch,
+  WSAPIPriceTicker,
+  WSAPIRateLimit,
+  WSAPIServerTime,
+  WSAPISessionStatus,
+  WSAPISOROrderPlaceResponse,
+  WSAPISOROrderTestResponse,
+  WSAPISOROrderTestResponseWithCommission,
+  WSAPISpotOrderResponse,
+  WSAPITrade,
+} from './ws-api-responses';
+⋮----
+/**
+ * Standard WS commands (for consumers)
+ */
+export type WsOperation =
+  | 'SUBSCRIBE'
+  | 'UNSUBSCRIBE'
+  | 'LIST_SUBSCRIPTIONS'
+  | 'SET_PROPERTY'
+  | 'GET_PROPERTY';
+⋮----
+/**
+ * WS API commands (for sending requests via WS)
+ */
+⋮----
+//// General commands
+⋮----
+//// Market data commands
+⋮----
+//// Account commands
+// Spot
+⋮----
+// Futures
+⋮----
+//// Trading commands
+⋮----
+// Order list commands
+⋮----
+// SOR commands
+⋮----
+// user data stream
+⋮----
+export interface WSAPIUserDataListenKeyRequest {
+  apiKey: string;
+  listenKey: string;
+}
+⋮----
+export type WsAPIOperation = (typeof WS_API_Operations)[number];
+⋮----
+export interface WsRequestOperationBinance<
+  TWSTopic extends string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TWSParams extends object = any,
+> {
+  method: WsOperation | WsAPIOperation;
+  params?: (TWSTopic | string | number)[] | TWSParams;
+  id: number;
+}
+⋮----
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+⋮----
+export interface WSAPIResponse<TResponseData extends object = object> {
+  /** Auto-generated */
+  id: string;
+
+  status: number;
+  result: TResponseData;
+  rateLimits: {
+    rateLimitType: 'REQUEST_WEIGHT';
+    interval: 'MINUTE';
+    intervalNum: number;
+    limit: number;
+    count: number;
+  }[];
+
+  wsKey: WsKey;
+  isWSAPIResponse: boolean;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  request?: any;
+}
+⋮----
+/** Auto-generated */
+⋮----
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+⋮----
+export type Exact<T> = {
+  // This part says: if there's any key that's not in T, it's an error
+  // This conflicts sometimes for some reason...
+  // [K: string]: never;
+} & {
+  [K in keyof T]: T[K];
+};
+⋮----
+// This part says: if there's any key that's not in T, it's an error
+// This conflicts sometimes for some reason...
+// [K: string]: never;
+⋮----
+/**
+ * List of operations supported for this WsKey (connection)
+ */
+export interface WsAPIWsKeyTopicMap {
+  [WS_KEY_MAP.main]: WsOperation;
+  [WS_KEY_MAP.main2]: WsOperation;
+  [WS_KEY_MAP.main3]: WsOperation;
+
+  [WS_KEY_MAP.mainTestnetPublic]: WsOperation;
+  [WS_KEY_MAP.mainTestnetUserData]: WsOperation;
+
+  [WS_KEY_MAP.marginRiskUserData]: WsOperation;
+  [WS_KEY_MAP.marginUserData]: WsAPIOperation;
+  [WS_KEY_MAP.usdm]: WsOperation;
+  [WS_KEY_MAP.usdmTestnet]: WsOperation;
+
+  [WS_KEY_MAP.coinm]: WsOperation;
+  [WS_KEY_MAP.coinm2]: WsOperation;
+  [WS_KEY_MAP.coinmTestnet]: WsOperation;
+  [WS_KEY_MAP.eoptions]: WsOperation;
+  [WS_KEY_MAP.portfolioMarginUserData]: WsOperation;
+  [WS_KEY_MAP.portfolioMarginProUserData]: WsOperation;
+
+  [WS_KEY_MAP.alpha]: WsOperation;
+
+  [WS_KEY_MAP.mainWSAPI]: WsAPIOperation;
+  [WS_KEY_MAP.mainWSAPI2]: WsAPIOperation;
+  [WS_KEY_MAP.mainWSAPITestnet]: WsAPIOperation;
+
+  [WS_KEY_MAP.usdmWSAPI]: WsAPIOperation;
+  [WS_KEY_MAP.usdmWSAPITestnet]: WsAPIOperation;
+
+  [WS_KEY_MAP.coinmWSAPI]: WsAPIOperation;
+  [WS_KEY_MAP.coinmWSAPITestnet]: WsAPIOperation;
+}
+⋮----
+export type WsAPIFuturesWsKey =
+  | typeof WS_KEY_MAP.usdmWSAPI
+  | typeof WS_KEY_MAP.usdmWSAPITestnet;
+⋮----
+/**
+ * Request parameters expected per operation.
+ *
+ * - Each "key" here is the name of the command/operation.
+ * - Each "value" here has the parameters required for the command.
+ *
+ * Make sure to add new topics to WS_API_Operations and the response param map too.
+ */
+export interface WsAPITopicRequestParamMap<TWSKey = WsKey> {
+  SUBSCRIBE: never;
+  UNSUBSCRIBE: never;
+  LIST_SUBSCRIPTIONS: never;
+  SET_PROPERTY: never;
+  GET_PROPERTY: never;
+
+  /**
+   * Authentication commands & parameters:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/authentication-requests
+   */
+  'session.logon': WSAPISessionLogonRequest;
+  'session.status': void;
+  'session.logout': void;
+
+  /**
+   * General requests & parameters:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/general-requests
+   */
+  ping: void;
+  time: void;
+
+  exchangeInfo: void | WSAPIExchangeInfoRequest;
+
+  /**
+   * Market data requests & parameters:
+   * - Spot:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/market-data-requests
+   * - Futures:
+   * https://developers.binance.com/docs/derivatives/usds-margined-futures/market-data/websocket-api
+   */
+  depth: TWSKey extends WsAPIFuturesWsKey
+    ? WSAPIFuturesOrderBookRequest
+    : WSAPIOrderBookRequest;
+  'trades.recent': WSAPITradesRecentRequest;
+  'trades.historical': WSAPITradesHistoricalRequest;
+  'blockTrades.historical': WSAPIBlockTradesHistoricalRequest;
+  'trades.aggregate': WSAPITradesAggregateRequest;
+  klines: WSAPIKlinesRequest;
+  uiKlines: WSAPIKlinesRequest;
+  avgPrice: WSAPIAvgPriceRequest;
+  executionRules: void | WSAPIExecutionRulesRequest;
+  referencePrice: WSAPIReferencePriceRequest;
+  'referencePrice.calculation': WSAPIReferencePriceCalculationRequest;
+  'ticker.24hr': void | WSAPITicker24hrRequest;
+  'ticker.tradingDay': WSAPITickerTradingDayRequest;
+  ticker: WSAPITickerRequest;
+  'ticker.price': void | TWSKey extends WsAPIFuturesWsKey
+    ? WSAPIFuturesTickerPriceRequest | undefined
+    : WSAPITickerPriceRequest | undefined;
+  'ticker.book': void | TWSKey extends WsAPIFuturesWsKey
+    ? WSAPIFuturesTickerBookRequest | undefined
+    : WSAPITickerBookRequest | undefined;
+
+  /**
+   * Account requests & parameters:
+   * - Spot:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/account-requests
+   * - Futures:
+   * https://developers.binance.com/docs/derivatives/usds-margined-futures/account/websocket-api
+   */
+
+  'account.status':
+    | void
+    | (TWSKey extends WsAPIFuturesWsKey
+        ? WSAPIRecvWindowTimestamp
+        : WSAPIAccountInformationRequest);
+
+  'account.rateLimits.orders': void | WSAPIRecvWindowTimestamp;
+
+  allOrders: WSAPIAllOrdersRequest;
+
+  allOrderLists: void | WSAPIAllOrderListsRequest;
+
+  myTrades: WSAPIMyTradesRequest;
+
+  myPreventedMatches: WSAPIMyPreventedMatchesRequest;
+
+  myAllocations: WSAPIMyAllocationsRequest;
+
+  'account.commission': WSAPIAccountCommissionWSAPIRequest;
+
+  /**
+   * Futures account requests & parameters:
+   * https://developers.binance.com/docs/derivatives/usds-margined-futures/account/websocket-api
+   */
+  'account.position': WSAPIRecvWindowTimestamp;
+
+  'v2/account.position': WSAPIRecvWindowTimestamp;
+
+  'account.balance': WSAPIRecvWindowTimestamp;
+
+  'v2/account.balance': WSAPIRecvWindowTimestamp;
+
+  'v2/account.status': WSAPIRecvWindowTimestamp;
+
+  /**
+   * Trading requests & parameters:
+   * - Spot:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/trading-requests
+   * - Futures:
+   * https://developers.binance.com/docs/derivatives/usds-margined-futures/trading/websocket-api
+   */
+  'order.place': (TWSKey extends WsAPIFuturesWsKey
+    ? WSAPINewFuturesOrderRequest
+    : WSAPINewSpotOrderRequest) & {
+    timestamp?: number;
+  };
+  'order.test': WSAPIOrderTestRequest;
+  'order.status': TWSKey extends WsAPIFuturesWsKey
+    ? WSAPIFuturesOrderStatusRequest
+    : WSAPIOrderStatusRequest;
+  'order.cancel': TWSKey extends WsAPIFuturesWsKey
+    ? WSAPIFuturesOrderCancelRequest
+    : WSAPIOrderCancelRequest;
+  'order.modify': WSAPIFuturesOrderModifyRequest; // order.modify only futures
+  'order.cancelReplace': WSAPIOrderCancelReplaceRequest;
+  'order.amend.keepPriority': WSAPIOrderAmendKeepPriorityRequest;
+  'openOrders.status': WSAPIOpenOrdersStatusRequest;
+  'openOrders.cancelAll': WSAPIOpenOrdersCancelAllRequest;
+
+  'algoOrder.place': WSAPINewFuturesAlgoOrderRequest;
+  'algoOrder.cancel': WSAPIFuturesAlgoOrderCancelRequest;
+
+  /**
+   * Order list requests & parameters:
+   */
+  'orderList.place': WSAPIOrderListPlaceRequest;
+  'orderList.place.oco': WSAPIOrderListPlaceOCORequest;
+  'orderList.place.oto': WSAPIOrderListPlaceOTORequest;
+  'orderList.place.otoco': WSAPIOrderListPlaceOTOCORequest;
+  'orderList.place.opo': WSAPIOrderListPlaceOPORequest;
+  'orderList.place.opoco': WSAPIOrderListPlaceOPOCORequest;
+  'orderList.status': WSAPIOrderListStatusRequest;
+  'orderList.cancel': WSAPIOrderListCancelRequest;
+
+  'openOrderLists.status': WSAPIRecvWindowTimestamp;
+
+  /**
+   * SOR requests & parameters:
+   */
+  'sor.order.place': WSAPISOROrderPlaceRequest;
+  'sor.order.test': WSAPISOROrderTestRequest;
+
+  /**
+   * User data stream:
+   *
+   * - Spot:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/user-data-stream-requests
+   *
+   * - Futures:
+   * https://developers.binance.com/docs/derivatives/usds-margined-futures/account/websocket-api
+   *
+   * Note: for the user data stream, use the subscribe*UserDataStream() methods from the WS Client.
+   */
+  'userDataStream.start': { apiKey: string };
+  'userDataStream.ping': WSAPIUserDataListenKeyRequest;
+  'userDataStream.stop': WSAPIUserDataListenKeyRequest;
+  'userDataStream.subscribe': void;
+  'userDataStream.subscribe.signature': { timestamp: number };
+  'userDataStream.unsubscribe': void;
+
+  /**
+   * User data streams, margin:
+   */
+  'userDataStream.subscribe.listenToken': { listenToken: string };
+}
+⋮----
+/**
+   * Authentication commands & parameters:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/authentication-requests
+   */
+⋮----
+/**
+   * General requests & parameters:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/general-requests
+   */
+⋮----
+/**
+   * Market data requests & parameters:
+   * - Spot:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/market-data-requests
+   * - Futures:
+   * https://developers.binance.com/docs/derivatives/usds-margined-futures/market-data/websocket-api
+   */
+⋮----
+/**
+   * Account requests & parameters:
+   * - Spot:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/account-requests
+   * - Futures:
+   * https://developers.binance.com/docs/derivatives/usds-margined-futures/account/websocket-api
+   */
+⋮----
+/**
+   * Futures account requests & parameters:
+   * https://developers.binance.com/docs/derivatives/usds-margined-futures/account/websocket-api
+   */
+⋮----
+/**
+   * Trading requests & parameters:
+   * - Spot:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/trading-requests
+   * - Futures:
+   * https://developers.binance.com/docs/derivatives/usds-margined-futures/trading/websocket-api
+   */
+⋮----
+'order.modify': WSAPIFuturesOrderModifyRequest; // order.modify only futures
+⋮----
+/**
+   * Order list requests & parameters:
+   */
+⋮----
+/**
+   * SOR requests & parameters:
+   */
+⋮----
+/**
+   * User data stream:
+   *
+   * - Spot:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/user-data-stream-requests
+   *
+   * - Futures:
+   * https://developers.binance.com/docs/derivatives/usds-margined-futures/account/websocket-api
+   *
+   * Note: for the user data stream, use the subscribe*UserDataStream() methods from the WS Client.
+   */
+⋮----
+/**
+   * User data streams, margin:
+   */
+⋮----
+/**
+ * Response structure expected for each operation
+ *
+ * - Each "key" here is a command/request supported by the WS API
+ * - Each "value" here is the response schema for that command.
+ */
+export interface WsAPIOperationResponseMap {
+  [key: string]: unknown;
+
+  SUBSCRIBE: never;
+  UNSUBSCRIBE: never;
+  LIST_SUBSCRIPTIONS: never;
+  SET_PROPERTY: never;
+  GET_PROPERTY: never;
+
+  /**
+   * Session authentication responses:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/session-authentication
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/authentication-requests
+   */
+  'session.login': WSAPIResponse<WSAPISessionStatus>;
+  'session.status': WSAPIResponse<WSAPISessionStatus>;
+  'session.logout': WSAPIResponse<WSAPISessionStatus>;
+
+  /**
+   * General responses:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/general-requests
+   */
+
+  ping: unknown;
+  time: WSAPIResponse<WSAPIServerTime>;
+  exchangeInfo: WSAPIResponse<FuturesExchangeInfo | ExchangeInfo>;
+
+  /**
+   * Market data responses
+   * - Spot:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/market-data-requests
+   * - Futures:
+   * https://developers.binance.com/docs/derivatives/usds-margined-futures/market-data/websocket-api
+   */
+  depth: WSAPIResponse<WSAPIOrderBook | WSAPIFuturesOrderBook>;
+  'trades.recent': WSAPIResponse<WSAPITrade[]>;
+  'trades.historical': WSAPIResponse<WSAPITrade[]>;
+  'blockTrades.historical': WSAPIResponse<WSAPIBlockTrade[]>;
+  'trades.aggregate': WSAPIResponse<WSAPIAggregateTrade[]>;
+  klines: WSAPIResponse<WSAPIKline[]>;
+  uiKlines: WSAPIResponse<WSAPIKline[]>;
+  avgPrice: WSAPIResponse<WSAPIAvgPrice>;
+  executionRules: WSAPIResponse<SpotExecutionRulesResponse>;
+  referencePrice: WSAPIResponse<SpotReferencePriceResult>;
+  'referencePrice.calculation': WSAPIResponse<SpotReferencePriceCalculationResponse>;
+  'ticker.24hr': WSAPIResponse<
+    WSAPIFullTicker | WSAPIMiniTicker | WSAPIFullTicker[] | WSAPIMiniTicker[]
+  >;
+  'ticker.tradingDay': WSAPIResponse<
+    WSAPIFullTicker | WSAPIMiniTicker | WSAPIFullTicker[] | WSAPIMiniTicker[]
+  >;
+  ticker: WSAPIResponse<
+    WSAPIFullTicker | WSAPIMiniTicker | WSAPIFullTicker[] | WSAPIMiniTicker[]
+  >;
+  'ticker.price': WSAPIResponse<
+    | WSAPIPriceTicker
+    | WSAPIPriceTicker[]
+    | WSAPIFuturesPriceTicker
+    | WSAPIFuturesPriceTicker[]
+  >;
+  'ticker.book': WSAPIResponse<
+    | WSAPIBookTicker
+    | WSAPIBookTicker[]
+    | WSAPIFuturesBookTicker
+    | WSAPIFuturesBookTicker[]
+  >;
+
+  /**
+   * Account responses:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/account-requests
+   */
+
+  'account.status': WSAPIResponse<
+    WSAPIAccountInformation | WSAPIFuturesAccountStatus
+  >;
+  'account.commission': WSAPIResponse<WSAPIAccountCommission>;
+  'account.rateLimits.orders': WSAPIResponse<WSAPIRateLimit[]>;
+  allOrders: WSAPIResponse<WSAPIOrder[]>;
+  allOrderLists: WSAPIResponse<WSAPIOrderListStatusResponse[]>;
+  myTrades: WSAPIResponse<WSAPITrade[]>;
+  myPreventedMatches: WSAPIResponse<WSAPIPreventedMatch[]>;
+  myAllocations: WSAPIResponse<WSAPIAllocation[]>;
+
+  /**
+   * Futures account responses:
+   * https://developers.binance.com/docs/derivatives/usds-margined-futures/account/websocket-api
+   */
+  'account.position': WSAPIResponse<WSAPIFuturesPosition[]>;
+  'v2/account.position': WSAPIResponse<WSAPIFuturesPositionV2[]>;
+  'account.balance': WSAPIResponse<WSAPIFuturesAccountBalanceItem[]>;
+  'v2/account.balance': WSAPIResponse<WSAPIFuturesAccountBalanceItem[]>;
+  'v2/account.status': WSAPIResponse<WSAPIFuturesAccountStatus>;
+
+  /**
+   * Trading responses
+   * - Spot:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/trading-requests
+   * - Futures:
+   * https://developers.binance.com/docs/derivatives/usds-margined-futures/trading/websocket-api
+   */
+  'order.place': WSAPIResponse<WSAPISpotOrderResponse | WSAPIFuturesOrder>;
+  'order.test': WSAPIResponse<
+    WSAPIOrderTestResponse | WSAPIOrderTestWithCommission
+  >;
+  'order.status': WSAPIResponse<WSAPIOrder | WSAPIFuturesOrder>;
+  'order.cancel': WSAPIResponse<WSAPIOrderCancel | WSAPIFuturesOrder>;
+  'order.modify': WSAPIResponse<WSAPIFuturesOrder>;
+  'order.cancelReplace': WSAPIResponse<WSAPIOrderCancelReplaceResponse>;
+  'openOrders.status': WSAPIResponse<WSAPIOrder[] | WSAPIFuturesOrder[]>;
+  'openOrders.cancelAll': WSAPIResponse<
+    (WSAPIOrderCancel | WSAPIOrderListCancelResponse)[]
+  >;
+  'algoOrder.place': WSAPIResponse<WSAPIFuturesAlgoOrder>;
+  'algoOrder.cancel': WSAPIResponse<WSAPIFuturesAlgoOrderCancelResponse>;
+  /**
+   * Order list responses
+   */
+  'orderList.place': WSAPIResponse<WSAPIOrderListPlaceResponse>;
+  'orderList.place.oco': WSAPIResponse<WSAPIOrderListPlaceResponse>;
+  'orderList.place.oto': WSAPIResponse<WSAPIOrderListPlaceResponse>;
+  'orderList.place.otoco': WSAPIResponse<WSAPIOrderListPlaceResponse>;
+  'orderList.place.opo': WSAPIResponse<WSAPIOrderListPlaceResponse>;
+  'orderList.place.opoco': WSAPIResponse<WSAPIOrderListPlaceResponse>;
+  'orderList.status': WSAPIResponse<WSAPIOrderListStatusResponse>;
+  'orderList.cancel': WSAPIResponse<WSAPIOrderListCancelResponse>;
+  'openOrderLists.status': WSAPIResponse<WSAPIOrderListStatusResponse[]>;
+
+  /**
+   * SOR responses
+   */
+  'sor.order.place': WSAPIResponse<WSAPISOROrderPlaceResponse>;
+  'sor.order.test': WSAPIResponse<
+    WSAPISOROrderTestResponse | WSAPISOROrderTestResponseWithCommission
+  >;
+
+  'userDataStream.start': WSAPIResponse<{ listenKey: string }>;
+  'userDataStream.ping': WSAPIResponse<object>;
+  'userDataStream.stop': WSAPIResponse<object>;
+  'userDataStream.subscribe': WSAPIResponse<object>;
+  'userDataStream.subscribe.signature': WSAPIResponse<object>;
+  'userDataStream.unsubscribe': WSAPIResponse<object>;
+}
+⋮----
+/**
+   * Session authentication responses:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/session-authentication
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/authentication-requests
+   */
+⋮----
+/**
+   * General responses:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/general-requests
+   */
+⋮----
+/**
+   * Market data responses
+   * - Spot:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/market-data-requests
+   * - Futures:
+   * https://developers.binance.com/docs/derivatives/usds-margined-futures/market-data/websocket-api
+   */
+⋮----
+/**
+   * Account responses:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/account-requests
+   */
+⋮----
+/**
+   * Futures account responses:
+   * https://developers.binance.com/docs/derivatives/usds-margined-futures/account/websocket-api
+   */
+⋮----
+/**
+   * Trading responses
+   * - Spot:
+   * https://developers.binance.com/docs/binance-spot-api-docs/web-socket-api/trading-requests
+   * - Futures:
+   * https://developers.binance.com/docs/derivatives/usds-margined-futures/trading/websocket-api
+   */
+⋮----
+/**
+   * Order list responses
+   */
+⋮----
+/**
+   * SOR responses
+   */
+
+================
 File: README.md
 ================
 # Node.js & JavaScript SDK for Binance REST APIs & WebSockets
@@ -12581,7 +14365,8 @@ Updated & performant JavaScript & Node.js SDK for the Binance REST APIs and WebS
   - Real API calls in e2e tests.
 - Proxy support via axios integration.
 - Active community support & collaboration in telegram: [Node.js Algo Traders](https://t.me/nodetraders).
-- QuickStart Guide: https://siebly.io/sdk/binance/javascript
+- QuickStart Guide: [Binance JavaScript QuickStart Guide](https://siebly.io/sdk/binance/javascript)
+- Binance JavaScript Tutorial: [Binance JavaScript REST API & WebSocket Tutorial](https://siebly.io/sdk/binance/javascript/tutorial)
 
 ## Table of Contents
 
@@ -13380,285 +15165,6 @@ Contributions are encouraged, I will review any incoming pull requests. See the 
 <!-- template_star_history_end -->
 
 ================
-File: src/types/websockets/ws-general.ts
-================
-import { AxiosRequestConfig } from 'axios';
-import type { ClientRequestArgs } from 'http';
-import WebSocket from 'isomorphic-ws';
-⋮----
-import { RestClientOptions } from '../../util/requestUtils';
-import { WsKey } from '../../util/websockets/websocket-util';
-⋮----
-export interface MessageEventLike {
-  target: WebSocket;
-  type: 'message';
-  data: string;
-}
-⋮----
-export function isMessageEvent(msg: unknown): msg is MessageEventLike
-⋮----
-export type WsMarket =
-  | 'spot'
-  | 'spotTestnet'
-  | 'crossMargin'
-  | 'isolatedMargin'
-  | 'riskDataMargin'
-  | 'usdm'
-  | 'usdmTestnet'
-  | 'coinm'
-  | 'coinmTestnet'
-  | 'options'
-  | 'optionsTestnet'
-  | 'portfoliom'
-  | 'alpha';
-⋮----
-export interface WsSharedBase {
-  wsMarket: WsMarket;
-  wsKey: WsKey;
-  streamName: string;
-}
-⋮----
-export interface WsResponse {
-  type: 'message';
-  data: {
-    result: boolean | string[] | null;
-    id: number;
-    isWSAPIResponse: boolean;
-    wsKey: WsKey;
-  };
-}
-⋮----
-// Same as inverse futures
-export type WsPublicInverseTopic =
-  | 'orderBookL2_25'
-  | 'orderBookL2_200'
-  | 'trade'
-  | 'insurance'
-  | 'instrument_info'
-  | 'klineV2';
-⋮----
-export type WsPublicUSDTPerpTopic =
-  | 'orderBookL2_25'
-  | 'orderBookL2_200'
-  | 'trade'
-  | 'insurance'
-  | 'instrument_info'
-  | 'kline';
-⋮----
-export type WsPublicSpotV1Topic =
-  | 'trade'
-  | 'realtimes'
-  | 'kline'
-  | 'mergedDepth'
-  | 'diffDepth';
-⋮----
-export type WsPublicSpotV2Topic = 'depth' | 'kline' | 'trade' | 'realtimes';
-⋮----
-// https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Important-WebSocket-Change-Notice#public-high-frequency-public-data
-export type WsPublicUSDMTopic = 'bookTicker' | 'depth';
-⋮----
-// https://developers.binance.com/docs/derivatives/usds-margined-futures/websocket-market-streams/Important-WebSocket-Change-Notice#market-regular-market-data
-export type WsMarketUSDMTopic =
-  | 'aggTrade'
-  | 'markPrice'
-  | 'kline'
-  | 'continuousKline'
-  | 'miniTicker'
-  | 'ticker'
-  | 'forceOrder'
-  | 'compositeIndex'
-  | 'contractInfo'
-  | 'assetIndex';
-⋮----
-export type WsPublicTopics =
-  | WsPublicInverseTopic
-  | WsPublicUSDTPerpTopic
-  | WsPublicSpotV1Topic
-  | WsPublicSpotV2Topic
-  | WsMarketUSDMTopic
-  | WsPublicUSDMTopic
-  | string;
-⋮----
-// Same as inverse futures
-export type WsPrivateInverseTopic =
-  | 'position'
-  | 'execution'
-  | 'order'
-  | 'stop_order';
-⋮----
-export type WsPrivateUSDTPerpTopic =
-  | 'position'
-  | 'execution'
-  | 'order'
-  | 'stop_order'
-  | 'wallet';
-⋮----
-export type WsPrivateSpotTopic =
-  | 'outboundAccountInfo'
-  | 'executionReport'
-  | 'ticketInfo';
-⋮----
-export type WsPrivateTopic =
-  | WsPrivateInverseTopic
-  | WsPrivateUSDTPerpTopic
-  | WsPrivateSpotTopic
-  | string;
-⋮----
-export type WsTopic = WsPublicTopics | WsPrivateTopic;
-⋮----
-export interface WSClientConfigurableOptions {
-  /** Your API key */
-  api_key?: string;
-
-  /** Your API secret */
-  api_secret?: string;
-
-  beautify?: boolean;
-
-  /**
-   * If true, log a warning if the beautifier is missing anything for an event
-   */
-  beautifyWarnIfMissing?: boolean;
-
-  /**
-   * Set to `true` to connect to Binance's testnet environment.
-   *
-   * Notes:
-   * - Not all WebSocket categories support testnet.
-   * - If testing a strategy, this is not recommended. Testnet market data is very different from real market conditions. More guidance here: https://github.com/tiagosiebler/awesome-crypto-examples/wiki/CEX-Testnets
-   */
-  testnet?: boolean;
-
-  /**
-   * Set to `true` to use Binance's demo trading WebSocket endpoints.
-   * Demo trading uses real market data but simulated trading.
-   * More info: https://demo.binance.com/
-   *
-   * Notes:
-   * - If demo trading, `testnet` should be set to false!
-   * - If testing a strategy, use demo trading instead. Testnet market data is very different from real market conditions.
-   */
-  demoTrading?: boolean;
-
-  /**
-   * Default: false. If true, use market maker endpoints when available.
-   * Eligible for high-frequency trading users who have enrolled and qualified
-   * in at least one of the Futures Liquidity Provider Programs.
-   * More info: https://www.binance.com/en/support/faq/detail/7df7f3838c3b49e692d175374c3a3283
-   */
-  useMMSubdomain?: boolean;
-
-  /** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
-  recvWindow?: number;
-
-  // Disable ping/pong ws heartbeat mechanism (not recommended)
-  disableHeartbeat?: boolean;
-
-  /** How often to check if the connection is alive */
-  pingInterval?: number;
-
-  /** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
-  pongTimeout?: number;
-
-  /** Delay in milliseconds before respawning the connection */
-  reconnectTimeout?: number;
-
-  restOptions?: RestClientOptions;
-
-  requestOptions?: AxiosRequestConfig;
-
-  wsOptions?: {
-    protocols?: string[];
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    agent?: any;
-  } & Partial<WebSocket.ClientOptions | ClientRequestArgs>;
-
-  wsUrl?: string;
-
-  /**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
-
-  /**
-   * Optional custom JSON parser used for incoming WS messages.
-   * Defaults to JSON.parse.
-   */
-  customParseJSONFn?: (raw: string) => object;
-}
-⋮----
-/** Your API key */
-⋮----
-/** Your API secret */
-⋮----
-/**
-   * If true, log a warning if the beautifier is missing anything for an event
-   */
-⋮----
-/**
-   * Set to `true` to connect to Binance's testnet environment.
-   *
-   * Notes:
-   * - Not all WebSocket categories support testnet.
-   * - If testing a strategy, this is not recommended. Testnet market data is very different from real market conditions. More guidance here: https://github.com/tiagosiebler/awesome-crypto-examples/wiki/CEX-Testnets
-   */
-⋮----
-/**
-   * Set to `true` to use Binance's demo trading WebSocket endpoints.
-   * Demo trading uses real market data but simulated trading.
-   * More info: https://demo.binance.com/
-   *
-   * Notes:
-   * - If demo trading, `testnet` should be set to false!
-   * - If testing a strategy, use demo trading instead. Testnet market data is very different from real market conditions.
-   */
-⋮----
-/**
-   * Default: false. If true, use market maker endpoints when available.
-   * Eligible for high-frequency trading users who have enrolled and qualified
-   * in at least one of the Futures Liquidity Provider Programs.
-   * More info: https://www.binance.com/en/support/faq/detail/7df7f3838c3b49e692d175374c3a3283
-   */
-⋮----
-/** Define a recv window when preparing a private websocket signature. This is in milliseconds, so 5000 == 5 seconds */
-⋮----
-// Disable ping/pong ws heartbeat mechanism (not recommended)
-⋮----
-/** How often to check if the connection is alive */
-⋮----
-/** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
-⋮----
-/** Delay in milliseconds before respawning the connection */
-⋮----
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-⋮----
-/**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-⋮----
-/**
-   * Optional custom JSON parser used for incoming WS messages.
-   * Defaults to JSON.parse.
-   */
-⋮----
-/**
- * WS configuration that's always defined, regardless of user configuration
- * (usually comes from defaults if there's no user-provided values)
- */
-export interface WebsocketClientOptions extends WSClientConfigurableOptions {
-  pongTimeout: number;
-  pingInterval: number;
-  reconnectTimeout: number;
-  recvWindow: number;
-  authPrivateConnectionsOnConnect: boolean;
-  authPrivateRequestsIndividually: boolean;
-}
-
-================
 File: src/types/spot.ts
 ================
 import {
@@ -13998,6 +15504,41 @@ export interface ConvertDustParams {
   accountType?: 'SPOT' | 'MARGIN';
 }
 ⋮----
+export type DustConvertAccountType = 'SPOT' | 'MARGIN';
+⋮----
+export interface DustConvertParams {
+  asset: string[];
+  accountType?: DustConvertAccountType;
+  clientId?: string;
+  targetAsset?: string;
+  thirdPartyClientId?: string;
+  dustQuotaAssetToTargetAssetPrice?: numberInString;
+}
+⋮----
+export interface DustConvertibleAssetsParams {
+  targetAsset: string;
+  accountType?: DustConvertAccountType;
+  dustQuotaAssetToTargetAssetPrice?: numberInString;
+}
+⋮----
+export interface DustConvertibleAssetDetail {
+  asset: string;
+  assetFullName: string;
+  amountFree: numberInString;
+  exchange: numberInString;
+  toQuotaAssetAmount: numberInString;
+  toTargetAssetAmount: numberInString;
+  toTargetAssetOffExchange: numberInString;
+}
+⋮----
+export interface DustConvertibleAssetsResponse {
+  dribbletPercentage: numberInString;
+  totalTransferQuotaAssetAmount: numberInString;
+  totalTransferTargetAssetAmount: numberInString;
+  dribbletBase: numberInString;
+  details: DustConvertibleAssetDetail[];
+}
+⋮----
 export interface DustInfoDetail {
   asset: string;
   assetFullName: string;
@@ -14278,6 +15819,21 @@ export interface RawTrade {
   isBestMatch: boolean;
 }
 ⋮----
+export interface BlockTrade {
+  id: number;
+  price: numberInString;
+  qty: numberInString;
+  quoteQty: numberInString;
+  time: number;
+  isBuyerMaker: boolean;
+}
+⋮----
+export interface HistoricalBlockTradesParams {
+  symbol: string;
+  fromId: number;
+  limit?: number;
+}
+⋮----
 export interface RawAccountTrade {
   symbol: string;
   id: number;
@@ -14490,7 +16046,11 @@ export interface OrderListOrder {
   symbol: string;
   orderId: number;
   clientOrderId: string;
+  /** Present only for expired orders. */
+  expiryReason?: string;
 }
+⋮----
+/** Present only for expired orders. */
 ⋮----
 export interface OrderListResponse<RT extends OrderResponseType = 'ACK'> {
   orderListId: number;
@@ -14658,7 +16218,11 @@ export interface SpotOrder {
   isWorking: boolean;
   origQuoteOrderQty: numberInString;
   selfTradePreventionMode: SelfTradePreventionMode;
+  /** Present only for expired orders. */
+  expiryReason?: string;
 }
+⋮----
+/** Present only for expired orders. */
 ⋮----
 export interface SpotAmendKeepPriorityResult {
   transactTime: number;
@@ -19797,6 +21361,48 @@ export interface SpecialLowLatencyKeyInfo {
   type: 'HMAC_SHA256' | 'RSA' | 'Ed25519';
 }
 ⋮----
+export interface MarginLiquidationLoan {
+  asset: string;
+  amount: string;
+  repaidAmount: string;
+  remainingAmount: string;
+}
+⋮----
+export interface RepayMarginLiquidationLoanParams {
+  asset: string;
+  amount: string;
+}
+⋮----
+export type MarginLiquidationLoanRepayStatus = 'SUCCESS' | 'PENDING';
+⋮----
+export interface MarginLiquidationLoanRepayResponse {
+  repayId: number;
+  asset: string;
+  amount: string;
+  status: MarginLiquidationLoanRepayStatus;
+  createTime: number;
+}
+⋮----
+export interface GetMarginLiquidationLoanRepayHistoryParams {
+  startTime?: number;
+  endTime?: number;
+  current?: number;
+  size?: number;
+}
+⋮----
+export interface MarginLiquidationLoanRepayHistoryRecord {
+  repayId: number;
+  asset: string;
+  amount: string;
+  status: MarginLiquidationLoanRepayStatus;
+  createTime: number;
+}
+⋮----
+export interface MarginLiquidationLoanRepayHistoryResponse {
+  total: number;
+  rows: MarginLiquidationLoanRepayHistoryRecord[];
+}
+⋮----
 export interface SolStakingAccount {
   bnsolAmount: string; // Amount in bNSOL
   holdingInSOL: string; // Holding in SOL
@@ -20972,6 +22578,7 @@ import {
   WSAPIAllOrderListsRequest,
   WSAPIAllOrdersRequest,
   WSAPIAvgPriceRequest,
+  WSAPIBlockTradesHistoricalRequest,
   WSAPIExchangeInfoRequest,
   WSAPIExecutionRulesRequest,
   WSAPIFuturesAlgoOrderCancelRequest,
@@ -21026,6 +22633,7 @@ import {
   WSAPIAggregateTrade,
   WSAPIAllocation,
   WSAPIAvgPrice,
+  WSAPIBlockTrade,
   WSAPIBookTicker,
   WSAPIFullTicker,
   WSAPIFuturesAccountBalanceItem,
@@ -21284,6 +22892,14 @@ getSpotHistoricalTrades(
     params: WSAPITradesHistoricalRequest,
     wsKey?: WSAPIWsKeyMain,
 ): Promise<WSAPIResponse<WSAPITrade[]>>
+⋮----
+/**
+   * Get historical block trades
+   */
+getSpotHistoricalBlockTrades(
+    params: WSAPIBlockTradesHistoricalRequest,
+    wsKey?: WSAPIWsKeyMain,
+): Promise<WSAPIResponse<WSAPIBlockTrade[]>>
 ⋮----
 /**
    * Get aggregate trades
@@ -22114,6 +23730,7 @@ import {
   BfusdSubscribeParams,
   BfusdSubscribeResponse,
   BfusdSubscriptionHistoryRow,
+  BlockTrade,
   BlvtRedemptionRecord,
   BlvtSubscriptionRecord,
   BlvtUserLimitInfo,
@@ -22200,6 +23817,9 @@ import {
   DualInvestmentPosition,
   DualInvestmentProduct,
   DustConversion,
+  DustConvertibleAssetsParams,
+  DustConvertibleAssetsResponse,
+  DustConvertParams,
   DustInfo,
   DustLog,
   EditInvestmentPlanParams,
@@ -22327,6 +23947,7 @@ import {
   GetMarginCapitalFlowParams,
   GetMarginInterestHistoryParams,
   GetMarginInterestRebateBalanceRecordsParams,
+  GetMarginLiquidationLoanRepayHistoryParams,
   GetMarginOrderCountUsageParams,
   GetMinerDetailsParams,
   GetMinerDetailsResponse,
@@ -22391,6 +24012,7 @@ import {
   GetWbethRewardsHistoryResponse,
   GetWrapHistoryParams,
   HistoricalAlgoOrder,
+  HistoricalBlockTradesParams,
   HistoricalDataLink,
   HistoricalSpotAlgoOrder,
   IndexLinkedPlanRedemptionRecord,
@@ -22438,6 +24060,9 @@ import {
   MarginInterestRateHistory,
   MarginInterestRebateBalanceRecordsResponse,
   MarginInterestRebateBalanceResponse,
+  MarginLiquidationLoan,
+  MarginLiquidationLoanRepayHistoryResponse,
+  MarginLiquidationLoanRepayResponse,
   MarginOrderCountUsageResponse,
   MarginOTOCOOrder,
   MarginOTOOrder,
@@ -22532,6 +24157,7 @@ import {
   RepayCryptoLoanFlexibleWithCollateralResponse,
   RepayCryptoLoanParams,
   RepayCryptoLoanResponse,
+  RepayMarginLiquidationLoanParams,
   ReplaceSpotOrderParams,
   ReplaceSpotOrderResultSuccess,
   RollingWindowTickerParams,
@@ -22766,6 +24392,10 @@ getOrderBook(params: OrderBookParams): Promise<OrderBookResponse>
 getRecentTrades(params: RecentTradesParams): Promise<RawTrade[]>
 ⋮----
 getHistoricalTrades(params: HistoricalTradesParams): Promise<RawTrade[]>
+⋮----
+getHistoricalBlockTrades(
+    params: HistoricalBlockTradesParams,
+): Promise<BlockTrade[]>
 ⋮----
 getAggregateTrades(
     params: SymbolFromPaginatedRequestFromId,
@@ -23148,6 +24778,30 @@ getMarginSpecialLowLatencyKey(params: {
 }): Promise<SpecialLowLatencyKeyInfo>
 ⋮----
 /**
+   * Query the current cross-margin liquidation loan status (bankruptcy deficit).
+   */
+getMarginLiquidationLoan(): Promise<MarginLiquidationLoan>
+⋮----
+/**
+   * Repay an outstanding cross-margin liquidation loan from the spot wallet.
+   */
+repayMarginLiquidationLoan(
+    params: RepayMarginLiquidationLoanParams,
+): Promise<MarginLiquidationLoanRepayResponse>
+⋮----
+/**
+   * Query cross-margin liquidation loan repayment history.
+   */
+getMarginLiquidationLoanRepayHistory(
+    params?: GetMarginLiquidationLoanRepayHistoryParams,
+): Promise<MarginLiquidationLoanRepayHistoryResponse>
+⋮----
+/**
+   * Exit Margin Special Key mode for Cross Margin Classic accounts.
+   */
+exitMarginSpecialKeyMode(): Promise<object>
+⋮----
+/**
    *
    * MARGIN TRADING Endpoints - Transfer endpoints
    *
@@ -23293,6 +24947,18 @@ getUniversalTransferHistory(
 getDust(params:
 ⋮----
 convertDustToBnb(params: ConvertDustParams): Promise<DustConversion>
+⋮----
+/**
+   * Convert dust assets to a target asset (e.g. BNB, USDT).
+   */
+convertDustAssets(params: DustConvertParams): Promise<DustConversion>
+⋮----
+/**
+   * Query assets eligible for dust conversion.
+   */
+queryDustConvertibleAssets(
+    params: DustConvertibleAssetsParams,
+): Promise<DustConvertibleAssetsResponse>
 ⋮----
 getDustLog(params?: BasicTimeRangeParam): Promise<DustLog>
 ⋮----
@@ -25307,6 +26973,7 @@ import {
   getPromiseRefForWSAPIRequest,
   getRealWsKeyFromDerivedWsKey,
   getTestnetWsKey,
+  getTopicsPerWSKey,
   getWsKeyForProductGroup,
   getWsUrl,
   getWsURLSuffix,
@@ -25325,6 +26992,8 @@ import {
   WsTopicRequest,
 } from './util/websockets/websocket-util';
 import { WSConnectedResult } from './util/websockets/WsStore.types';
+⋮----
+type TopicRequestsPerWsKeyEntry = [WsKey, WsTopicRequest<string>[]];
 ⋮----
 export interface WSAPIRequestFlags {
   /** If true, will skip auth requirement for WS API connection */
@@ -25896,12 +27565,14 @@ public unsubscribeMarginRiskUserDataStream(
    * Note: the wsKey parameter is optional, but can be used to connect to other environments for this product group.
    */
 public async subscribeUsdFuturesUserDataStream(
-    wsKey: WsKey = WS_KEY_MAP.usdmPrivate, // usdm | usdmPrivate | usdmTestnet
+    userWsKey: WsKey = WS_KEY_MAP.usdmPrivate, //  usdmPrivate | usdmTestnetPrivate
     forceNewConnection?: boolean,
     miscState?: MiscUserDataConnectionState,
 ): Promise<WSConnectedResult | undefined>
 ⋮----
-wsKey: WsKey = WS_KEY_MAP.usdmPrivate, // usdm | usdmPrivate | usdmTestnet
+userWsKey: WsKey = WS_KEY_MAP.usdmPrivate, //  usdmPrivate | usdmTestnetPrivate
+⋮----
+// Prevent 'usdm' from being used unintentionally, since this has to be routed via the private endpoints.
 ⋮----
 public unsubscribeUsdFuturesUserDataStream(
     wsKey: WsKey = WS_KEY_MAP.usdmPrivate,
@@ -25954,8 +27625,6 @@ public async closeUserDataStream(
 // built around the assumption in how per-connection listen key wskeys are created
 // isolatedMargin_userData_BTCUSDC_6RszN123x213x1233x213x1233x213xx123x1uzkTV_main
 // coinm_userData__WRAVTxGaQa1Nhd1243312kjn13kj12n3m5wRFv6JoFQgwUR5AEFofZtlk_coinm
-⋮----
-// todo: close?
 ⋮----
 protected isCustomReconnectionNeeded(wsKey: string): boolean
 ⋮----
@@ -26388,7 +28057,7 @@ File: package.json
 ================
 {
   "name": "binance",
-  "version": "3.5.5",
+  "version": "3.5.9",
   "description": "Professional Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "binance",
-  "version": "3.5.8",
+  "version": "3.5.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "binance",
-      "version": "3.5.8",
+      "version": "3.5.9",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binance",
-  "version": "3.5.8",
+  "version": "3.5.9",
   "description": "Professional Node.js & JavaScript SDK for Binance REST APIs & WebSockets, with TypeScript & end-to-end tests.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/main-client.ts
+++ b/src/main-client.ts
@@ -74,6 +74,7 @@ import {
   BfusdSubscribeParams,
   BfusdSubscribeResponse,
   BfusdSubscriptionHistoryRow,
+  BlockTrade,
   BlvtRedemptionRecord,
   BlvtSubscriptionRecord,
   BlvtUserLimitInfo,
@@ -160,6 +161,9 @@ import {
   DualInvestmentPosition,
   DualInvestmentProduct,
   DustConversion,
+  DustConvertibleAssetsParams,
+  DustConvertibleAssetsResponse,
+  DustConvertParams,
   DustInfo,
   DustLog,
   EditInvestmentPlanParams,
@@ -287,6 +291,7 @@ import {
   GetMarginCapitalFlowParams,
   GetMarginInterestHistoryParams,
   GetMarginInterestRebateBalanceRecordsParams,
+  GetMarginLiquidationLoanRepayHistoryParams,
   GetMarginOrderCountUsageParams,
   GetMinerDetailsParams,
   GetMinerDetailsResponse,
@@ -351,6 +356,7 @@ import {
   GetWbethRewardsHistoryResponse,
   GetWrapHistoryParams,
   HistoricalAlgoOrder,
+  HistoricalBlockTradesParams,
   HistoricalDataLink,
   HistoricalSpotAlgoOrder,
   IndexLinkedPlanRedemptionRecord,
@@ -398,6 +404,9 @@ import {
   MarginInterestRateHistory,
   MarginInterestRebateBalanceRecordsResponse,
   MarginInterestRebateBalanceResponse,
+  MarginLiquidationLoan,
+  MarginLiquidationLoanRepayHistoryResponse,
+  MarginLiquidationLoanRepayResponse,
   MarginOrderCountUsageResponse,
   MarginOTOCOOrder,
   MarginOTOOrder,
@@ -492,6 +501,7 @@ import {
   RepayCryptoLoanFlexibleWithCollateralResponse,
   RepayCryptoLoanParams,
   RepayCryptoLoanResponse,
+  RepayMarginLiquidationLoanParams,
   ReplaceSpotOrderParams,
   ReplaceSpotOrderResultSuccess,
   RollingWindowTickerParams,
@@ -796,6 +806,12 @@ export class MainClient extends BaseRestClient {
 
   getHistoricalTrades(params: HistoricalTradesParams): Promise<RawTrade[]> {
     return this.get('api/v3/historicalTrades', params);
+  }
+
+  getHistoricalBlockTrades(
+    params: HistoricalBlockTradesParams,
+  ): Promise<BlockTrade[]> {
+    return this.get('api/v3/historicalBlockTrades', params);
   }
 
   getAggregateTrades(
@@ -1428,6 +1444,41 @@ export class MainClient extends BaseRestClient {
   }
 
   /**
+   * Query the current cross-margin liquidation loan status (bankruptcy deficit).
+   */
+  getMarginLiquidationLoan(): Promise<MarginLiquidationLoan> {
+    return this.getPrivate('sapi/v1/margin/liquidation-loan');
+  }
+
+  /**
+   * Repay an outstanding cross-margin liquidation loan from the spot wallet.
+   */
+  repayMarginLiquidationLoan(
+    params: RepayMarginLiquidationLoanParams,
+  ): Promise<MarginLiquidationLoanRepayResponse> {
+    return this.postPrivate('sapi/v1/margin/liquidation-loan/repay', params);
+  }
+
+  /**
+   * Query cross-margin liquidation loan repayment history.
+   */
+  getMarginLiquidationLoanRepayHistory(
+    params?: GetMarginLiquidationLoanRepayHistoryParams,
+  ): Promise<MarginLiquidationLoanRepayHistoryResponse> {
+    return this.getPrivate(
+      'sapi/v1/margin/liquidation-loan/repay-history',
+      params,
+    );
+  }
+
+  /**
+   * Exit Margin Special Key mode for Cross Margin Classic accounts.
+   */
+  exitMarginSpecialKeyMode(): Promise<object> {
+    return this.postPrivate('sapi/v1/margin/exit-special-key-mode');
+  }
+
+  /**
    *
    * MARGIN TRADING Endpoints - Transfer endpoints
    *
@@ -1659,6 +1710,25 @@ export class MainClient extends BaseRestClient {
 
   convertDustToBnb(params: ConvertDustParams): Promise<DustConversion> {
     return this.postPrivate('sapi/v1/asset/dust', params);
+  }
+
+  /**
+   * Convert dust assets to a target asset (e.g. BNB, USDT).
+   */
+  convertDustAssets(params: DustConvertParams): Promise<DustConversion> {
+    return this.postPrivate('sapi/v1/asset/dust-convert/convert', params);
+  }
+
+  /**
+   * Query assets eligible for dust conversion.
+   */
+  queryDustConvertibleAssets(
+    params: DustConvertibleAssetsParams,
+  ): Promise<DustConvertibleAssetsResponse> {
+    return this.postPrivate(
+      'sapi/v1/asset/dust-convert/query-convertible-assets',
+      params,
+    );
   }
 
   getDustLog(params?: BasicTimeRangeParam): Promise<DustLog> {

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -330,6 +330,22 @@ export interface SymbolPercentPriceFilter {
   avgPriceMins: number;
 }
 
+export interface SymbolPercentPriceBySideFilter {
+  filterType: 'PERCENT_PRICE_BY_SIDE';
+  bidMultiplierUp: numberInString;
+  bidMultiplierDown: numberInString;
+  askMultiplierUp: numberInString;
+  askMultiplierDown: numberInString;
+  avgPriceMins: number;
+}
+
+export interface SymbolLegacyMinNotionalFilter {
+  filterType: 'MIN_NOTIONAL';
+  minNotional: numberInString;
+  applyToMarket: boolean;
+  avgPriceMins: number;
+}
+
 export interface SymbolLotSizeFilter {
   filterType: 'LOT_SIZE';
   minQty: numberInString;
@@ -381,6 +397,8 @@ export interface SymbolMaxPositionFilter {
 export type SymbolFilter =
   | SymbolPriceFilter
   | SymbolPercentPriceFilter
+  | SymbolPercentPriceBySideFilter
+  | SymbolLegacyMinNotionalFilter
   | SymbolLotSizeFilter
   | SymbolMinNotionalFilter
   | SymbolIcebergPartsFilter

--- a/src/types/spot.ts
+++ b/src/types/spot.ts
@@ -316,6 +316,41 @@ export interface ConvertDustParams {
   accountType?: 'SPOT' | 'MARGIN';
 }
 
+export type DustConvertAccountType = 'SPOT' | 'MARGIN';
+
+export interface DustConvertParams {
+  asset: string[];
+  accountType?: DustConvertAccountType;
+  clientId?: string;
+  targetAsset?: string;
+  thirdPartyClientId?: string;
+  dustQuotaAssetToTargetAssetPrice?: numberInString;
+}
+
+export interface DustConvertibleAssetsParams {
+  targetAsset: string;
+  accountType?: DustConvertAccountType;
+  dustQuotaAssetToTargetAssetPrice?: numberInString;
+}
+
+export interface DustConvertibleAssetDetail {
+  asset: string;
+  assetFullName: string;
+  amountFree: numberInString;
+  exchange: numberInString;
+  toQuotaAssetAmount: numberInString;
+  toTargetAssetAmount: numberInString;
+  toTargetAssetOffExchange: numberInString;
+}
+
+export interface DustConvertibleAssetsResponse {
+  dribbletPercentage: numberInString;
+  totalTransferQuotaAssetAmount: numberInString;
+  totalTransferTargetAssetAmount: numberInString;
+  dribbletBase: numberInString;
+  details: DustConvertibleAssetDetail[];
+}
+
 export interface DustInfoDetail {
   asset: string;
   assetFullName: string;
@@ -585,6 +620,21 @@ export interface RawTrade {
   isBestMatch: boolean;
 }
 
+export interface BlockTrade {
+  id: number;
+  price: numberInString;
+  qty: numberInString;
+  quoteQty: numberInString;
+  time: number;
+  isBuyerMaker: boolean;
+}
+
+export interface HistoricalBlockTradesParams {
+  symbol: string;
+  fromId: number;
+  limit?: number;
+}
+
 export interface RawAccountTrade {
   symbol: string;
   id: number;
@@ -793,6 +843,8 @@ export interface OrderListOrder {
   symbol: string;
   orderId: number;
   clientOrderId: string;
+  /** Present only for expired orders. */
+  expiryReason?: string;
 }
 
 export interface OrderListResponse<RT extends OrderResponseType = 'ACK'> {
@@ -953,6 +1005,8 @@ export interface SpotOrder {
   isWorking: boolean;
   origQuoteOrderQty: numberInString;
   selfTradePreventionMode: SelfTradePreventionMode;
+  /** Present only for expired orders. */
+  expiryReason?: string;
 }
 
 export interface SpotAmendKeepPriorityResult {
@@ -6064,6 +6118,48 @@ export interface SpecialLowLatencyKeyInfo {
   apiKey: string;
   ip: string;
   type: 'HMAC_SHA256' | 'RSA' | 'Ed25519';
+}
+
+export interface MarginLiquidationLoan {
+  asset: string;
+  amount: string;
+  repaidAmount: string;
+  remainingAmount: string;
+}
+
+export interface RepayMarginLiquidationLoanParams {
+  asset: string;
+  amount: string;
+}
+
+export type MarginLiquidationLoanRepayStatus = 'SUCCESS' | 'PENDING';
+
+export interface MarginLiquidationLoanRepayResponse {
+  repayId: number;
+  asset: string;
+  amount: string;
+  status: MarginLiquidationLoanRepayStatus;
+  createTime: number;
+}
+
+export interface GetMarginLiquidationLoanRepayHistoryParams {
+  startTime?: number;
+  endTime?: number;
+  current?: number;
+  size?: number;
+}
+
+export interface MarginLiquidationLoanRepayHistoryRecord {
+  repayId: number;
+  asset: string;
+  amount: string;
+  status: MarginLiquidationLoanRepayStatus;
+  createTime: number;
+}
+
+export interface MarginLiquidationLoanRepayHistoryResponse {
+  total: number;
+  rows: MarginLiquidationLoanRepayHistoryRecord[];
 }
 
 export interface SolStakingAccount {

--- a/src/types/websockets/ws-api-requests.ts
+++ b/src/types/websockets/ws-api-requests.ts
@@ -70,6 +70,12 @@ export interface WSAPITradesHistoricalRequest {
   limit?: number;
 }
 
+export interface WSAPIBlockTradesHistoricalRequest {
+  symbol: string;
+  fromId: number;
+  limit?: number;
+}
+
 export interface WSAPITradesAggregateRequest {
   symbol: string;
   fromId?: number;

--- a/src/types/websockets/ws-api-responses.ts
+++ b/src/types/websockets/ws-api-responses.ts
@@ -254,6 +254,17 @@ export interface WSAPIOrder {
   selfTradePreventionMode: string;
   preventedMatchId?: number;
   preventedQuantity?: numberInString;
+  /** Present only for expired orders. */
+  expiryReason?: string;
+}
+
+export interface WSAPIBlockTrade {
+  id: number;
+  price: numberInString;
+  qty: numberInString;
+  quoteQty: numberInString;
+  time: number;
+  isBuyerMaker: boolean;
 }
 
 export interface WSAPIOrderList {
@@ -421,6 +432,8 @@ export interface WSAPIOrderListStatusResponse {
     symbol: string;
     orderId: number;
     clientOrderId: string;
+    /** Present only for expired orders. */
+    expiryReason?: string;
   }[];
 }
 

--- a/src/types/websockets/ws-api.ts
+++ b/src/types/websockets/ws-api.ts
@@ -12,6 +12,7 @@ import {
   WSAPIAllOrderListsRequest,
   WSAPIAllOrdersRequest,
   WSAPIAvgPriceRequest,
+  WSAPIBlockTradesHistoricalRequest,
   WSAPIExchangeInfoRequest,
   WSAPIExecutionRulesRequest,
   WSAPIFuturesAlgoOrderCancelRequest,
@@ -65,6 +66,7 @@ import {
   WSAPIAggregateTrade,
   WSAPIAllocation,
   WSAPIAvgPrice,
+  WSAPIBlockTrade,
   WSAPIBookTicker,
   WSAPIFullTicker,
   WSAPIFuturesAccountBalanceItem,
@@ -125,6 +127,7 @@ export const WS_API_Operations = [
   'depth',
   'trades.recent',
   'trades.historical',
+  'blockTrades.historical',
   'trades.aggregate',
   'klines',
   'uiKlines',
@@ -318,6 +321,7 @@ export interface WsAPITopicRequestParamMap<TWSKey = WsKey> {
     : WSAPIOrderBookRequest;
   'trades.recent': WSAPITradesRecentRequest;
   'trades.historical': WSAPITradesHistoricalRequest;
+  'blockTrades.historical': WSAPIBlockTradesHistoricalRequest;
   'trades.aggregate': WSAPITradesAggregateRequest;
   klines: WSAPIKlinesRequest;
   uiKlines: WSAPIKlinesRequest;
@@ -491,6 +495,7 @@ export interface WsAPIOperationResponseMap {
   depth: WSAPIResponse<WSAPIOrderBook | WSAPIFuturesOrderBook>;
   'trades.recent': WSAPIResponse<WSAPITrade[]>;
   'trades.historical': WSAPIResponse<WSAPITrade[]>;
+  'blockTrades.historical': WSAPIResponse<WSAPIBlockTrade[]>;
   'trades.aggregate': WSAPIResponse<WSAPIAggregateTrade[]>;
   klines: WSAPIResponse<WSAPIKline[]>;
   uiKlines: WSAPIResponse<WSAPIKline[]>;

--- a/src/websocket-api-client.ts
+++ b/src/websocket-api-client.ts
@@ -15,6 +15,7 @@ import {
   WSAPIAllOrderListsRequest,
   WSAPIAllOrdersRequest,
   WSAPIAvgPriceRequest,
+  WSAPIBlockTradesHistoricalRequest,
   WSAPIExchangeInfoRequest,
   WSAPIExecutionRulesRequest,
   WSAPIFuturesAlgoOrderCancelRequest,
@@ -69,6 +70,7 @@ import {
   WSAPIAggregateTrade,
   WSAPIAllocation,
   WSAPIAvgPrice,
+  WSAPIBlockTrade,
   WSAPIBookTicker,
   WSAPIFullTicker,
   WSAPIFuturesAccountBalanceItem,
@@ -358,6 +360,21 @@ export class WebsocketAPIClient {
     return this.wsClient.sendWSAPIRequest(
       wsKey || WS_KEY_MAP.mainWSAPI,
       'trades.historical',
+      params,
+      { authIsOptional: true },
+    );
+  }
+
+  /**
+   * Get historical block trades
+   */
+  getSpotHistoricalBlockTrades(
+    params: WSAPIBlockTradesHistoricalRequest,
+    wsKey?: WSAPIWsKeyMain,
+  ): Promise<WSAPIResponse<WSAPIBlockTrade[]>> {
+    return this.wsClient.sendWSAPIRequest(
+      wsKey || WS_KEY_MAP.mainWSAPI,
+      'blockTrades.historical',
       params,
       { authIsOptional: true },
     );


### PR DESCRIPTION
# Release notes

## Margin — liquidation loans & special key mode (2026-05-05)

### New `MainClient` methods

| Method                                   | Endpoint                                             | Description                                                |
| ---------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------- |
| `getMarginLiquidationLoan()`             | `GET /sapi/v1/margin/liquidation-loan`               | Current cross-margin liquidation loan (bankruptcy deficit) |
| `repayMarginLiquidationLoan()`           | `POST /sapi/v1/margin/liquidation-loan/repay`        | Repay liquidation loan from spot wallet                    |
| `getMarginLiquidationLoanRepayHistory()` | `GET /sapi/v1/margin/liquidation-loan/repay-history` | Repayment history (paginated, up to 90 days)               |
| `exitMarginSpecialKeyMode()`             | `POST /sapi/v1/margin/exit-special-key-mode`         | Exit Margin Special Key mode (Cross Margin Classic)        |

### New types (`spot.ts`)

- `MarginLiquidationLoan`, `RepayMarginLiquidationLoanParams`
- `MarginLiquidationLoanRepayResponse`, `MarginLiquidationLoanRepayStatus`
- `GetMarginLiquidationLoanRepayHistoryParams`, `MarginLiquidationLoanRepayHistoryRecord`, `MarginLiquidationLoanRepayHistoryResponse`

---

## Spot — block trades, order expiry, filters (2026-05-06)

### New `MainClient` method

| Method                       | Endpoint                            | Description                         |
| ---------------------------- | ----------------------------------- | ----------------------------------- |
| `getHistoricalBlockTrades()` | `GET /api/v3/historicalBlockTrades` | Historical block trades (weight 25) |

### New `WebsocketAPIClient` method

| Method                           | WS API method            | Description                                |
| -------------------------------- | ------------------------ | ------------------------------------------ |
| `getSpotHistoricalBlockTrades()` | `blockTrades.historical` | Historical block trades over WebSocket API |

### New types

- `BlockTrade`, `HistoricalBlockTradesParams`
- `WSAPIBlockTrade`, `WSAPIBlockTradesHistoricalRequest`

### `expiryReason` on order query responses

Optional `expiryReason` added where Binance returns it for **expired** orders only:

- `SpotOrder` — `getOrder()`, `getAllOrders()`
- `OrderListOrder` — `getOCO()`, `getAllOCO()`, etc.
- `WSAPIOrder` — `order.status`, `allOrders`
- `WSAPIOrderListStatusResponse.orders[]` — `orderList.status`, `allOrderLists`

_(Already present on placement responses, execution reports, and related WS API place-order types.)_

### Exchange info filters

`SymbolFilter` union extended:

- `PERCENT_PRICE_BY_SIDE` → `SymbolPercentPriceBySideFilter`
- `MIN_NOTIONAL` (legacy) → `SymbolLegacyMinNotionalFilter`

Reference-price behavior for `PERCENT_PRICE`, `PERCENT_PRICE_BY_SIDE`, `MIN_NOTIONAL`, and `NOTIONAL` is enforced by Binance; types now match `exchangeInfo`.

### Already supported (no code change)

- **`serverShutdown`** WebSocket event (10 minutes before disconnect) — raw/formatted types and beautifier mapping were already in the SDK.

---

## Wallet — dust convert (2026-05-22)

### New `MainClient` methods

| Method                         | Endpoint                                                    | Description                    |
| ------------------------------ | ----------------------------------------------------------- | ------------------------------ |
| `convertDustAssets()`          | `POST /sapi/v1/asset/dust-convert/convert`                  | Convert dust to a target asset |
| `queryDustConvertibleAssets()` | `POST /sapi/v1/asset/dust-convert/query-convertible-assets` | List convertible dust assets   |

Both support optional **`accountType`**: `'SPOT' | 'MARGIN'` (default `SPOT` on the exchange).

### New types (`spot.ts`)

- `DustConvertAccountType`
- `DustConvertParams` — `asset`, `accountType`, `clientId`, `targetAsset`, `thirdPartyClientId`, `dustQuotaAssetToTargetAssetPrice`
- `DustConvertibleAssetsParams` — `targetAsset`, `accountType`, `dustQuotaAssetToTargetAssetPrice`
- `DustConvertibleAssetsResponse`, `DustConvertibleAssetDetail`

`convertDustAssets()` returns existing `DustConversion`.

---

## Usage examples

```typescript
// Margin liquidation loan
const loan = await client.getMarginLiquidationLoan();
await client.repayMarginLiquidationLoan({ asset: 'USDT', amount: '100' });
const history = await client.getMarginLiquidationLoanRepayHistory({ size: 50 });
await client.exitMarginSpecialKeyMode();

// Block trades
const blockTrades = await client.getHistoricalBlockTrades({
  symbol: 'BNBBTC',
  fromId: 582,
  limit: 100,
});

// Dust convert
await client.convertDustAssets({
  asset: ['AR', 'BNB'],
  accountType: 'MARGIN',
  targetAsset: 'USDT',
});
const convertible = await client.queryDustConvertibleAssets({
  targetAsset: 'USDT',
  accountType: 'SPOT',
});
```

---
